### PR TITLE
Extract shared endpoint reachability test helper

### DIFF
--- a/crates/datasource-utils/src/http.rs
+++ b/crates/datasource-utils/src/http.rs
@@ -31,6 +31,32 @@ pub fn check_response_status(
     )))
 }
 
+/// Assert that an HTTP endpoint responds to a HEAD request.
+///
+/// Accepts 2xx or 405 (Method Not Allowed — means the server is up but
+/// rejects HEAD). Panics with a descriptive message on connection failure
+/// or unexpected status codes.
+///
+/// Intended for `#[ignore]` integration tests that verify upstream URLs.
+pub fn assert_endpoint_reachable(url: &str) {
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(15))
+        .build()
+        .expect("Failed to build HTTP client");
+
+    let resp = client
+        .head(url)
+        .send()
+        .unwrap_or_else(|e| panic!("HEAD request failed for {}: {}", url, e));
+
+    assert!(
+        resp.status().is_success() || resp.status().as_u16() == 405,
+        "Endpoint {} returned HTTP {}",
+        url,
+        resp.status()
+    );
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/datasource-utils/src/lib.rs
+++ b/crates/datasource-utils/src/lib.rs
@@ -9,4 +9,4 @@ pub mod http;
 
 pub use cache::{cache_dir, ensure_cache_dir, ensure_cache_subdir, file_exists_and_not_empty};
 pub use download::download_to_file;
-pub use http::{build_http_client, check_response_status};
+pub use http::{assert_endpoint_reachable, build_http_client, check_response_status};

--- a/crates/hipparcos/src/downloader.rs
+++ b/crates/hipparcos/src/downloader.rs
@@ -25,7 +25,6 @@ pub fn get_cache_dir() -> PathBuf {
     starfield_datasource_utils::cache_dir()
 }
 
-
 /// Decompress a gzipped file
 /// Currently unused as we're using synthetic data, but kept for future reference
 #[allow(dead_code)]
@@ -102,7 +101,6 @@ pub fn resolve_url(filename: &str) -> Option<String> {
 
     None
 }
-
 
 /// Ensure a data file is available locally, downloading it if necessary.
 ///
@@ -191,7 +189,7 @@ pub fn download_hipparcos() -> Result<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use starfield_datasource_utils::build_http_client;
+    use starfield_datasource_utils::assert_endpoint_reachable;
 
     #[test]
     fn test_cache_dir() {
@@ -261,21 +259,9 @@ mod tests {
             "jup365.bsp",
         ];
 
-        let client = build_http_client(15).expect("Failed to build HTTP client");
-
         for filename in filenames {
             let url = resolve_url(filename).expect("resolve_url returned None");
-            let response = client
-                .head(&url)
-                .send()
-                .unwrap_or_else(|e| panic!("HEAD request failed for {}: {}", url, e));
-
-            assert!(
-                response.status().is_success(),
-                "Endpoint {} returned HTTP {}",
-                url,
-                response.status()
-            );
+            assert_endpoint_reachable(&url);
         }
     }
 }

