### PR TITLE
Extract unified download utility with progress bar

### DIFF
--- a/crates/datasource-utils/Cargo.toml
+++ b/crates/datasource-utils/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 [dependencies]
 starfield = { workspace = true }
 reqwest = { workspace = true }
+indicatif.workspace = true
 
 [dev-dependencies]
 tempfile = "3.26.0"

--- a/crates/datasource-utils/src/download.rs
+++ b/crates/datasource-utils/src/download.rs
@@ -1,0 +1,84 @@
+//! Shared file download utilities
+//!
+//! Provides atomic download-to-file with optional progress bar display.
+
+use std::fs::{self, File};
+use std::io::{BufWriter, Read, Write};
+use std::path::Path;
+
+use indicatif::{ProgressBar, ProgressStyle};
+use starfield::{Result, StarfieldError};
+
+use crate::{build_http_client, check_response_status};
+
+/// Download `url` to `path` atomically (via a `.tmp` intermediate file).
+///
+/// Creates parent directories as needed. Shows an `indicatif` progress bar
+/// when the server provides a `Content-Length` header.
+///
+/// `timeout_secs` controls the HTTP client read timeout.
+pub fn download_to_file<P: AsRef<Path>>(url: &str, path: P, timeout_secs: u64) -> Result<()> {
+    if let Some(parent) = path.as_ref().parent() {
+        fs::create_dir_all(parent).map_err(StarfieldError::IoError)?;
+    }
+
+    let temp_path = path.as_ref().with_extension("tmp");
+    let mut file = BufWriter::new(File::create(&temp_path).map_err(StarfieldError::IoError)?);
+
+    let client = build_http_client(timeout_secs)?;
+
+    let response = check_response_status(
+        client
+            .get(url)
+            .send()
+            .map_err(|e| StarfieldError::DataError(format!("Failed to download {}: {}", url, e)))?,
+        url,
+    )?;
+
+    let total_size = response.content_length().unwrap_or(0);
+    let pb = if total_size > 0 {
+        let pb = ProgressBar::new(total_size);
+        pb.set_style(
+            ProgressStyle::default_bar()
+                .template("[{bar:40}] {percent}% {bytes}/{total_bytes} ({bytes_per_sec})")
+                .unwrap()
+                .progress_chars("##-"),
+        );
+        Some(pb)
+    } else {
+        None
+    };
+
+    let mut reader = std::io::BufReader::new(response);
+    let mut downloaded: u64 = 0;
+    let mut buffer = [0u8; 131_072]; // 128KB chunks
+
+    loop {
+        let n = reader
+            .read(&mut buffer)
+            .map_err(|e| StarfieldError::DataError(format!("Failed to read response: {}", e)))?;
+
+        if n == 0 {
+            break;
+        }
+
+        file.write_all(&buffer[..n])
+            .map_err(StarfieldError::IoError)?;
+
+        downloaded += n as u64;
+        if let Some(ref pb) = pb {
+            pb.set_position(downloaded);
+        }
+    }
+
+    if let Some(ref pb) = pb {
+        pb.finish_and_clear();
+    }
+
+    file.flush().map_err(StarfieldError::IoError)?;
+    drop(file);
+
+    fs::rename(temp_path, path).map_err(StarfieldError::IoError)?;
+
+    Ok(())
+}

--- a/crates/datasource-utils/src/lib.rs
+++ b/crates/datasource-utils/src/lib.rs
@@ -4,7 +4,9 @@
 //! used across multiple datasource implementations.
 
 pub mod cache;
+pub mod download;
 pub mod http;
 
 pub use cache::{cache_dir, ensure_cache_dir, ensure_cache_subdir, file_exists_and_not_empty};
+pub use download::download_to_file;
 pub use http::{build_http_client, check_response_status};

--- a/crates/gaia/Cargo.toml
+++ b/crates/gaia/Cargo.toml
@@ -8,7 +8,6 @@ repository.workspace = true
 
 [dependencies]
 starfield = { workspace = true }
-reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/gaia/src/downloader.rs
+++ b/crates/gaia/src/downloader.rs
@@ -4,13 +4,14 @@
 
 use std::collections::HashMap;
 use std::fs::{self, File};
