### PR TITLE
Extract shared HTTP client builder into utils crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "crates/datasource-utils",
     "crates/jplephem",
     "crates/horizons",
     "crates/sbdb",

--- a/crates/datasource-utils/Cargo.toml
+++ b/crates/datasource-utils/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "starfield-datasource-utils"
+version = "0.1.0"
+description = "Shared utilities for starfield datasource crates"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+starfield = { workspace = true }
+reqwest = { workspace = true }

--- a/crates/datasource-utils/src/http.rs
+++ b/crates/datasource-utils/src/http.rs
@@ -1,0 +1,27 @@
+//! Shared HTTP client utilities
+
+use std::time::Duration;
+
+use starfield::{Result, StarfieldError};
+
+/// Build a blocking HTTP client with the given timeout.
+///
+/// All datasource crates use the same pattern for creating reqwest clients.
+/// This centralizes that boilerplate.
+pub fn build_http_client(timeout_secs: u64) -> Result<reqwest::blocking::Client> {
+    reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(timeout_secs))
+        .build()
+        .map_err(|e| StarfieldError::DataError(format!("Failed to create HTTP client: {}", e)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_http_client() {
+        let client = build_http_client(30);
+        assert!(client.is_ok());
+    }
+}

--- a/crates/datasource-utils/src/lib.rs
+++ b/crates/datasource-utils/src/lib.rs
@@ -1,0 +1,8 @@
+//! Shared utilities for starfield datasource crates
+//!
+//! Common helpers for HTTP clients, file caching, and downloads
+//! used across multiple datasource implementations.
+
+pub mod http;
+
+pub use http::build_http_client;

--- a/crates/gaia/Cargo.toml
+++ b/crates/gaia/Cargo.toml
@@ -17,3 +17,4 @@ md5 = { workspace = true }
 regex = { workspace = true }
 rand = { workspace = true }
 nalgebra = { workspace = true }
+starfield-datasource-utils = { version = "0.1.0", path = "../datasource-utils" }

--- a/crates/gaia/src/downloader.rs
+++ b/crates/gaia/src/downloader.rs
@@ -7,11 +7,11 @@ use std::env;
 use std::fs::{self, File};
 use std::io::{self, BufRead, BufReader, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
-use std::time::Duration;
 // No need for sync primitives yet
 
 use regex::Regex;
 use starfield::{Result, StarfieldError};
+use starfield_datasource_utils::build_http_client;
 
 // Base URL for Gaia DR1 catalog
 const GAIA_DR1_BASE_URL: &str = "https://cdn.gea.esac.esa.int/Gaia/gdr1/gaia_source/csv/";
@@ -53,11 +53,7 @@ fn download_file<P: AsRef<Path>>(url: &str, path: P) -> Result<()> {
     let temp_path = path.as_ref().with_extension("tmp");
     let mut file = BufWriter::new(File::create(&temp_path).map_err(StarfieldError::IoError)?);
 
-    // Create HTTP client with timeout
-    let client = reqwest::blocking::Client::builder()
-        .timeout(Duration::from_secs(600)) // 10 minute timeout for large files
-        .build()
-        .map_err(|e| StarfieldError::DataError(format!("Failed to create HTTP client: {}", e)))?;
+    let client = build_http_client(600)?;
 
     println!("Downloading: {}", url);
 
@@ -201,11 +197,7 @@ fn download_md5sums() -> Result<HashMap<String, String>> {
 
 /// List all files in the Gaia DR1 catalog index
 fn list_gaia_files() -> Result<Vec<String>> {
-    // Get the index page containing the file list
-    let client = reqwest::blocking::Client::builder()
-        .timeout(Duration::from_secs(60))
-        .build()
-        .map_err(|e| StarfieldError::DataError(format!("Failed to create HTTP client: {}", e)))?;
+    let client = build_http_client(60)?;
 
     println!("Fetching Gaia catalog index...");
     let response = client

--- a/crates/hipparcos/Cargo.toml
+++ b/crates/hipparcos/Cargo.toml
@@ -15,6 +15,7 @@ indicatif = { workspace = true }
 rand = { workspace = true }
 nalgebra = { workspace = true }
 flate2.workspace = true
+starfield-datasource-utils = { version = "0.1.0", path = "../datasource-utils" }
 
 [dev-dependencies]
 tempfile = "3.26.0"

--- a/crates/hipparcos/src/downloader.rs
+++ b/crates/hipparcos/src/downloader.rs
@@ -6,10 +6,10 @@ use std::env;
 use std::fs::{self, File};
 use std::io::{self, BufReader, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
-use std::time::Duration;
 
 use starfield::Result;
 use starfield::StarfieldError;
+use starfield_datasource_utils::build_http_client;
 
 use indicatif::{ProgressBar, ProgressStyle};
 
@@ -55,11 +55,7 @@ fn download_file<P: AsRef<Path>>(url: &str, path: P) -> Result<()> {
     let temp_path = path.as_ref().with_extension("tmp");
     let mut file = BufWriter::new(File::create(&temp_path).map_err(StarfieldError::IoError)?);
 
-    // Create HTTP client with timeout
-    let client = reqwest::blocking::Client::builder()
-        .timeout(Duration::from_secs(30))
-        .build()
-        .map_err(|e| StarfieldError::DataError(format!("Failed to create HTTP client: {}", e)))?;
+    let client = build_http_client(30)?;
 
     // Make the request
     let mut response = client
@@ -189,10 +185,7 @@ pub fn download_file_with_progress<P: AsRef<Path>>(url: &str, path: P) -> Result
     let temp_path = path.as_ref().with_extension("tmp");
     let mut file = BufWriter::new(File::create(&temp_path).map_err(StarfieldError::IoError)?);
 
-    let client = reqwest::blocking::Client::builder()
-        .timeout(Duration::from_secs(600))
-        .build()
-        .map_err(|e| StarfieldError::DataError(format!("Failed to create HTTP client: {}", e)))?;
+    let client = build_http_client(600)?;
 
     let response = client
         .get(url)
@@ -411,10 +404,7 @@ mod tests {
             "jup365.bsp",
         ];
 
-        let client = reqwest::blocking::Client::builder()
-            .timeout(Duration::from_secs(15))
-            .build()
-            .expect("Failed to build HTTP client");
+        let client = build_http_client(15).expect("Failed to build HTTP client");
 
         for filename in filenames {
             let url = resolve_url(filename).expect("resolve_url returned None");

--- a/crates/horizons/Cargo.toml
+++ b/crates/horizons/Cargo.toml
@@ -14,3 +14,4 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 base64 = { workspace = true }
+starfield-datasource-utils = { version = "0.1.0", path = "../datasource-utils" }

--- a/crates/horizons/src/client.rs
+++ b/crates/horizons/src/client.rs
@@ -9,6 +9,7 @@
 use base64::Engine;
 use serde::Deserialize;
 use starfield::{Result, StarfieldError};
+use starfield_datasource_utils::build_http_client;
 use starfield_jplephem::SpiceKernel;
 use std::collections::HashMap;
 use std::path::Path;
@@ -947,12 +948,7 @@ pub struct HorizonsClient {
 impl HorizonsClient {
     /// Create a new HORIZONS API client
     pub fn new() -> Result<Self> {
-        let client = reqwest::blocking::Client::builder()
-            .timeout(std::time::Duration::from_secs(60))
-            .build()
-            .map_err(|e| {
-                StarfieldError::DataError(format!("Failed to create HTTP client: {}", e))
-            })?;
+        let client = build_http_client(60)?;
         Ok(Self { client })
     }
 

--- a/crates/mpc/Cargo.toml
+++ b/crates/mpc/Cargo.toml
@@ -13,3 +13,4 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 log = { workspace = true }
+starfield-datasource-utils = { version = "0.1.0", path = "../datasource-utils" }

--- a/crates/mpc/src/client.rs
+++ b/crates/mpc/src/client.rs
@@ -6,6 +6,7 @@ use std::io::Read;
 use std::time::{Duration, Instant};
 
 use starfield::{Result, StarfieldError};
+use starfield_datasource_utils::build_http_client;
 
 use crate::mpcorb::{parse_mpcorb, MpcOrbRecord};
 use crate::observatory::{parse_observatory_codes, Observatory};
@@ -25,12 +26,7 @@ pub struct MpcClient {
 impl MpcClient {
     /// Create a new MPC client with default settings
     pub fn new() -> Result<Self> {
-        let client = reqwest::blocking::Client::builder()
-            .timeout(Duration::from_secs(120))
-            .build()
-            .map_err(|e| {
-                StarfieldError::DataError(format!("Failed to create HTTP client: {}", e))
-            })?;
+        let client = build_http_client(120)?;
         Ok(Self {
             client,
             last_request: None,

--- a/crates/sbdb/Cargo.toml
+++ b/crates/sbdb/Cargo.toml
@@ -12,3 +12,4 @@ reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+starfield-datasource-utils = { version = "0.1.0", path = "../datasource-utils" }

--- a/crates/sbdb/src/client.rs
+++ b/crates/sbdb/src/client.rs
@@ -9,6 +9,7 @@
 use crate::types::*;
 use serde_json::Value;
 use starfield::{Result, StarfieldError};
+use starfield_datasource_utils::build_http_client;
 use std::collections::HashMap;
 
 const SBDB_API_URL: &str = "https://ssd-api.jpl.nasa.gov/sbdb.api";
@@ -31,12 +32,7 @@ pub struct SbdbClient {
 impl SbdbClient {
     /// Create a new SBDB API client
     pub fn new() -> Result<Self> {
-        let client = reqwest::blocking::Client::builder()
-            .timeout(std::time::Duration::from_secs(30))
-            .build()
-            .map_err(|e| {
-                StarfieldError::DataError(format!("Failed to create HTTP client: {}", e))
-            })?;
+        let client = build_http_client(30)?;
         Ok(Self { client })
     }
 


### PR DESCRIPTION
## Summary
- Creates `starfield-datasource-utils` crate with a shared `build_http_client(timeout_secs)` function
- Replaces duplicated `reqwest::blocking::Client::builder()` boilerplate across all 5 consumer crates (sbdb, horizons, mpc, gaia, hipparcos)
- Removes now-unused `std::time::Duration` imports from gaia and hipparcos

## Test plan
- [x] `cargo check` passes with no warnings
- [x] `cargo test --workspace` all tests pass
- [x] New `test_build_http_client` unit test in utils crate