### PR TITLE
Extract cache directory and file-existence helpers

### DIFF
--- a/crates/datasource-utils/Cargo.toml
+++ b/crates/datasource-utils/Cargo.toml
@@ -9,3 +9,6 @@ repository.workspace = true
 [dependencies]
 starfield = { workspace = true }
 reqwest = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3.26.0"

--- a/crates/datasource-utils/src/cache.rs
+++ b/crates/datasource-utils/src/cache.rs
@@ -1,0 +1,67 @@
+//! Shared cache directory and file-existence helpers
+
+use std::env;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// Return the base starfield cache directory (`~/.cache/starfield`).
+pub fn cache_dir() -> PathBuf {
+    let home = env::var("HOME").unwrap_or_else(|_| ".".to_string());
+    PathBuf::from(home).join(".cache").join("starfield")
+}
+
+/// Return a cache subdirectory (e.g. `~/.cache/starfield/gaia`),
+/// creating it if it does not exist.
+pub fn ensure_cache_subdir(subdir: &str) -> io::Result<PathBuf> {
+    let dir = cache_dir().join(subdir);
+    fs::create_dir_all(&dir)?;
+    Ok(dir)
+}
+
+/// Ensure the base cache directory exists and return its path.
+pub fn ensure_cache_dir() -> io::Result<PathBuf> {
+    let dir = cache_dir();
+    fs::create_dir_all(&dir)?;
+    Ok(dir)
+}
+
+/// Check if a file exists and is not empty.
+pub fn file_exists_and_not_empty<P: AsRef<Path>>(path: P) -> bool {
+    match fs::metadata(path) {
+        Ok(metadata) => metadata.is_file() && metadata.len() > 0,
+        Err(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cache_dir_contains_starfield() {
+        let dir = cache_dir();
+        assert!(dir.to_str().unwrap().contains(".cache/starfield"));
+    }
+
+    #[test]
+    fn test_file_exists_nonexistent() {
+        assert!(!file_exists_and_not_empty("/nonexistent/path/xyz"));
+    }
+
+    #[test]
+    fn test_file_exists_real_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.txt");
+        std::fs::write(&path, b"data").unwrap();
+        assert!(file_exists_and_not_empty(&path));
+    }
+
+    #[test]
+    fn test_file_exists_empty_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("empty.txt");
+        std::fs::write(&path, b"").unwrap();
+        assert!(!file_exists_and_not_empty(&path));
+    }
+}

--- a/crates/datasource-utils/src/lib.rs
+++ b/crates/datasource-utils/src/lib.rs
@@ -3,6 +3,8 @@
 //! Common helpers for HTTP clients, file caching, and downloads
 //! used across multiple datasource implementations.
 
+pub mod cache;
 pub mod http;
 
+pub use cache::{cache_dir, ensure_cache_dir, ensure_cache_subdir, file_exists_and_not_empty};
 pub use http::{build_http_client, check_response_status};

--- a/crates/gaia/src/downloader.rs
+++ b/crates/gaia/src/downloader.rs
@@ -3,15 +3,15 @@
 //! This module provides functionality for downloading and caching Gaia catalog files.
 
 use std::collections::HashMap;
-use std::env;
 use std::fs::{self, File};
 use std::io::{self, BufRead, BufReader, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
-// No need for sync primitives yet
 
 use regex::Regex;
 use starfield::{Result, StarfieldError};
-use starfield_datasource_utils::{build_http_client, check_response_status};
+use starfield_datasource_utils::{
+    build_http_client, check_response_status, ensure_cache_subdir, file_exists_and_not_empty,
+};
 
 // Base URL for Gaia DR1 catalog
 const GAIA_DR1_BASE_URL: &str = "https://cdn.gea.esac.esa.int/Gaia/gdr1/gaia_source/csv/";
@@ -20,26 +20,12 @@ const GAIA_MD5SUMS_URL: &str = "https://cdn.gea.esac.esa.int/Gaia/gdr1/gaia_sour
 
 /// Get the Gaia cache directory path
 pub fn get_gaia_cache_dir() -> PathBuf {
-    let home = env::var("HOME").unwrap_or_else(|_| ".".to_string());
-    PathBuf::from(home)
-        .join(".cache")
-        .join("starfield")
-        .join("gaia")
+    starfield_datasource_utils::cache_dir().join("gaia")
 }
 
 /// Ensure that the Gaia cache directory exists
 pub fn ensure_gaia_cache_dir() -> io::Result<PathBuf> {
-    let cache_dir = get_gaia_cache_dir();
-    fs::create_dir_all(&cache_dir)?;
-    Ok(cache_dir)
-}
-
-/// Check if a file exists and is not empty
-fn file_exists_and_not_empty<P: AsRef<Path>>(path: P) -> bool {
-    match fs::metadata(path) {
-        Ok(metadata) => metadata.is_file() && metadata.len() > 0,
-        Err(_) => false,
-    }
+    ensure_cache_subdir("gaia")
 }
 
 /// Download a file from URL to a local path

--- a/crates/hipparcos/src/downloader.rs
+++ b/crates/hipparcos/src/downloader.rs
@@ -2,14 +2,15 @@
 //!
 //! This module handles downloading and caching of astronomical data files.
 
-use std::env;
 use std::fs::{self, File};
 use std::io::{self, BufReader, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
 
 use starfield::Result;
 use starfield::StarfieldError;
-use starfield_datasource_utils::{build_http_client, check_response_status};
+use starfield_datasource_utils::{
+    build_http_client, check_response_status, ensure_cache_dir, file_exists_and_not_empty,
+};
 
 use indicatif::{ProgressBar, ProgressStyle};
 
@@ -25,23 +26,7 @@ const NAIF_SATELLITES_URL: &str =
 
 /// Get the cache directory path
 pub fn get_cache_dir() -> PathBuf {
-    let home = env::var("HOME").unwrap_or_else(|_| ".".to_string());
-    PathBuf::from(home).join(".cache").join("starfield")
-}
-
-/// Ensure that the cache directory exists
-pub fn ensure_cache_dir() -> io::Result<PathBuf> {
-    let cache_dir = get_cache_dir();
-    fs::create_dir_all(&cache_dir)?;
-    Ok(cache_dir)
-}
-
-/// Check if a file exists and is not empty
-pub(crate) fn file_exists_and_not_empty<P: AsRef<Path>>(path: P) -> bool {
-    match fs::metadata(path) {
-        Ok(metadata) => metadata.is_file() && metadata.len() > 0,
-        Err(_) => false,
-    }
+    starfield_datasource_utils::cache_dir()
 }
 
 /// Download a file from URL to a local path


### PR DESCRIPTION
## Summary
- Adds `cache` module to `starfield-datasource-utils` with `cache_dir()`, `ensure_cache_dir()`, `ensure_cache_subdir()`, and `file_exists_and_not_empty()`
- Removes duplicated implementations from hipparcos and gaia crates
- Thin wrappers (`get_cache_dir`, `get_gaia_cache_dir`) preserved for public API stability
- 4 new unit tests for file-existence edge cases

## Test plan
- [x] `cargo check --workspace` passes with no warnings
- [x] `cargo test --workspace` all tests pass