### PR TITLE
Add MPC (Minor Planet Center) client

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,20 @@
+# starfield-datasources
+
+## Versioning
+
+- When adding a new datasource crate, increment the minor version of the `starfield-datasources` facade crate by 1
+- Each new datasource crate starts at version 0.1.0
+
+## Project Structure
+
+- Workspace with datasource crates under `crates/`
+- Facade crate at `crates/starfield-datasources/` re-exports all datasource crates behind feature flags
+- Default branch is `meawoppl/initial-workspace`
+
+## Patterns
+
+- Clients use `reqwest::blocking::Client` with timeouts (30-60s)
+- Error handling uses `starfield::{Result, StarfieldError}`
+- All dependencies come from workspace
+- Integration tests requiring network are marked `#[ignore]`
+- Real data excerpts should be used for parser unit tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/sbdb",
     "crates/gaia",
     "crates/hipparcos",
+    "crates/mpc",
     "crates/starfield-datasources",
 ]
 

--- a/crates/mpc/Cargo.toml
+++ b/crates/mpc/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "starfield-mpc"
+version = "0.1.0"
+description = "Minor Planet Center client — MPCORB catalog, observatory codes, and observation records"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+starfield = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+log = { workspace = true }

--- a/crates/mpc/src/client.rs
+++ b/crates/mpc/src/client.rs
@@ -1,0 +1,190 @@
+//! MPC HTTP client with rate limiting
+//!
+//! Provides access to MPC bulk data files and the web service API.
+
+use std::io::Read;
+use std::time::{Duration, Instant};
+
+use starfield::{Result, StarfieldError};
+
+use crate::mpcorb::{parse_mpcorb, MpcOrbRecord};
+use crate::observatory::{parse_observatory_codes, Observatory};
+
+/// Base URL for MPC data files
+const MPC_DATA_URL: &str = "https://www.minorplanetcenter.net/iau";
+
+/// Minimum delay between HTTP requests (2 seconds)
+const RATE_LIMIT_MS: u64 = 2000;
+
+/// Client for accessing Minor Planet Center data
+pub struct MpcClient {
+    client: reqwest::blocking::Client,
+    last_request: Option<Instant>,
+}
+
+impl MpcClient {
+    /// Create a new MPC client with default settings
+    pub fn new() -> Result<Self> {
+        let client = reqwest::blocking::Client::builder()
+            .timeout(Duration::from_secs(120))
+            .build()
+            .map_err(|e| {
+                StarfieldError::DataError(format!("Failed to create HTTP client: {}", e))
+            })?;
+        Ok(Self {
+            client,
+            last_request: None,
+        })
+    }
+
+    /// Enforce rate limiting between requests
+    fn rate_limit(&mut self) {
+        if let Some(last) = self.last_request {
+            let elapsed = last.elapsed();
+            let min_delay = Duration::from_millis(RATE_LIMIT_MS);
+            if elapsed < min_delay {
+                std::thread::sleep(min_delay - elapsed);
+            }
+        }
+        self.last_request = Some(Instant::now());
+    }
+
+    /// Fetch text content from a URL with rate limiting
+    fn fetch_text(&mut self, url: &str) -> Result<String> {
+        self.rate_limit();
+        log::info!("Fetching {}", url);
+
+        let response = self.client.get(url).send().map_err(|e| {
+            StarfieldError::DataError(format!("MPC request failed for {}: {}", url, e))
+        })?;
+
+        if !response.status().is_success() {
+            return Err(StarfieldError::DataError(format!(
+                "MPC returned HTTP {} for {}",
+                response.status(),
+                url
+            )));
+        }
+
+        response
+            .text()
+            .map_err(|e| StarfieldError::DataError(format!("Failed to read MPC response: {}", e)))
+    }
+
+    /// Fetch raw bytes from a URL with rate limiting (for large files)
+    fn fetch_bytes(&mut self, url: &str) -> Result<Vec<u8>> {
+        self.rate_limit();
+        log::info!("Fetching {} (bytes)", url);
+
+        let mut response = self.client.get(url).send().map_err(|e| {
+            StarfieldError::DataError(format!("MPC request failed for {}: {}", url, e))
+        })?;
+
+        if !response.status().is_success() {
+            return Err(StarfieldError::DataError(format!(
+                "MPC returned HTTP {} for {}",
+                response.status(),
+                url
+            )));
+        }
+
+        let mut bytes = Vec::new();
+        response.read_to_end(&mut bytes).map_err(|e| {
+            StarfieldError::DataError(format!("Failed to read MPC response: {}", e))
+        })?;
+
+        Ok(bytes)
+    }
+
+    /// Download and parse the MPC observatory code registry.
+    ///
+    /// Source: <https://minorplanetcenter.net/iau/lists/ObsCodes.html>
+    pub fn fetch_observatory_codes(&mut self) -> Result<Vec<Observatory>> {
+        let url = format!("{}/lists/ObsCodes.html", MPC_DATA_URL);
+        let html = self.fetch_text(&url)?;
+
+        // The observatory data is inside <pre> tags in the HTML
+        let text = extract_pre_content(&html).ok_or_else(|| {
+            StarfieldError::DataError(
+                "Could not find observatory data in HTML response".to_string(),
+            )
+        })?;
+
+        parse_observatory_codes(&text)
+    }
+
+    /// Download and parse the full MPCORB.DAT catalog.
+    ///
+    /// This is a large download (~300+ MB). Results are streamed and parsed.
+    /// Source: <https://minorplanetcenter.net/iau/MPCORB/MPCORB.DAT>
+    pub fn fetch_mpcorb(&mut self) -> Result<Vec<MpcOrbRecord>> {
+        let url = format!("{}/MPCORB/MPCORB.DAT", MPC_DATA_URL);
+        let bytes = self.fetch_bytes(&url)?;
+        let text = String::from_utf8_lossy(&bytes);
+        parse_mpcorb(&text)
+    }
+
+    /// Fetch a subset of MPCORB focusing on distant objects (TNOs, Centaurs).
+    ///
+    /// Filters records where semimajor axis exceeds `min_a_au`.
+    pub fn fetch_distant_objects(&mut self, min_a_au: f64) -> Result<Vec<MpcOrbRecord>> {
+        let all = self.fetch_mpcorb()?;
+        Ok(all
+            .into_iter()
+            .filter(|r| r.semimajor_axis > min_a_au)
+            .collect())
+    }
+}
+
+/// Extract text content between <pre> and </pre> tags
+fn extract_pre_content(html: &str) -> Option<String> {
+    let lower = html.to_lowercase();
+    let start = lower.find("<pre>")? + 5;
+    let end = lower[start..].find("</pre>")? + start;
+    Some(html[start..end].to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_pre_content() {
+        let html = "<html><body><pre>hello world</pre></body></html>";
+        assert_eq!(extract_pre_content(html), Some("hello world".to_string()));
+    }
+
+    #[test]
+    fn test_extract_pre_content_missing() {
+        assert_eq!(extract_pre_content("<html>no pre here</html>"), None);
+    }
+
+    #[test]
+    fn test_extract_pre_content_case_insensitive() {
+        let html = "<PRE>data</PRE>";
+        assert_eq!(extract_pre_content(html), Some("data".to_string()));
+    }
+
+    #[test]
+    fn test_client_creation() {
+        let client = MpcClient::new();
+        assert!(client.is_ok());
+    }
+
+    #[test]
+    #[ignore]
+    fn test_live_observatory_codes() {
+        let mut client = MpcClient::new().unwrap();
+        let observatories = client.fetch_observatory_codes().unwrap();
+        assert!(
+            observatories.len() > 1000,
+            "Expected 1000+ observatories, got {}",
+            observatories.len()
+        );
+
+        // Greenwich should be present
+        let greenwich = observatories.iter().find(|o| o.code == "000");
+        assert!(greenwich.is_some(), "Greenwich (000) should be present");
+        assert_eq!(greenwich.unwrap().name, "Greenwich");
+    }
+}

--- a/crates/mpc/src/lib.rs
+++ b/crates/mpc/src/lib.rs
@@ -1,0 +1,31 @@
+//! Minor Planet Center (MPC) data client
+//!
+//! Provides access to the MPC's astronomical data products:
+//!
+//! - **MPCORB catalog** — orbital elements for all numbered and unnumbered
+//!   minor planets (asteroids, TNOs, comets)
+//! - **Observatory codes** — geographic positions of all registered observatories
+//! - **Observation records** — 80-column astrometric observation format parser
+//!
+//! No API key or authentication is required. Bulk data files are downloaded
+//! directly from <https://minorplanetcenter.net>.
+//!
+//! # Quick Start
+//!
+//! ```no_run
+//! use starfield_mpc::MpcClient;
+//!
+//! let mut client = MpcClient::new().unwrap();
+//! let observatories = client.fetch_observatory_codes().unwrap();
+//! println!("Loaded {} observatories", observatories.len());
+//! ```
+
+pub mod client;
+pub mod mpcorb;
+pub mod observation;
+pub mod observatory;
+
+pub use client::MpcClient;
+pub use mpcorb::{parse_mpcorb, parse_mpcorb_line, unpack_epoch, MpcOrbRecord};
+pub use observation::{parse_observation_line, parse_observations, Observation};
+pub use observatory::{parse_observatory_codes, parse_observatory_line, Observatory};

--- a/crates/mpc/src/mpcorb.rs
+++ b/crates/mpc/src/mpcorb.rs
@@ -1,0 +1,266 @@
+//! Parser for MPCORB.DAT fixed-width records
+//!
+//! Format: <https://www.minorplanetcenter.net/iau/info/MPOrbitFormat.html>
+//!
+//! Each record is a single line with fields at fixed column positions.
+
+use starfield::{Result, StarfieldError};
+
+/// Orbital elements for a minor planet from MPCORB.DAT
+#[derive(Debug, Clone)]
+pub struct MpcOrbRecord {
+    /// Packed designation (cols 1-7)
+    pub designation: String,
+    /// Absolute magnitude H (cols 9-13)
+    pub h_magnitude: Option<f64>,
+    /// Slope parameter G (cols 15-19)
+    pub g_slope: Option<f64>,
+    /// Epoch in packed form (cols 21-25)
+    pub epoch_packed: String,
+    /// Mean anomaly at epoch, degrees (cols 27-35)
+    pub mean_anomaly: f64,
+    /// Argument of perihelion, J2000, degrees (cols 38-46)
+    pub arg_perihelion: f64,
+    /// Longitude of ascending node, J2000, degrees (cols 49-57)
+    pub long_asc_node: f64,
+    /// Inclination to ecliptic, J2000, degrees (cols 60-68)
+    pub inclination: f64,
+    /// Orbital eccentricity (cols 71-79)
+    pub eccentricity: f64,
+    /// Mean daily motion, degrees/day (cols 81-91)
+    pub mean_motion: f64,
+    /// Semimajor axis, AU (cols 93-103)
+    pub semimajor_axis: f64,
+    /// Reference designation (cols 108-116)
+    pub reference: String,
+    /// Number of observations (cols 118-122)
+    pub num_observations: Option<u32>,
+    /// Number of oppositions (cols 124-126)
+    pub num_oppositions: Option<u32>,
+    /// Arc span string, e.g. "1801-2026" (cols 128-136)
+    pub arc: String,
+    /// RMS residual, arcsec (cols 138-141)
+    pub residual_rms: Option<f64>,
+    /// Computer name (cols 151-160)
+    pub computer: String,
+    /// Readable designation (cols 167-194)
+    pub readable_designation: String,
+    /// Date of last observation, YYYYMMDD (cols 195-202)
+    pub last_obs_date: String,
+}
+
+fn slice_field(line: &str, start: usize, end: usize) -> &str {
+    if line.len() >= end {
+        line[start..end].trim()
+    } else if line.len() > start {
+        line[start..].trim()
+    } else {
+        ""
+    }
+}
+
+/// Parse a single MPCORB.DAT record line.
+///
+/// Returns `None` for header lines, blank lines, or separator lines.
+pub fn parse_mpcorb_line(line: &str) -> Option<MpcOrbRecord> {
+    // Skip short lines, headers, blank lines, and separator lines
+    if line.len() < 160 || line.starts_with('-') || line.starts_with(' ') {
+        return None;
+    }
+
+    let designation = slice_field(line, 0, 7).to_string();
+    if designation.is_empty() {
+        return None;
+    }
+
+    let h_magnitude = slice_field(line, 8, 13).parse::<f64>().ok();
+    let g_slope = slice_field(line, 14, 19).parse::<f64>().ok();
+    let epoch_packed = slice_field(line, 20, 25).to_string();
+
+    let mean_anomaly = slice_field(line, 26, 35)
+        .parse::<f64>()
+        .map_err(|e| {
+            StarfieldError::DataError(format!("Bad mean anomaly for {}: {}", designation, e))
+        })
+        .ok()?;
+
+    let arg_perihelion = slice_field(line, 37, 46).parse::<f64>().ok()?;
+    let long_asc_node = slice_field(line, 48, 57).parse::<f64>().ok()?;
+    let inclination = slice_field(line, 59, 68).parse::<f64>().ok()?;
+    let eccentricity = slice_field(line, 70, 79).parse::<f64>().ok()?;
+    let mean_motion = slice_field(line, 80, 91).parse::<f64>().ok()?;
+    let semimajor_axis = slice_field(line, 92, 103).parse::<f64>().ok()?;
+
+    let reference = slice_field(line, 107, 116).to_string();
+    let num_observations = slice_field(line, 117, 122).parse::<u32>().ok();
+    let num_oppositions = slice_field(line, 123, 126).parse::<u32>().ok();
+    let arc = slice_field(line, 127, 136).to_string();
+    let residual_rms = slice_field(line, 137, 141).parse::<f64>().ok();
+    let computer = slice_field(line, 150, 160).to_string();
+    let readable_designation = slice_field(line, 166, 194).to_string();
+    let last_obs_date = slice_field(line, 194, 202).to_string();
+
+    Some(MpcOrbRecord {
+        designation,
+        h_magnitude,
+        g_slope,
+        epoch_packed,
+        mean_anomaly,
+        arg_perihelion,
+        long_asc_node,
+        inclination,
+        eccentricity,
+        mean_motion,
+        semimajor_axis,
+        reference,
+        num_observations,
+        num_oppositions,
+        arc,
+        residual_rms,
+        computer,
+        readable_designation,
+        last_obs_date,
+    })
+}
+
+/// Parse the full MPCORB.DAT content, skipping the header block.
+pub fn parse_mpcorb(text: &str) -> Result<Vec<MpcOrbRecord>> {
+    let records: Vec<MpcOrbRecord> = text.lines().filter_map(parse_mpcorb_line).collect();
+
+    if records.is_empty() {
+        return Err(StarfieldError::DataError(
+            "No MPCORB records found".to_string(),
+        ));
+    }
+
+    Ok(records)
+}
+
+/// Unpack an MPC packed epoch into (year, month, day).
+///
+/// Packed epoch format: first two chars = century+year (e.g. "K25" = 2025),
+/// third char = month (1-9, A=10, B=11, C=12),
+/// fourth-fifth chars = day (packed similarly).
+pub fn unpack_epoch(packed: &str) -> Option<(i32, u32, f64)> {
+    if packed.len() < 5 {
+        return None;
+    }
+
+    let bytes = packed.as_bytes();
+    let century = match bytes[0] {
+        b'I' => 1800,
+        b'J' => 1900,
+        b'K' => 2000,
+        _ => return None,
+    };
+
+    let year_tens = (bytes[1] as char).to_digit(10)?;
+    let year_ones = (bytes[2] as char).to_digit(10)?;
+    let year = century + (year_tens * 10 + year_ones) as i32;
+
+    let month = unpack_digit(bytes[3])?;
+    let day = unpack_digit(bytes[4])? as f64;
+
+    Some((year, month, day))
+}
+
+fn unpack_digit(b: u8) -> Option<u32> {
+    match b {
+        b'1'..=b'9' => Some((b - b'0') as u32),
+        b'A'..=b'V' => Some((b - b'A') as u32 + 10),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Real records from MPCORB.DAT (fetched 2026-03-09)
+    const CERES_LINE: &str = "00001    3.35  0.15 K25BL 231.53975   73.29974   80.24963   10.58789  0.0795763  0.21429712   2.7656157  0 MPO964264  7384 126 1801-2026 0.69 M-v 30k MPCORBFIT  4000      (1) Ceres              20260103";
+    const PALLAS_LINE: &str = "00002    4.11  0.15 K25BL 211.52977  310.93340  172.88859   34.92833  0.2306430  0.21379713   2.7699258  0 MPO964264  9023 124 1804-2025 0.64 M-c 28k MPCORBFIT  4000      (2) Pallas             20251214";
+    const VESTA_LINE: &str = "00004    3.25  0.15 K25BL  26.80969  151.53711  103.70232    7.14406  0.0901676  0.27158812   2.3615413  0 MPO964264  7603 112 1821-2025 0.69 M-p 18k MPCORBFIT  4000      (4) Vesta              20250624";
+
+    #[test]
+    fn test_parse_ceres() {
+        let rec = parse_mpcorb_line(CERES_LINE).unwrap();
+        assert_eq!(rec.designation, "00001");
+        assert!((rec.h_magnitude.unwrap() - 3.35).abs() < 1e-2);
+        assert!((rec.g_slope.unwrap() - 0.15).abs() < 1e-2);
+        assert_eq!(rec.epoch_packed, "K25BL");
+        assert!((rec.mean_anomaly - 231.53975).abs() < 1e-4);
+        assert!((rec.arg_perihelion - 73.29974).abs() < 1e-4);
+        assert!((rec.long_asc_node - 80.24963).abs() < 1e-4);
+        assert!((rec.inclination - 10.58789).abs() < 1e-4);
+        assert!((rec.eccentricity - 0.0795763).abs() < 1e-7);
+        assert!((rec.mean_motion - 0.21429712).abs() < 1e-7);
+        assert!((rec.semimajor_axis - 2.7656157).abs() < 1e-6);
+        assert_eq!(rec.num_observations, Some(7384));
+        assert_eq!(rec.num_oppositions, Some(126));
+        assert_eq!(rec.arc, "1801-2026");
+        assert!((rec.residual_rms.unwrap() - 0.69).abs() < 1e-2);
+        assert!(rec.readable_designation.contains("Ceres"));
+        assert_eq!(rec.last_obs_date, "20260103");
+    }
+
+    #[test]
+    fn test_parse_pallas() {
+        let rec = parse_mpcorb_line(PALLAS_LINE).unwrap();
+        assert_eq!(rec.designation, "00002");
+        assert!((rec.inclination - 34.92833).abs() < 1e-4);
+        assert!((rec.eccentricity - 0.2306430).abs() < 1e-7);
+        assert!(rec.readable_designation.contains("Pallas"));
+    }
+
+    #[test]
+    fn test_parse_vesta() {
+        let rec = parse_mpcorb_line(VESTA_LINE).unwrap();
+        assert_eq!(rec.designation, "00004");
+        assert!((rec.semimajor_axis - 2.3615413).abs() < 1e-6);
+        assert!(rec.readable_designation.contains("Vesta"));
+    }
+
+    #[test]
+    fn test_parse_batch_with_headers() {
+        let input = format!(
+            "MINOR PLANET CENTER ORBIT DATABASE\n\n{}\n{}\n{}",
+            CERES_LINE, PALLAS_LINE, VESTA_LINE
+        );
+        let records = parse_mpcorb(&input).unwrap();
+        assert_eq!(records.len(), 3);
+    }
+
+    #[test]
+    fn test_skip_header_lines() {
+        assert!(parse_mpcorb_line("MINOR PLANET CENTER ORBIT DATABASE").is_none());
+        assert!(parse_mpcorb_line("").is_none());
+        assert!(parse_mpcorb_line("---").is_none());
+        assert!(parse_mpcorb_line("   Software programs may include").is_none());
+    }
+
+    #[test]
+    fn test_unpack_epoch() {
+        let (y, m, d) = unpack_epoch("K25BL").unwrap();
+        assert_eq!(y, 2025);
+        assert_eq!(m, 11); // B = 11
+        assert_eq!(d, 21.0); // L = 21
+    }
+
+    #[test]
+    fn test_unpack_epoch_j_century() {
+        let (y, m, _) = unpack_epoch("J9611").unwrap();
+        assert_eq!(y, 1996);
+        assert_eq!(m, 1);
+    }
+
+    #[test]
+    fn test_ceres_physical_sanity() {
+        let rec = parse_mpcorb_line(CERES_LINE).unwrap();
+        // Ceres orbits in the main belt at ~2.77 AU
+        assert!(rec.semimajor_axis > 2.5 && rec.semimajor_axis < 3.0);
+        // Near-circular orbit
+        assert!(rec.eccentricity < 0.15);
+        // Low inclination
+        assert!(rec.inclination < 15.0);
+    }
+}

--- a/crates/mpc/src/observation.rs
+++ b/crates/mpc/src/observation.rs
@@ -1,0 +1,227 @@
+//! Parser for MPC 80-column optical observation records
+//!
+//! Format: <https://www.minorplanetcenter.net/iau/info/OpticalObs.html>
+//!
+//! Cols 1-12:  Designation (packed)
+//! Col 13:     Discovery asterisk
+//! Col 14:     Publishable note
+//! Col 15:     Observation type (C=CCD, P=photographic, etc.)
+//! Cols 16-32: Date (YYYY MM DD.ddddd)
+//! Cols 33-44: RA J2000 (HH MM SS.ddd)
+//! Cols 45-56: Dec J2000 (sDD MM SS.dd)
+//! Cols 66-71: Magnitude + band
+//! Cols 78-80: Observatory code
+
+use starfield::{Result, StarfieldError};
+
+/// A single astrometric observation from the MPC
+#[derive(Debug, Clone)]
+pub struct Observation {
+    /// Packed designation (cols 1-12)
+    pub designation: String,
+    /// Whether this is the discovery observation
+    pub is_discovery: bool,
+    /// Observation type: 'C' = CCD, 'P' = photographic, etc.
+    pub obs_type: Option<char>,
+    /// Observation date as (year, month, fractional day)
+    pub date: (i32, u32, f64),
+    /// Right ascension in degrees (J2000)
+    pub ra_deg: f64,
+    /// Declination in degrees (J2000)
+    pub dec_deg: f64,
+    /// Observed magnitude
+    pub magnitude: Option<f64>,
+    /// Photometric band (V, R, B, etc.)
+    pub band: Option<char>,
+    /// 3-character observatory code
+    pub observatory_code: String,
+}
+
+/// Parse RA from "HH MM SS.ddd" format to degrees
+fn parse_ra(s: &str) -> Option<f64> {
+    let parts: Vec<&str> = s.split_whitespace().collect();
+    if parts.len() < 3 {
+        return None;
+    }
+    let h: f64 = parts[0].parse().ok()?;
+    let m: f64 = parts[1].parse().ok()?;
+    let sec: f64 = parts[2].parse().ok()?;
+    Some((h + m / 60.0 + sec / 3600.0) * 15.0)
+}
+
+/// Parse Dec from "sDD MM SS.dd" format to degrees
+fn parse_dec(s: &str) -> Option<f64> {
+    let s = s.trim();
+    let parts: Vec<&str> = s.split_whitespace().collect();
+    if parts.len() < 3 {
+        return None;
+    }
+    let deg_str = parts[0];
+    let sign: f64 = if deg_str.starts_with('-') { -1.0 } else { 1.0 };
+    let d: f64 = deg_str.trim_start_matches(['+', '-']).parse().ok()?;
+    let m: f64 = parts[1].parse().ok()?;
+    let sec: f64 = parts[2].parse().ok()?;
+    Some(sign * (d + m / 60.0 + sec / 3600.0))
+}
+
+/// Parse a date string "YYYY MM DD.ddddd" to (year, month, fractional_day)
+fn parse_date(s: &str) -> Option<(i32, u32, f64)> {
+    let parts: Vec<&str> = s.split_whitespace().collect();
+    if parts.len() < 3 {
+        return None;
+    }
+    let year: i32 = parts[0].parse().ok()?;
+    let month: u32 = parts[1].parse().ok()?;
+    let day: f64 = parts[2].parse().ok()?;
+    Some((year, month, day))
+}
+
+/// Parse a single 80-column observation record.
+///
+/// Returns `None` for lines that don't match the expected format.
+pub fn parse_observation_line(line: &str) -> Option<Observation> {
+    if line.len() < 80 {
+        return None;
+    }
+
+    let designation = line[..12].trim().to_string();
+    if designation.is_empty() {
+        return None;
+    }
+
+    let is_discovery = line.as_bytes().get(12) == Some(&b'*');
+    let obs_type = line.as_bytes().get(14).and_then(|&b| {
+        let c = b as char;
+        if c.is_ascii_alphabetic() {
+            Some(c)
+        } else {
+            None
+        }
+    });
+
+    let date = parse_date(line[15..32].trim())?;
+    let ra_deg = parse_ra(line[32..44].trim())?;
+    let dec_deg = parse_dec(line[44..56].trim())?;
+
+    let mag_str = if line.len() >= 71 {
+        line[65..70].trim()
+    } else {
+        ""
+    };
+    let magnitude = mag_str.parse::<f64>().ok();
+
+    let band = if line.len() >= 72 {
+        let b = line.as_bytes()[70];
+        if b.is_ascii_alphabetic() {
+            Some(b as char)
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    let observatory_code = if line.len() >= 80 {
+        line[77..80].trim().to_string()
+    } else {
+        String::new()
+    };
+
+    Some(Observation {
+        designation,
+        is_discovery,
+        obs_type,
+        date,
+        ra_deg,
+        dec_deg,
+        magnitude,
+        band,
+        observatory_code,
+    })
+}
+
+/// Parse multiple 80-column observation records.
+pub fn parse_observations(text: &str) -> Result<Vec<Observation>> {
+    let obs: Vec<Observation> = text.lines().filter_map(parse_observation_line).collect();
+
+    if obs.is_empty() {
+        return Err(StarfieldError::DataError(
+            "No observation records found".to_string(),
+        ));
+    }
+
+    Ok(obs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Synthetic 80-column observation records following MPC format.
+    // Each line is exactly 80 characters with fields at fixed positions.
+    //                         1111111111222222222233333333334444444444555555555566666666667777777778
+    //                1234567890123456789012345678901234567890123456789012345678901234567890123456789 0
+    const CERES_OBS_1: &str =
+        "00001         C2024 01 15.12345 06 23 45.123-08 12 34.56          18.5V      568";
+    const CERES_OBS_2: &str =
+        "00001       * C2024 01 15.12345 06 23 45.123-08 12 34.56          18.5R      568";
+
+    #[test]
+    fn test_parse_ra() {
+        let ra = parse_ra("06 23 45.123").unwrap();
+        // 6h 23m 45.123s = (6 + 23/60 + 45.123/3600) * 15
+        let expected = (6.0 + 23.0 / 60.0 + 45.123 / 3600.0) * 15.0;
+        assert!((ra - expected).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_parse_dec_negative() {
+        let dec = parse_dec("-08 12 34.56").unwrap();
+        let expected = -(8.0 + 12.0 / 60.0 + 34.56 / 3600.0);
+        assert!((dec - expected).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_parse_dec_positive() {
+        let dec = parse_dec("+16 17 25.5").unwrap();
+        let expected = 16.0 + 17.0 / 60.0 + 25.5 / 3600.0;
+        assert!((dec - expected).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_parse_observation() {
+        let obs = parse_observation_line(CERES_OBS_1).unwrap();
+        assert_eq!(obs.designation, "00001");
+        assert!(!obs.is_discovery);
+        assert_eq!(obs.obs_type, Some('C'));
+        assert_eq!(obs.date.0, 2024);
+        assert_eq!(obs.date.1, 1);
+        assert!((obs.date.2 - 15.12345).abs() < 1e-5);
+        assert!(obs.ra_deg > 95.0 && obs.ra_deg < 96.0);
+        assert!(obs.dec_deg < -8.0 && obs.dec_deg > -9.0);
+        assert!((obs.magnitude.unwrap() - 18.5).abs() < 1e-2);
+        assert_eq!(obs.band, Some('V'));
+        assert_eq!(obs.observatory_code, "568");
+    }
+
+    #[test]
+    fn test_discovery_flag() {
+        let obs = parse_observation_line(CERES_OBS_2).unwrap();
+        assert!(obs.is_discovery);
+        assert_eq!(obs.band, Some('R'));
+    }
+
+    #[test]
+    fn test_skip_short_lines() {
+        assert!(parse_observation_line("too short").is_none());
+        assert!(parse_observation_line("").is_none());
+    }
+
+    #[test]
+    fn test_parse_date() {
+        let (y, m, d) = parse_date("2024 01 15.12345").unwrap();
+        assert_eq!(y, 2024);
+        assert_eq!(m, 1);
+        assert!((d - 15.12345).abs() < 1e-5);
+    }
+}

--- a/crates/mpc/src/observatory.rs
+++ b/crates/mpc/src/observatory.rs
@@ -1,0 +1,131 @@
+//! Parser for MPC observatory code records
+//!
+//! Source: <https://minorplanetcenter.net/iau/lists/ObsCodes.html>
+//!
+//! Each line is fixed-width:
+//!   Cols 1-3:   Observatory code
+//!   Cols 4-13:  Longitude (degrees, east positive)
+//!   Cols 14-21: cos(latitude) * rho
+//!   Cols 22-30: sin(latitude) * rho
+//!   Cols 31+:   Name
+
+use starfield::{Result, StarfieldError};
+
+/// An MPC observatory with its geographic position
+#[derive(Debug, Clone)]
+pub struct Observatory {
+    /// 3-character MPC observatory code
+    pub code: String,
+    /// East longitude in degrees (0-360)
+    pub longitude: Option<f64>,
+    /// cos(latitude) * distance-from-center (Earth radii)
+    pub cos_lat_rho: Option<f64>,
+    /// sin(latitude) * distance-from-center (Earth radii)
+    pub sin_lat_rho: Option<f64>,
+    /// Observatory name
+    pub name: String,
+}
+
+/// Parse a single observatory code line.
+///
+/// Returns `None` for header/blank lines that should be skipped.
+pub fn parse_observatory_line(line: &str) -> Option<Observatory> {
+    if line.len() < 30 {
+        return None;
+    }
+
+    let code = line[..3].trim().to_string();
+    if code.is_empty() || code == "Cod" {
+        return None;
+    }
+
+    let lon_str = line[3..13].trim();
+    let cos_str = line[13..21].trim();
+    let sin_str = line[21..30].trim();
+    let name = line[30..].trim().to_string();
+
+    let longitude = lon_str.parse::<f64>().ok();
+    let cos_lat_rho = cos_str.parse::<f64>().ok();
+    let sin_lat_rho = sin_str.parse::<f64>().ok();
+
+    Some(Observatory {
+        code,
+        longitude,
+        cos_lat_rho,
+        sin_lat_rho,
+        name,
+    })
+}
+
+/// Parse a full observatory codes file (text content, not HTML).
+pub fn parse_observatory_codes(text: &str) -> Result<Vec<Observatory>> {
+    let observatories: Vec<Observatory> = text.lines().filter_map(parse_observatory_line).collect();
+
+    if observatories.is_empty() {
+        return Err(StarfieldError::DataError(
+            "No observatory records found".to_string(),
+        ));
+    }
+
+    Ok(observatories)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Real data excerpt from https://minorplanetcenter.net/iau/lists/ObsCodes.html
+    const SAMPLE_OBSERVATORY_LINES: &str = "\
+000   0.0000 0.62411 +0.77873 Greenwich
+001   0.1542 0.62992 +0.77411 Crowborough
+002   0.62   0.622   +0.781   Rayleigh
+003   3.90   0.725   +0.687   Montpellier
+004   1.4625 0.72520 +0.68627 Toulouse
+005   2.231000.659891+0.748875Meudon
+006   2.124170.751042+0.658129Fabra Observatory, Barcelona
+007   2.336750.659470+0.749223Paris
+008   3.0355 0.80172 +0.59578 Algiers-Bouzareah
+009   7.4417 0.6838  +0.7272  Berne-Uecht
+010   6.921240.723655+0.688135Caussols
+011   8.7975 0.67920 +0.73161 Wetzikon
+012   4.358210.633333+0.771306Uccle
+013   4.483970.614813+0.786029Leiden
+014   5.395090.728859+0.682384Marseilles
+015   5.129290.615770+0.785285Utrecht
+016   5.9893 0.68006 +0.73076 Besancon
+017   6.849240.641946+0.764282Hoher List
+018   6.7612 0.62779 +0.77578 Dusseldorf-Bilk
+019   6.9575 0.68331 +0.72779 Neuchatel";
+
+    #[test]
+    fn test_parse_greenwich() {
+        let obs = parse_observatory_line("000   0.0000 0.62411 +0.77873 Greenwich").unwrap();
+        assert_eq!(obs.code, "000");
+        assert!((obs.longitude.unwrap() - 0.0).abs() < 1e-4);
+        assert!((obs.cos_lat_rho.unwrap() - 0.62411).abs() < 1e-5);
+        assert!((obs.sin_lat_rho.unwrap() - 0.77873).abs() < 1e-5);
+        assert_eq!(obs.name, "Greenwich");
+    }
+
+    #[test]
+    fn test_parse_compact_spacing() {
+        // Meudon has no space between some fields
+        let obs = parse_observatory_line("005   2.231000.659891+0.748875Meudon").unwrap();
+        assert_eq!(obs.code, "005");
+        assert_eq!(obs.name, "Meudon");
+    }
+
+    #[test]
+    fn test_parse_batch() {
+        let result = parse_observatory_codes(SAMPLE_OBSERVATORY_LINES).unwrap();
+        assert_eq!(result.len(), 20);
+        assert_eq!(result[0].code, "000");
+        assert_eq!(result[19].code, "019");
+    }
+
+    #[test]
+    fn test_skip_short_lines() {
+        assert!(parse_observatory_line("").is_none());
+        assert!(parse_observatory_line("short").is_none());
+    }
+}

--- a/crates/starfield-datasources/Cargo.toml
+++ b/crates/starfield-datasources/Cargo.toml
@@ -1,18 +1,19 @@
 [package]
 name = "starfield-datasources"
-version = "0.1.0"
+version = "0.2.0"
 description = "Astronomical data source clients for the starfield ecosystem"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 
 [features]
-default = ["horizons", "sbdb", "gaia", "hipparcos", "jplephem"]
+default = ["horizons", "sbdb", "gaia", "hipparcos", "jplephem", "mpc"]
 horizons = ["dep:starfield-horizons"]
 sbdb = ["dep:starfield-sbdb"]
 gaia = ["dep:starfield-gaia"]
 hipparcos = ["dep:starfield-hipparcos"]
 jplephem = ["dep:starfield-jplephem"]
+mpc = ["dep:starfield-mpc"]
 
 [dependencies]
 starfield-jplephem = { path = "../jplephem", optional = true }
@@ -20,3 +21,4 @@ starfield-horizons = { path = "../horizons", optional = true }
 starfield-sbdb = { path = "../sbdb", optional = true }
 starfield-gaia = { path = "../gaia", optional = true }
 starfield-hipparcos = { path = "../hipparcos", optional = true }
+starfield-mpc = { path = "../mpc", optional = true }

--- a/crates/starfield-datasources/src/lib.rs
+++ b/crates/starfield-datasources/src/lib.rs
@@ -10,6 +10,7 @@
 //! - `sbdb` — NASA JPL Small-Body Database API client
 //! - `gaia` — ESA Gaia star catalog loader
 //! - `hipparcos` — Hipparcos star catalog loader
+//! - `mpc` — Minor Planet Center client (MPCORB, observatory codes, observations)
 
 #[cfg(feature = "jplephem")]
 pub use starfield_jplephem as jplephem;
@@ -25,3 +26,6 @@ pub use starfield_gaia as gaia;
 
 #[cfg(feature = "hipparcos")]
 pub use starfield_hipparcos as hipparcos;
+
+#[cfg(feature = "mpc")]
+pub use starfield_mpc as mpc;


### PR DESCRIPTION
## Summary
- New `starfield-mpc` crate with parsers for MPC data formats and an HTTP client
- **MPCORB parser**: Fixed-width record parser for MPCORB.DAT (orbital elements catalog), tested against real Ceres/Pallas/Vesta records
- **Observatory codes parser**: Parses the MPC observatory registry, tested with 20 real entries
- **Observation parser**: 80-column optical observation format parser
- **Client**: HTTP client with 2-second rate limiting between requests, methods for `fetch_observatory_codes()`, `fetch_mpcorb()`, and `fetch_distant_objects()`
- Facade crate bumped to v0.2.0 with `mpc` feature flag
- CLAUDE.md added with project conventions

23 unit tests + 1 doctest + 1 live integration test (ignored by default)

Closes #1

## Test plan
- [x] 23 unit tests pass (parser tests with real data excerpts)
- [x] Doctest compiles
- [x] Live observatory codes fetch verified
- [x] Facade crate compiles with mpc feature