-use std::io::{self, BufRead, BufReader, BufWriter, Read, Write};
+use std::io::{self, BufRead, BufReader, Read};
 use std::path::{Path, PathBuf};
 
 use regex::Regex;
 use starfield::{Result, StarfieldError};
 use starfield_datasource_utils::{
-    build_http_client, check_response_status, ensure_cache_subdir, file_exists_and_not_empty,
+    build_http_client, check_response_status, download_to_file, ensure_cache_subdir,
+    file_exists_and_not_empty,
 };
 
 // Base URL for Gaia DR1 catalog
@@ -26,107 +27,6 @@ pub fn get_gaia_cache_dir() -> PathBuf {
 /// Ensure that the Gaia cache directory exists
 pub fn ensure_gaia_cache_dir() -> io::Result<PathBuf> {
     ensure_cache_subdir("gaia")
-}
-
-/// Download a file from URL to a local path
-fn download_file<P: AsRef<Path>>(url: &str, path: P) -> Result<()> {
-    // Create parent directories if they don't exist
-    if let Some(parent) = path.as_ref().parent() {
-        fs::create_dir_all(parent).map_err(StarfieldError::IoError)?;
-    }
-
-    // Create a temporary file first to avoid partial downloads
-    let temp_path = path.as_ref().with_extension("tmp");
-    let mut file = BufWriter::new(File::create(&temp_path).map_err(StarfieldError::IoError)?);
-
-    let client = build_http_client(600)?;
-
-    println!("Downloading: {}", url);
-
-    // Make the request
-    let mut response = check_response_status(
-        client
-            .get(url)
-            .send()
-            .map_err(|e| StarfieldError::DataError(format!("Failed to download file: {}", e)))?,
-        url,
-    )?;
-
-    // Get file size for progress tracking
-    let total_size = response.content_length().unwrap_or(0);
-    let mut downloaded: u64 = 0;
-    let start_time = std::time::Instant::now();
-
-    // Copy the response body to the file with progress reporting
-    let mut buffer = [0; 8192];
-
-    loop {
-        match response.read(&mut buffer) {
-            Ok(0) => break, // EOF
-            Ok(n) => {
-                file.write_all(&buffer[..n])
-                    .map_err(StarfieldError::IoError)?;
-                downloaded += n as u64;
-
-                // Print progress every 5MB
-                if downloaded.is_multiple_of(5 * 1024 * 1024) {
-                    let elapsed = start_time.elapsed().as_secs_f64();
-                    let speed = if elapsed > 0.0 {
-                        downloaded as f64 / elapsed / 1024.0 / 1024.0
-                    } else {
-                        0.0
-                    };
-
-                    if total_size > 0 {
-                        let percentage = (downloaded as f64 / total_size as f64) * 100.0;
-                        print!(
-                            "\rDownloaded: {:.1}% ({:.1}MB/{:.1}MB) at {:.1} MB/s",
-                            percentage,
-                            downloaded as f64 / 1024.0 / 1024.0,
-                            total_size as f64 / 1024.0 / 1024.0,
-                            speed
-                        );
-                    } else {
-                        print!(
-                            "\rDownloaded: {:.1}MB at {:.1} MB/s",
-                            downloaded as f64 / 1024.0 / 1024.0,
-                            speed
-                        );
-                    }
-                    io::stdout().flush().unwrap();
-                }
-            }
-            Err(e) => {
-                return Err(StarfieldError::DataError(format!(
-                    "Error downloading file: {}",
-                    e
-                )))
-            }
-        }
-    }
-
-    // Final progress update
-    let elapsed = start_time.elapsed().as_secs_f64();
-    let speed = if elapsed > 0.0 {
-        downloaded as f64 / elapsed / 1024.0 / 1024.0
-    } else {
-        0.0
-    };
-    println!(
-        "\rDownload complete: {:.1}MB at {:.1} MB/s in {:.1}s",
-        downloaded as f64 / 1024.0 / 1024.0,
-        speed,
-        elapsed
-    );
-
-    // Flush and sync the file
-    file.flush().map_err(StarfieldError::IoError)?;
-    drop(file);
-
-    // Rename the temporary file to the final path
-    fs::rename(temp_path, path).map_err(StarfieldError::IoError)?;
-
-    Ok(())
 }
 
 /// Calculate MD5 checksum of a file
@@ -154,7 +54,7 @@ fn download_md5sums() -> Result<HashMap<String, String>> {
 
     // Download MD5SUMS file if it doesn't exist or is empty
     if !file_exists_and_not_empty(&md5sums_path) {
-        download_file(GAIA_MD5SUMS_URL, &md5sums_path)?;
+        download_to_file(GAIA_MD5SUMS_URL, &md5sums_path, 600)?;
     }
 
     // Parse MD5SUMS file
@@ -284,7 +184,7 @@ pub fn download_gaia_file(filename: &str) -> Result<PathBuf> {
     // Download the gzipped file if it doesn't exist
     if !file_exists_and_not_empty(&gz_path) {
         let file_url = format!("{}{}", GAIA_DR1_BASE_URL, filename);
-        download_file(&file_url, &gz_path)?;
+        download_to_file(&file_url, &gz_path, 600)?;
     }
 
     // Verify the file

--- a/crates/hipparcos/Cargo.toml
+++ b/crates/hipparcos/Cargo.toml
@@ -8,10 +8,8 @@ repository.workspace = true
 
 [dependencies]
 starfield = { workspace = true }
-reqwest = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
-indicatif = { workspace = true }
 rand = { workspace = true }
 nalgebra = { workspace = true }
 flate2.workspace = true

--- a/crates/hipparcos/src/downloader.rs
+++ b/crates/hipparcos/src/downloader.rs
@@ -8,11 +8,7 @@ use std::path::{Path, PathBuf};
 
 use starfield::Result;
 use starfield::StarfieldError;
-use starfield_datasource_utils::{
-    build_http_client, check_response_status, ensure_cache_dir, file_exists_and_not_empty,
-};
-
-use indicatif::{ProgressBar, ProgressStyle};
+use starfield_datasource_utils::{download_to_file, ensure_cache_dir, file_exists_and_not_empty};
 
 // Hipparcos catalog URL
 const HIPPARCOS_URL: &str = "https://cdsarc.cds.unistra.fr/ftp/cats/I/239/hip_main.dat";
@@ -29,52 +25,6 @@ pub fn get_cache_dir() -> PathBuf {
     starfield_datasource_utils::cache_dir()
 }
 
-/// Download a file from URL to a local path
-fn download_file<P: AsRef<Path>>(url: &str, path: P) -> Result<()> {
-    // Create parent directories if they don't exist
-    if let Some(parent) = path.as_ref().parent() {
-        fs::create_dir_all(parent).map_err(StarfieldError::IoError)?;
-    }
-
-    // Create a temporary file first to avoid partial downloads
-    let temp_path = path.as_ref().with_extension("tmp");
-    let mut file = BufWriter::new(File::create(&temp_path).map_err(StarfieldError::IoError)?);
-
-    let client = build_http_client(30)?;
-
-    // Make the request
-    let mut response = check_response_status(
-        client
-            .get(url)
-            .send()
-            .map_err(|e| StarfieldError::DataError(format!("Failed to download file: {}", e)))?,
-        url,
-    )?;
-
-    // Copy the response body to the file
-    let mut buffer = [0; 8192];
-    loop {
-        let bytes_read = response
-            .read(&mut buffer)
-            .map_err(|e| StarfieldError::DataError(format!("Failed to read response: {}", e)))?;
-
-        if bytes_read == 0 {
-            break;
-        }
-
-        file.write_all(&buffer[..bytes_read])
-            .map_err(StarfieldError::IoError)?;
-    }
-
-    // Flush and sync the file
-    file.flush().map_err(StarfieldError::IoError)?;
-    drop(file);
-
-    // Rename the temporary file to the final path
-    fs::rename(temp_path, path).map_err(StarfieldError::IoError)?;
-
-    Ok(())
-}
 
 /// Decompress a gzipped file
 /// Currently unused as we're using synthetic data, but kept for future reference
@@ -153,75 +103,6 @@ pub fn resolve_url(filename: &str) -> Option<String> {
     None
 }
 
-/// Download a file from URL to a local path, showing a progress bar.
-///
-/// Uses a longer timeout (600s) suitable for large ephemeris files.
-/// Downloads to a temporary file first, then atomically renames.
-pub fn download_file_with_progress<P: AsRef<Path>>(url: &str, path: P) -> Result<()> {
-    if let Some(parent) = path.as_ref().parent() {
-        fs::create_dir_all(parent).map_err(StarfieldError::IoError)?;
-    }
-
-    let temp_path = path.as_ref().with_extension("tmp");
-    let mut file = BufWriter::new(File::create(&temp_path).map_err(StarfieldError::IoError)?);
-
-    let client = build_http_client(600)?;
-
-    let response = check_response_status(
-        client
-            .get(url)
-            .send()
-            .map_err(|e| StarfieldError::DataError(format!("Failed to download {}: {}", url, e)))?,
-        url,
-    )?;
-
-    let total_size = response.content_length().unwrap_or(0);
-    let pb = if total_size > 0 {
-        let pb = ProgressBar::new(total_size);
-        pb.set_style(
-            ProgressStyle::default_bar()
-                .template("[{bar:40}] {percent}% {bytes}/{total_bytes} ({bytes_per_sec})")
-                .unwrap()
-                .progress_chars("##-"),
-        );
-        Some(pb)
-    } else {
-        None
-    };
-
-    let mut reader = io::BufReader::new(response);
-    let mut downloaded: u64 = 0;
-    let mut buffer = [0u8; 131_072]; // 128KB chunks
-
-    loop {
-        let bytes_read = reader
-            .read(&mut buffer)
-            .map_err(|e| StarfieldError::DataError(format!("Failed to read response: {}", e)))?;
-
-        if bytes_read == 0 {
-            break;
-        }
-
-        file.write_all(&buffer[..bytes_read])
-            .map_err(StarfieldError::IoError)?;
-
-        downloaded += bytes_read as u64;
-        if let Some(ref pb) = pb {
-            pb.set_position(downloaded);
-        }
-    }
-
-    if let Some(ref pb) = pb {
-        pb.finish_and_clear();
-    }
-
-    file.flush().map_err(StarfieldError::IoError)?;
-    drop(file);
-
-    fs::rename(temp_path, path).map_err(StarfieldError::IoError)?;
-
-    Ok(())
-}
 
 /// Ensure a data file is available locally, downloading it if necessary.
 ///
@@ -251,7 +132,7 @@ pub fn download_or_cache(filename: &str, data_dir: Option<&Path>) -> Result<Path
     })?;
 
     eprintln!("Downloading {} ...", url);
-    download_file_with_progress(&url, &local_path)?;
+    download_to_file(&url, &local_path, 600)?;
     eprintln!("Saved to {}", local_path.display());
 
     Ok(local_path)
@@ -289,7 +170,7 @@ pub fn download_hipparcos() -> Result<PathBuf> {
     println!("This may take a moment as the catalog is approximately 36MB");
 
     // Attempt to download the file
-    match download_file(HIPPARCOS_URL, &dat_path) {
+    match download_to_file(HIPPARCOS_URL, &dat_path, 30) {
         Ok(_) => {
             println!(
                 "Hipparcos catalog downloaded successfully to {}",
@@ -310,6 +191,7 @@ pub fn download_hipparcos() -> Result<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use starfield_datasource_utils::build_http_client;
 
     #[test]
     fn test_cache_dir() {


### PR DESCRIPTION
## Summary
- Adds `download_to_file(url, path, timeout_secs)` to `starfield-datasource-utils` with indicatif progress bar, atomic temp-file rename, and parent directory creation
- Replaces 3 separate download implementations: hipparcos `download_file` (30s timeout, no progress), hipparcos `download_file_with_progress` (600s, indicatif), and gaia `download_file` (600s, manual print progress)
- Removes direct `reqwest` and `indicatif` dependencies from hipparcos and gaia crates (now transitive via utils)
- Net deletion of ~134 lines

## Test plan
- [x] `cargo check --workspace` passes with no warnings
- [x] `cargo test --workspace` all tests pass