--- a/crates/horizons/src/client.rs
+++ b/crates/horizons/src/client.rs
@@ -1146,6 +1146,7 @@ fn extract_error_message(result: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use starfield_datasource_utils::assert_endpoint_reachable;
 
     #[test]
     fn test_command_major_body() {
@@ -1633,23 +1634,13 @@ mod tests {
     #[test]
     #[ignore]
     fn test_horizons_api_reachable() {
-        let client = reqwest::blocking::Client::new();
-        let resp = client
-            .head(HORIZONS_API_URL)
-            .send()
-            .expect("HORIZONS API unreachable");
-        assert!(resp.status().is_success() || resp.status().as_u16() == 405);
+        assert_endpoint_reachable(HORIZONS_API_URL);
     }
 
     #[test]
     #[ignore]
     fn test_lookup_api_reachable() {
-        let client = reqwest::blocking::Client::new();
-        let resp = client
-            .head(HORIZONS_LOOKUP_URL)
-            .send()
-            .expect("HORIZONS lookup API unreachable");
-        assert!(resp.status().is_success() || resp.status().as_u16() == 405);
+        assert_endpoint_reachable(HORIZONS_LOOKUP_URL);
     }
 
     #[test]

--- a/crates/sbdb/src/client.rs
+++ b/crates/sbdb/src/client.rs
@@ -1489,6 +1489,7 @@ fn parse_count(json: &Value) -> u32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use starfield_datasource_utils::assert_endpoint_reachable;
 
     #[test]
     fn test_cad_params_default() {
@@ -1939,23 +1940,13 @@ mod tests {
     #[test]
     #[ignore]
     fn test_sbdb_api_reachable() {
-        let client = reqwest::blocking::Client::new();
-        let resp = client
-            .head(SBDB_API_URL)
-            .send()
-            .expect("SBDB API unreachable");
-        assert!(resp.status().is_success() || resp.status().as_u16() == 405);
+        assert_endpoint_reachable(SBDB_API_URL);
     }
 
     #[test]
     #[ignore]
     fn test_cad_api_reachable() {
-        let client = reqwest::blocking::Client::new();
-        let resp = client
-            .head(CAD_API_URL)
-            .send()
-            .expect("CAD API unreachable");
-        assert!(resp.status().is_success() || resp.status().as_u16() == 405);
+        assert_endpoint_reachable(CAD_API_URL);
     }
 
     #[test]
@@ -2097,12 +2088,7 @@ mod tests {
     #[test]
     #[ignore]
     fn test_mdesign_api_reachable() {
-        let client = reqwest::blocking::Client::new();
-        let resp = client
-            .head(MDESIGN_API_URL)
-            .send()
-            .expect("Mission Design API unreachable");
-        assert!(resp.status().is_success() || resp.status().as_u16() == 405);
+        assert_endpoint_reachable(MDESIGN_API_URL);
     }
 
     #[test]
@@ -2210,12 +2196,7 @@ mod tests {
     #[test]
     #[ignore]
     fn test_radar_api_reachable() {
-        let client = reqwest::blocking::Client::new();
-        let resp = client
-            .head(RADAR_API_URL)
-            .send()
-            .expect("Radar API unreachable");
-        assert!(resp.status().is_success() || resp.status().as_u16() == 405);
+        assert_endpoint_reachable(RADAR_API_URL);
     }
 
     #[test]
@@ -2366,12 +2347,7 @@ mod tests {
     #[test]
     #[ignore]
     fn test_sb_ident_api_reachable() {
-        let client = reqwest::blocking::Client::new();
-        let resp = client
-            .head(SB_IDENT_API_URL)
-            .send()
-            .expect("SB Ident API unreachable");
-        assert!(resp.status().is_success() || resp.status().as_u16() == 405);
+        assert_endpoint_reachable(SB_IDENT_API_URL);
     }
 
     #[test]
@@ -2501,12 +2477,7 @@ mod tests {
     #[test]
     #[ignore]
     fn test_sbwobs_api_reachable() {
-        let client = reqwest::blocking::Client::new();
-        let resp = client
-            .head(SBWOBS_API_URL)
-            .send()
-            .expect("SBWOBS API unreachable");
-        assert!(resp.status().is_success() || resp.status().as_u16() == 405);
+        assert_endpoint_reachable(SBWOBS_API_URL);
     }
 
     #[test]
@@ -2645,12 +2616,7 @@ mod tests {
     #[test]
     #[ignore]
     fn test_nhats_api_reachable() {
-        let client = reqwest::blocking::Client::new();
-        let resp = client
-            .head(NHATS_API_URL)
-            .send()
-            .expect("NHATS API unreachable");
-        assert!(resp.status().is_success() || resp.status().as_u16() == 405);
+        assert_endpoint_reachable(NHATS_API_URL);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds `assert_endpoint_reachable(url)` to `starfield-datasource-utils` — sends a HEAD request with 15s timeout, accepts 2xx or 405 (Method Not Allowed)
- Replaces 10 duplicated reachability test patterns across sbdb (7), horizons (2), and hipparcos (1)
- Each test body reduced from 5-7 lines to a single function call

## Test plan
- [x] `cargo check --workspace` passes with no warnings
- [x] `cargo test --workspace` all tests pass