### PR TITLE
Extract shared HTTP response status checking

### DIFF
--- a/crates/datasource-utils/src/http.rs
+++ b/crates/datasource-utils/src/http.rs
@@ -15,6 +15,22 @@ pub fn build_http_client(timeout_secs: u64) -> Result<reqwest::blocking::Client>
         .map_err(|e| StarfieldError::DataError(format!("Failed to create HTTP client: {}", e)))
 }
 
+/// Check that an HTTP response has a success status, returning a descriptive
+/// error that includes `context` (typically the service or URL) on failure.
+pub fn check_response_status(
+    response: reqwest::blocking::Response,
+    context: &str,
+) -> Result<reqwest::blocking::Response> {
+    if response.status().is_success() {
+        return Ok(response);
+    }
+    Err(StarfieldError::DataError(format!(
+        "{} returned HTTP {}",
+        context,
+        response.status()
+    )))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/datasource-utils/src/lib.rs
+++ b/crates/datasource-utils/src/lib.rs
@@ -5,4 +5,4 @@
 
 pub mod http;
 
-pub use http::build_http_client;
+pub use http::{build_http_client, check_response_status};

--- a/crates/gaia/src/downloader.rs
+++ b/crates/gaia/src/downloader.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 
 use regex::Regex;
 use starfield::{Result, StarfieldError};
-use starfield_datasource_utils::build_http_client;
+use starfield_datasource_utils::{build_http_client, check_response_status};
 
 // Base URL for Gaia DR1 catalog
 const GAIA_DR1_BASE_URL: &str = "https://cdn.gea.esac.esa.int/Gaia/gdr1/gaia_source/csv/";
@@ -58,18 +58,13 @@ fn download_file<P: AsRef<Path>>(url: &str, path: P) -> Result<()> {
     println!("Downloading: {}", url);
 
     // Make the request
-    let mut response = client
-        .get(url)
-        .send()
-        .map_err(|e| StarfieldError::DataError(format!("Failed to download file: {}", e)))?;
-
-    // Check if the request was successful
-    if !response.status().is_success() {
-        return Err(StarfieldError::DataError(format!(
-            "Failed to download file, status: {}",
-            response.status()
-        )));
-    }
+    let mut response = check_response_status(
+        client
+            .get(url)
+            .send()
+            .map_err(|e| StarfieldError::DataError(format!("Failed to download file: {}", e)))?,
+        url,
+    )?;
 
     // Get file size for progress tracking
     let total_size = response.content_length().unwrap_or(0);
@@ -200,17 +195,13 @@ fn list_gaia_files() -> Result<Vec<String>> {
     let client = build_http_client(60)?;
 
     println!("Fetching Gaia catalog index...");
-    let response = client
-        .get(GAIA_DR1_BASE_URL)
-        .send()
-        .map_err(|e| StarfieldError::DataError(format!("Failed to fetch Gaia index: {}", e)))?;
-
-    if !response.status().is_success() {
-        return Err(StarfieldError::DataError(format!(
-            "Failed to fetch Gaia index, status: {}",
-            response.status()
-        )));
-    }
+    let response = check_response_status(
+        client
+            .get(GAIA_DR1_BASE_URL)
+            .send()
+            .map_err(|e| StarfieldError::DataError(format!("Failed to fetch Gaia index: {}", e)))?,
+        "Gaia catalog index",
+    )?;
 
     let html = response
         .text()

--- a/crates/hipparcos/src/downloader.rs
+++ b/crates/hipparcos/src/downloader.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 
 use starfield::Result;
 use starfield::StarfieldError;
-use starfield_datasource_utils::build_http_client;
+use starfield_datasource_utils::{build_http_client, check_response_status};
 
 use indicatif::{ProgressBar, ProgressStyle};
 
@@ -58,18 +58,13 @@ fn download_file<P: AsRef<Path>>(url: &str, path: P) -> Result<()> {
     let client = build_http_client(30)?;
 
     // Make the request
-    let mut response = client
-        .get(url)
-        .send()
-        .map_err(|e| StarfieldError::DataError(format!("Failed to download file: {}", e)))?;
-
-    // Check if the request was successful
-    if !response.status().is_success() {
-        return Err(StarfieldError::DataError(format!(
-            "Failed to download file, status: {}",
-            response.status()
-        )));
-    }
+    let mut response = check_response_status(
+        client
+            .get(url)
+            .send()
+            .map_err(|e| StarfieldError::DataError(format!("Failed to download file: {}", e)))?,
+        url,
+    )?;
 
     // Copy the response body to the file
     let mut buffer = [0; 8192];
@@ -187,18 +182,13 @@ pub fn download_file_with_progress<P: AsRef<Path>>(url: &str, path: P) -> Result
 
     let client = build_http_client(600)?;
 
-    let response = client
-        .get(url)
-        .send()
-        .map_err(|e| StarfieldError::DataError(format!("Failed to download {}: {}", url, e)))?;
-
-    if !response.status().is_success() {
-        return Err(StarfieldError::DataError(format!(
-            "Download failed for {}: HTTP {}",
-            url,
-            response.status()
-        )));
-    }
+    let response = check_response_status(
+        client
+            .get(url)
+            .send()
+            .map_err(|e| StarfieldError::DataError(format!("Failed to download {}: {}", url, e)))?,
+        url,
+    )?;
 
     let total_size = response.content_length().unwrap_or(0);
     let pb = if total_size > 0 {

--- a/crates/horizons/src/client.rs
+++ b/crates/horizons/src/client.rs
@@ -9,7 +9,7 @@
 use base64::Engine;
 use serde::Deserialize;
 use starfield::{Result, StarfieldError};
-use starfield_datasource_utils::build_http_client;
+use starfield_datasource_utils::{build_http_client, check_response_status};
 use starfield_jplephem::SpiceKernel;
 use std::collections::HashMap;
 use std::path::Path;
@@ -955,19 +955,16 @@ impl HorizonsClient {
     /// Execute an ephemeris query and return the raw response
     pub fn query(&self, request: &EphemerisRequest) -> Result<HorizonsResponse> {
         let params = request.to_query_params();
-        let response = self
-            .client
-            .get(HORIZONS_API_URL)
-            .query(&params)
-            .send()
-            .map_err(|e| StarfieldError::DataError(format!("HORIZONS request failed: {}", e)))?;
-
-        if !response.status().is_success() {
-            return Err(StarfieldError::DataError(format!(
-                "HORIZONS API returned HTTP {}",
-                response.status()
-            )));
-        }
+        let response = check_response_status(
+            self.client
+                .get(HORIZONS_API_URL)
+                .query(&params)
+                .send()
+                .map_err(|e| {
+                    StarfieldError::DataError(format!("HORIZONS request failed: {}", e))
+                })?,
+            "HORIZONS API",
+        )?;
 
         let body: HorizonsResponse = response.json().map_err(|e| {
             StarfieldError::DataError(format!("Failed to parse HORIZONS response: {}", e))
@@ -1001,21 +998,16 @@ impl HorizonsClient {
             .text("input", input_file)
             .text("format", "json");
 
-        let response = self
-            .client
-            .post(HORIZONS_FILE_API_URL)
-            .multipart(form)
-            .send()
-            .map_err(|e| {
-                StarfieldError::DataError(format!("HORIZONS file request failed: {}", e))
-            })?;
-
-        if !response.status().is_success() {
-            return Err(StarfieldError::DataError(format!(
-                "HORIZONS File API returned HTTP {}",
-                response.status()
-            )));
-        }
+        let response = check_response_status(
+            self.client
+                .post(HORIZONS_FILE_API_URL)
+                .multipart(form)
+                .send()
+                .map_err(|e| {
+                    StarfieldError::DataError(format!("HORIZONS file request failed: {}", e))
+                })?,
+            "HORIZONS File API",
+        )?;
 
         let body: HorizonsResponse = response.json().map_err(|e| {
             StarfieldError::DataError(format!("Failed to parse HORIZONS file response: {}", e))
@@ -1060,19 +1052,14 @@ impl HorizonsClient {
             params.insert("group", g.as_str().to_string());
         }
 
-        let response = self
-            .client
-            .get(HORIZONS_LOOKUP_URL)
-            .query(&params)
-            .send()
-            .map_err(|e| StarfieldError::DataError(format!("HORIZONS lookup failed: {}", e)))?;
-
-        if !response.status().is_success() {
-            return Err(StarfieldError::DataError(format!(
-                "HORIZONS lookup API returned HTTP {}",
-                response.status()
-            )));
-        }
+        let response = check_response_status(
+            self.client
+                .get(HORIZONS_LOOKUP_URL)
+                .query(&params)
+                .send()
+                .map_err(|e| StarfieldError::DataError(format!("HORIZONS lookup failed: {}", e)))?,
+            "HORIZONS lookup API",
+        )?;
 
         let body: LookupResponse = response.json().map_err(|e| {
             StarfieldError::DataError(format!("Failed to parse lookup response: {}", e))

--- a/crates/mpc/src/client.rs
+++ b/crates/mpc/src/client.rs
@@ -6,7 +6,7 @@ use std::io::Read;
 use std::time::{Duration, Instant};
 
 use starfield::{Result, StarfieldError};
-use starfield_datasource_utils::build_http_client;
+use starfield_datasource_utils::{build_http_client, check_response_status};
 
 use crate::mpcorb::{parse_mpcorb, MpcOrbRecord};
 use crate::observatory::{parse_observatory_codes, Observatory};
@@ -50,17 +50,12 @@ impl MpcClient {
         self.rate_limit();
         log::info!("Fetching {}", url);
 
-        let response = self.client.get(url).send().map_err(|e| {
-            StarfieldError::DataError(format!("MPC request failed for {}: {}", url, e))
-        })?;
-
-        if !response.status().is_success() {
-            return Err(StarfieldError::DataError(format!(
-                "MPC returned HTTP {} for {}",
-                response.status(),
-                url
-            )));
-        }
+        let response = check_response_status(
+            self.client.get(url).send().map_err(|e| {
+                StarfieldError::DataError(format!("MPC request failed for {}: {}", url, e))
+            })?,
+            url,
+        )?;
 
         response
             .text()
@@ -72,17 +67,12 @@ impl MpcClient {
         self.rate_limit();
         log::info!("Fetching {} (bytes)", url);
 
-        let mut response = self.client.get(url).send().map_err(|e| {
-            StarfieldError::DataError(format!("MPC request failed for {}: {}", url, e))
-        })?;
-
-        if !response.status().is_success() {
-            return Err(StarfieldError::DataError(format!(
-                "MPC returned HTTP {} for {}",
-                response.status(),
-                url
-            )));
-        }
+        let mut response = check_response_status(
+            self.client.get(url).send().map_err(|e| {
+                StarfieldError::DataError(format!("MPC request failed for {}: {}", url, e))
+            })?,
+            url,
+        )?;
 
         let mut bytes = Vec::new();
         response.read_to_end(&mut bytes).map_err(|e| {

--- a/crates/sbdb/src/client.rs
+++ b/crates/sbdb/src/client.rs
@@ -9,7 +9,7 @@
 use crate::types::*;
 use serde_json::Value;
 use starfield::{Result, StarfieldError};
-use starfield_datasource_utils::build_http_client;
+use starfield_datasource_utils::{build_http_client, check_response_status};
 use std::collections::HashMap;
 
 const SBDB_API_URL: &str = "https://ssd-api.jpl.nasa.gov/sbdb.api";
@@ -234,19 +234,13 @@ impl SbdbClient {
             .send()
             .map_err(|e| StarfieldError::DataError(format!("SBDB request failed: {}", e)))?;
 
-        let status = response.status();
-        if status.as_u16() == 300 {
+        if response.status().as_u16() == 300 {
             return Err(StarfieldError::DataError(
                 "Ambiguous search: multiple objects matched. Try a more specific query."
                     .to_string(),
             ));
         }
-        if !status.is_success() {
-            return Err(StarfieldError::DataError(format!(
-                "SBDB API returned HTTP {}",
-                status
-            )));
-        }
+        let response = check_response_status(response, "SBDB API")?;
 
         response.json::<Value>().map_err(|e| {
             StarfieldError::DataError(format!("Failed to parse SBDB JSON response: {}", e))


### PR DESCRIPTION
## Summary
- Adds `check_response_status(response, context)` to `starfield-datasource-utils`
- Replaces 9 duplicated status-check-and-error blocks across gaia, hipparcos, horizons, mpc, and sbdb
- SBDB retains its custom HTTP 300 handling before the shared check

## Test plan
- [x] `cargo check` passes with no warnings
- [x] `cargo test --workspace` all tests pass