### PR TITLE
Add data source reference documentation

### DIFF
--- a/docs/data-sources/de-ephemeris.md
+++ b/docs/data-sources/de-ephemeris.md
@@ -1,0 +1,662 @@
+# JPL Development Ephemeris (DE-Series) Reference
+
+## 1. Overview
+
+The JPL Development Ephemeris (DE) series are the definitive high-precision
+planetary and lunar ephemerides produced by the Jet Propulsion Laboratory's
+Solar System Dynamics group. Each DE release provides the positions and
+velocities of the Sun, Moon, planets, and selected other bodies over a span of
+time, computed by numerically integrating the equations of motion for the solar
+system.
+
+DE ephemerides are the standard reference for planetary positions used
+worldwide by spacecraft navigators, observatory software, almanac offices, and
+open-source astronomy libraries alike. They are published as SPK (Spacecraft
+and Planet Kernel) binary files in the NAIF Double Array File (DAF) container
+format, conventionally distributed with the `.bsp` extension.
+
+### Historical Progression
+
+| Ephemeris | Year | Notes |
+|-----------|------|-------|
+| DE102 | 1981 | First widely distributed DE; Voyager-era |
+| DE200 | 1982 | Standard for The Astronomical Almanac 1984--2003 |
+| DE405 | 1997 | ICRF-aligned; dominant ephemeris for a decade |
+| DE421 | 2008 | Fit to Mars and lunar laser ranging data |
+| DE430 | 2013 | Improved spacecraft tracking fits (MESSENGER, Cassini) |
+| DE440 | 2021 | Current recommended general-purpose ephemeris |
+| DE441 | 2021 | Extended-range companion to DE440 (13200 BC -- AD 17191) |
+
+Each successive release incorporates additional observational data (spacecraft
+tracking, radar ranging, lunar laser ranging, VLBI) and improved dynamical
+models (asteroid perturbation ring, solar oblateness, general relativity
+parameters).
+
+---
+
+## 2. Available Ephemeris Files
+
+### DE421 (2008)
+
+| Property | Value |
+|----------|-------|
+| Coverage | 1899 Dec 14 -- 2053 Oct 8 |
+| File size | ~17 MB |
+| Bodies | Mercury--Pluto barycenters, Sun, Moon, Earth |
+| Data type | SPK Type 2 (Chebyshev position) |
+| Fit data | Mars ranging, LLR, planetary radar |
+
+DE421 is the best choice for quick calculations, prototyping, and CI
+environments. It covers the period most users care about with modern accuracy,
+and its small size makes it fast to download and embed.
+
+**Download URLs:**
+
+- JPL SSD: `https://ssd.jpl.nasa.gov/ftp/eph/planets/bsp/de421.bsp`
+- NAIF Generic Kernels: `https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/de421.bsp`
+
+### DE430 / DE430t (2013)
+
+| Property | Value |
+|----------|-------|
+| Coverage (DE430t) | 1549 Dec 20 -- 2650 Jan 25 |
+| File size | ~115 MB |
+| Bodies | Mercury--Pluto barycenters, Sun, Moon, Earth |
+| Data type | SPK Type 2 |
+| Fit data | DE421 data + MESSENGER, Cassini, Mars rovers, LLR |
+
+DE430 improved the fits to Mercury (MESSENGER tracking) and Saturn (Cassini
+tracking). The "t" variant (de430t.bsp) is the full-range truncated file
+commonly distributed by NAIF.
+
+**Download URLs:**
+
+- JPL SSD: `https://ssd.jpl.nasa.gov/ftp/eph/planets/bsp/de430t.bsp`
+- NAIF Generic Kernels: `https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/de430t.bsp`
+
+### DE440 (2021) -- Recommended
+
+| Property | Value |
+|----------|-------|
+| Coverage | 1549 Dec 20 -- 2650 Jan 25 |
+| File size | ~115 MB |
+| Bodies | Mercury--Pluto barycenters, Sun, Moon, Earth |
+| Data type | SPK Type 2 |
+| Fit data | All DE430 data + Juno, Cassini Grand Finale, MESSENGER extended mission |
+
+DE440 is the current recommended ephemeris for most applications. It
+incorporates the most extensive set of modern spacecraft tracking data and is
+the standard used by JPL for current mission navigation.
+
+**Download URLs:**
+
+- JPL SSD: `https://ssd.jpl.nasa.gov/ftp/eph/planets/bsp/de440.bsp`
+- NAIF Generic Kernels: `https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/de440.bsp`
+
+### DE440s (2021) -- Short Version
+
+| Property | Value |
+|----------|-------|
+| Coverage | 1849 Dec 26 -- 2150 Jan 22 |
+| File size | ~32 MB |
+| Bodies | Mercury--Pluto barycenters, Sun, Moon, Earth |
+| Data type | SPK Type 2 |
+
+DE440s contains the same polynomial coefficients as DE440, trimmed to a 300-year
+window. It is the best balance between accuracy and file size for applications
+that only need near-modern dates.
+
+**Download URLs:**
+
+- JPL SSD: `https://ssd.jpl.nasa.gov/ftp/eph/planets/bsp/de440s.bsp`
+- NAIF Generic Kernels: `https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/de440s.bsp`
+
+### DE441 (2021) -- Extended Range
+
+| Property | Value |
+|----------|-------|
+| Coverage | ~13200 BC -- AD 17191 |
+| File size | ~3.1 GB |
+| Bodies | Mercury--Pluto barycenters, Sun, Moon, Earth |
+| Data type | SPK Type 2 |
+
+DE441 is the extended-range companion to DE440. Within the DE440 time span
+it is identical to DE440. It is intended for paleoclimate research, historical
+eclipse verification, archaeoastronomy, and far-future mission planning. Its
+large size makes it impractical for most applications; prefer DE440 or DE440s
+unless you genuinely need dates outside their range.
+
+**Download URLs:**
+
+- JPL SSD: `https://ssd.jpl.nasa.gov/ftp/eph/planets/bsp/de441.bsp`
+- NAIF Generic Kernels: `https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/de441.bsp`
+
+### DE405 (1997) -- Legacy
+
+| Property | Value |
+|----------|-------|
+| Coverage | 1599 Dec 9 -- 2201 Feb 20 |
+| File size | ~55 MB |
+| Data type | SPK Type 2 |
+
+DE405 remains available for backward compatibility and reproducing published
+results that were computed against it. For new work, use DE440.
+
+**Download URLs:**
+
+- JPL SSD: `https://ssd.jpl.nasa.gov/ftp/eph/planets/bsp/de405.bsp`
+
+### Quick Selection Guide
+
+| Use case | Recommended file | Size |
+|----------|-----------------|------|
+| Getting started / CI / tests | `de421.bsp` | ~17 MB |
+| Production (modern dates) | `de440s.bsp` | ~32 MB |
+| Production (wide range) | `de440.bsp` | ~115 MB |
+| Ancient/far-future dates | `de441.bsp` | ~3.1 GB |
+| Legacy compatibility | `de405.bsp` | ~55 MB |
+
+---
+
+## 3. Bodies Included
+
+All DE ephemeris files contain the following 12 segments:
+
+| NAIF ID | Body | Center ID | Center Body | Description |
+|---------|------|-----------|-------------|-------------|
+| 1 | Mercury Barycenter | 0 | Solar System Barycenter (SSB) | Mercury system center of mass |
+| 2 | Venus Barycenter | 0 | SSB | Venus system center of mass (= Venus, no moons) |
+| 3 | Earth-Moon Barycenter (EMB) | 0 | SSB | Earth-Moon system center of mass |
+| 4 | Mars Barycenter | 0 | SSB | Mars system center of mass |
+| 5 | Jupiter Barycenter | 0 | SSB | Jupiter system center of mass |
+| 6 | Saturn Barycenter | 0 | SSB | Saturn system center of mass |
+| 7 | Uranus Barycenter | 0 | SSB | Uranus system center of mass |
+| 8 | Neptune Barycenter | 0 | SSB | Neptune system center of mass |
+| 9 | Pluto Barycenter | 0 | SSB | Pluto system center of mass |
+| 10 | Sun | 0 | SSB | Sun center |
+| 301 | Moon | 3 | EMB | Moon relative to Earth-Moon Barycenter |
+| 399 | Earth | 3 | EMB | Earth relative to Earth-Moon Barycenter |
+
+### Important Note on Barycenters
+
+For planets without substantial moons (Mercury and Venus), the barycenter is
+effectively the planet body itself. For Mars, the mass of Phobos and Deimos is
+negligible, so the Mars Barycenter is also essentially Mars itself. For the gas
+giants, the barycenter and the planet body can be separated by thousands of
+kilometers; to get the position of Jupiter itself (NAIF ID 599), you need a
+separate satellite SPK file (e.g., `jup365.bsp`).
+
+### Chain Resolution
+
+DE files do not store every body relative to the SSB. The Moon (301) and Earth
+(399) are stored relative to the Earth-Moon Barycenter (3), not relative to the
+SSB. To compute a vector between two arbitrary bodies, you must walk the chain
+of segments from each body back to their common root (the SSB).
+
+**Example: Earth-to-Mars vector**
+
+To find where Mars is as seen from Earth:
+
+```
+  Mars Barycenter (4) relative to SSB (0)        [segment 0 -> 4]
+- Earth-Moon Barycenter (3) relative to SSB (0)   [segment 0 -> 3]
+- Earth (399) relative to EMB (3)                  [segment 3 -> 399]
+```
+
+This gives: `position(Mars) = pos(4, SSB) - pos(3, SSB) - pos(399, EMB)`
+
+Or equivalently, the chain to Mars from the SSB is just `[(0, 4)]`, and the
+chain to Earth from the SSB is `[(0, 3), (3, 399)]`. Subtracting Earth's chain
+from Mars's chain yields the Earth-to-Mars vector.
+
+**Example: Earth-to-Moon vector**
+
+```
+  Moon (301) relative to EMB (3)                   [segment 3 -> 301]
+- Earth (399) relative to EMB (3)                   [segment 3 -> 399]
+```
+
+Since both are relative to the same center (EMB), the EMB-to-SSB chain cancels
+out, and you can simply subtract the two EMB-relative positions.
+
+---
+
+## 4. SPK Format Details
+
+### DAF Container Format
+
+All DE files use the NAIF Double Array File (DAF) format as their binary
+container. The DAF format is defined by three structural layers:
+
+**File Record (Record 1, bytes 0--1023):**
+
+| Offset | Size | Field | Description |
+|--------|------|-------|-------------|
+| 0 | 8 | LOCIDW | File ID word, e.g. `"DAF/SPK "` |
+| 8 | 4 | ND | Number of double-precision summary components (2 for SPK) |
+| 12 | 4 | NI | Number of integer summary components (6 for SPK) |
+| 16 | 60 | LOCIFN | Internal filename |
+| 76 | 4 | FWARD | Record number of first summary record |
+| 80 | 4 | BWARD | Record number of last summary record |
+| 84 | 4 | FREE | First free double-precision address |
+
+Each record is 1024 bytes. Records are 1-indexed. Byte order is detected
+automatically by checking whether ND and NI decode to sensible small integers
+in little-endian vs. big-endian. In practice, all modern DE files are
+little-endian.
+
+**Comment Records (Records 2 through FWARD-1):**
+
+Optional ASCII text describing the file contents, provenance, and creation date.
+
+**Summary Records (Records FWARD, FWARD+2, ...):**
+
+Each summary record contains a linked-list pointer (NEXT, PREV, NSUM) followed
+by packed segment summaries. Each summary contains ND doubles and NI integers:
+
+For SPK files (ND=2, NI=6), each segment summary contains:
+
+| Index | Type | Field | Description |
+|-------|------|-------|-------------|
+| 0 | f64 | start_second | Segment start epoch (TDB seconds past J2000.0) |
+| 1 | f64 | end_second | Segment end epoch (TDB seconds past J2000.0) |
+| 2 | i32 | target | Target body NAIF ID |
+| 3 | i32 | center | Center body NAIF ID |
+| 4 | i32 | frame | Reference frame code (1 = J2000/ICRF) |
+| 5 | i32 | data_type | SPK segment type (2 for DE files) |
+| 6 | i32 | start_i | Start address in file (1-indexed double-word) |
+| 7 | i32 | end_i | End address in file (1-indexed double-word) |
+
+Each summary record is paired with a name record (the next record) that
+provides an ASCII label for each segment.
+
+### SPK Type 2 Segments
+
+All DE ephemeris files use SPK Type 2, which stores position as Chebyshev
+polynomial coefficients. Velocity is not stored explicitly -- it is obtained by
+analytically differentiating the position polynomials.
+
+**Segment Layout:**
+
+A Type 2 segment (addressed by `start_i` through `end_i`) consists of:
+
+1. **Coefficient records** -- A sequence of fixed-size records, each covering one
+   time interval
+2. **Metadata** -- Four trailing doubles at the end of the segment
+
+**Metadata (last 4 doubles):**
+
+| Field | Description |
+|-------|-------------|
+| `init` | Initial epoch of first record (TDB seconds past J2000.0) |
+| `intlen` | Length of each time interval (seconds) |
+| `rsize` | Size of each record (number of doubles) |
+| `n` | Number of records |
+
+**Each Coefficient Record (rsize doubles):**
+
+| Offset | Count | Field |
+|--------|-------|-------|
+| 0 | 1 | `MID` -- Midpoint of the time interval (TDB seconds) |
+| 1 | 1 | `RADIUS` -- Half-length of the time interval (seconds) |
+| 2 | n_coeffs | X Chebyshev coefficients |
+| 2 + n_coeffs | n_coeffs | Y Chebyshev coefficients |
+| 2 + 2*n_coeffs | n_coeffs | Z Chebyshev coefficients |
+
+Where `n_coeffs = (rsize - 2) / 3`.
+
+The number of coefficients per component varies by body and ephemeris. Inner
+planets (Mercury, Venus) and the Moon typically use more coefficients and
+shorter time intervals (8--16 days) due to their faster orbital motion. Outer
+planets use fewer coefficients and longer intervals (32 days or more).
+
+### Reference Frame and Units
+
+| Property | Value |
+|----------|-------|
+| Reference frame | J2000 (ICRF-aligned, frame code 1) |
+| Position units | kilometers (km) |
+| Velocity units | kilometers per second (km/s), derived from differentiation |
+| Time system | Barycentric Dynamical Time (TDB) |
+| Time representation | Seconds past J2000.0 TDB epoch (JD 2451545.0) |
+
+---
+
+## 5. How Starfield Uses DE Files
+
+Starfield implements a complete DE ephemeris reader in the `jplephem` module.
+The relevant source files are:
+
+| File | Purpose |
+|------|---------|
+| `src/jplephem/daf.rs` | DAF binary container reader |
+| `src/jplephem/spk.rs` | SPK segment parser and Type 2/3 evaluator |
+| `src/jplephem/kernel.rs` | High-level API with name resolution and chain building |
+| `src/jplephem/chebyshev.rs` | Chebyshev polynomial evaluation and differentiation |
+| `src/jplephem/names.rs` | NAIF body name/ID mappings |
+| `src/data/downloader.rs` | Auto-downloading and caching of BSP files |
+
+### DAF Reader (`daf.rs`)
+
+The `DAF` struct handles:
+
+- **Automatic endianness detection:** Reads ND/NI in both byte orders and picks
+  whichever gives small positive values.
+- **Memory mapping:** Uses `memmap2` for efficient access to large files. Falls
+  back to standard file I/O if memory mapping is unavailable.
+- **In-memory buffers:** Supports `DAF::from_bytes()` for use with
+  `include_bytes!()`, enabling compile-time embedding of ephemeris data.
+- **Summary iteration:** Walks the linked list of summary records and unpacks
+  segment metadata.
+- **Array reading:** Reads arbitrary ranges of f64 values from the file using
+  1-indexed double-word addresses.
+
+### SPK Segment Parsing (`spk.rs`)
+
+The `SPK` struct opens a DAF file and parses all segment summaries into
+`Segment` objects. Each `Segment` holds:
+
+- Target and center body IDs
+- Time bounds (TDB seconds and Julian dates)
+- SPK data type (2 or 3)
+- File address range for the segment data
+
+Segment data is loaded lazily on first access and cached for subsequent
+evaluations. The loading process reads the trailing metadata (init, intlen,
+rsize, n), validates consistency, and stores the coefficient array.
+
+### Chebyshev Evaluation (`chebyshev.rs`)
+
+Position evaluation at a given time involves:
+
+1. **Record selection:** Compute `record_index = floor((et - init) / intlen)`
+   to find which coefficient record covers the requested time.
+
+2. **Time normalization:** Map the physical time to the interval `[-1, 1]`:
+   ```
+   t_normalized = (et - MID) / RADIUS
+   ```
+
+3. **Clenshaw recurrence:** Evaluate the Chebyshev series for each component
+   (X, Y, Z) using the Clenshaw algorithm, which is numerically stable and
+   efficient:
+   ```
+   b[n+1] = 0, b[n] = 0
+   for k = n-1 down to 1:
+       b[k] = 2*x*b[k+1] - b[k+2] + c[k]
+   result = c[0] + x*b[1] - b[2]
+   ```
+
+4. **Velocity by differentiation:** The derivative of a Chebyshev series uses
+   the identity `dT_n(x)/dx = n * U_{n-1}(x)` where `U` is the Chebyshev
+   polynomial of the second kind. The derivative in normalized time is then
+   rescaled to physical units by dividing by `RADIUS`:
+   ```
+   velocity_km_s = d(position)/d(t_normalized) / RADIUS
+   ```
+
+### BFS Chain Resolution (`kernel.rs`)
+
+The `SpiceKernel` struct wraps an `SPK` and precomputes paths from the Solar
+System Barycenter (SSB, NAIF ID 0) to every reachable body using breadth-first
+search over the segment graph.
+
+For each body, the chain is a list of `(center, target)` pairs. To compute a
+body's SSB-relative position, starfield walks the chain and sums the position
+vectors:
+
+```rust
+let mut total_pos = Vector3::zeros();
+for &(center, target) in chain {
+    let seg = spk.get_segment_mut(center, target)?;
+    let (pos, vel) = seg.compute_and_differentiate(tdb_seconds, 0.0)?;
+    total_pos += pos;
+}
+```
+
+For example, the chain for Earth (399) is `[(0, 3), (3, 399)]`:
+- Segment `(0, 3)`: EMB position relative to SSB
+- Segment `(3, 399)`: Earth position relative to EMB
+
+Summing these gives Earth's position relative to SSB.
+
+### Unit Conversion
+
+SPK files store positions in kilometers and velocities in km/s. The
+`SpiceKernel::compute_at()` method converts to astronomical units (AU) and
+AU/day using:
+
+```
+AU_KM = 149,597,870.700  (IAU 2012 exact definition)
+position_au = position_km / AU_KM
+velocity_au_day = velocity_km_s * 86400.0 / AU_KM
+```
+
+### Auto-Download and Caching
+
+The `Loader` struct provides zero-configuration access to DE files:
+
+```rust
+let loader = starfield::Loader::new();
+let mut kernel = loader.open("de421.bsp")?;
+```
+
+Behind the scenes:
+1. `download_or_cache()` checks `~/.cache/starfield/` for the file.
+2. If not found, `resolve_url()` maps the filename to a known URL. Files
+   matching `*.bsp` are resolved against `https://ssd.jpl.nasa.gov/ftp/eph/planets/bsp/`.
+3. The file is downloaded with a progress bar to a temporary file, then
+   atomically renamed into the cache directory.
+
+You can also use `SpiceKernel::open()` or `SpiceKernel::from_bytes()` directly
+if you manage file paths yourself.
+
+---
+
+## 6. Accuracy
+
+### Position Accuracy by Body
+
+| Body | Approximate accuracy | Notes |
+|------|---------------------|-------|
+| Moon | ~1 meter | Constrained by lunar laser ranging |
+| Inner planets (Mercury--Mars) | Sub-kilometer | Constrained by radar and spacecraft tracking |
+| Jupiter, Saturn | ~1--10 km | Constrained by spacecraft tracking (Juno, Cassini) |
+| Uranus, Neptune | ~10--100 km | Limited spacecraft data (Voyager flybys only) |
+| Pluto | ~100 km -- few thousand km | New Horizons flyby improved this significantly |
+
+These accuracy figures apply to DE440/441 within the well-observed portion of
+their time span (roughly 1900--2050). Accuracy degrades for dates far from the
+modern observational era.
+
+### Primary Error Sources
+
+- **Asteroid perturbations:** The main belt contains ~340 individually modeled
+  asteroids plus a ring representing the remainder. Imprecise asteroid masses
+  are the dominant error source for inner planet positions.
+- **Solar oblateness (J2):** Affects Mercury's orbit most strongly.
+- **Trans-Neptunian object masses:** Affects Pluto and Neptune predictions.
+- **General relativity parameters:** Post-Newtonian effects are included but
+  parameterized; small uncertainties propagate over centuries.
+
+### Degradation Over Time
+
+DE ephemerides are most accurate near the epoch of the observations that
+constrain them. Extrapolating to the year 3000 or back to 1000 BC incurs
+progressively larger errors, though the positions remain useful for most
+astronomical purposes across the full coverage span.
+
+---
+
+## 7. Comparison with Other Ephemerides
+
+Three major planetary ephemeris series exist worldwide:
+
+| Ephemeris | Institution | Country | SPK Type | Notes |
+|-----------|------------|---------|----------|-------|
+| DE (Development Ephemeris) | JPL/NASA | USA | Type 2 | The series documented here |
+| INPOP (Int. de Num. Plan. de l'Observatoire de Paris) | IMCCE | France | Type 2 | Comparable accuracy, different asteroid model |
+| EPM (Ephemerides of Planets and the Moon) | IAA RAS | Russia | Type 20 | Uses a different Chebyshev representation |
+
+All three series:
+- Agree at the sub-kilometer level for inner planets within their common
+  well-constrained time spans.
+- Use overlapping but not identical sets of observational data.
+- Are independently coded numerical integrations, providing valuable cross-checks.
+
+INPOP ephemerides are distributed in SPK format and can be read by the same DAF/SPK
+code used for DE files. EPM uses SPK Type 20 (Chebyshev with velocity), which
+starfield does not currently support.
+
+---
+
+## 8. Practical Notes
+
+### Choosing an Ephemeris
+
+- **`de421.bsp` (~17 MB)** -- Start here. Fast to download, covers 1900--2053,
+  perfectly adequate accuracy for most applications. Starfield's test suite uses
+  this file.
+- **`de440s.bsp` (~32 MB)** -- Best balance for production. Same accuracy as
+  DE440, covers 1850--2150.
+- **`de440.bsp` (~115 MB)** -- Full DE440 for applications needing dates back
+  to 1550 or forward to 2650.
+- **`de441.bsp` (~3.1 GB)** -- Only use this if you genuinely need positions
+  before 1550 or after 2650.
+
+### Performance Considerations
+
+- **Memory mapping:** Starfield uses `memmap2` to memory-map BSP files. This
+  means the OS manages paging -- only the portions of the file actually read
+  are loaded into physical memory. A 115 MB DE440 file does not consume 115 MB
+  of RAM.
+- **Lazy loading:** Segment coefficient data is loaded and cached on first
+  access. Subsequent evaluations for the same segment reuse the cached data.
+- **Compile-time embedding:** For constrained environments (WebAssembly,
+  embedded), use `SpiceKernel::from_bytes(include_bytes!("de421.bsp"))` to embed
+  the ephemeris directly in your binary. DE421's 17 MB size makes this feasible.
+
+### Cache Location
+
+Starfield caches downloaded files in `~/.cache/starfield/`. This follows the
+XDG Base Directory convention on Linux. The cache location is determined by:
+
+```rust
+let home = std::env::var("HOME").unwrap_or(".".to_string());
+PathBuf::from(home).join(".cache").join("starfield")
+```
+
+You can override this by passing a custom directory to `Loader::with_data_dir()`.
+
+### Mercury Barycenter vs Mercury
+
+For Mercury (and Venus), the "barycenter" and the planet body are the same
+point because these planets have no moons. The DE files contain segments for
+Mercury Barycenter (NAIF ID 1), not Mercury body (NAIF ID 199). When starfield
+resolves a request for "mercury", it returns the position from the barycenter
+segment, which is the planet itself.
+
+Note: Some DE files include a segment for Mercury body (1 -> 199), but this
+segment may have a more limited time range than the barycenter segment (0 -> 1).
+For Mercury, the barycenter segment is sufficient and preferred.
+
+### Satellite SPK Files
+
+DE ephemerides only contain data for planet barycenters, not for individual
+moons (other than Earth's Moon) or the planet bodies of the gas giants. To get
+positions of Jupiter (599), its Galilean moons (501--504), Saturn's rings, etc.,
+you need additional satellite SPK files from NAIF:
+
+- `jup365.bsp` -- Jupiter system satellites
+- `sat441.bsp` -- Saturn system satellites
+- etc.
+
+These are resolved by starfield from
+`https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/satellites/`.
+
+---
+
+## 9. Code Examples
+
+### Basic: Load and Query
+
+```rust
+use starfield::jplephem::SpiceKernel;
+use starfield::Timescale;
+
+let ts = Timescale::default();
+let mut kernel = SpiceKernel::open("de421.bsp")?;
+
+let t = ts.tdb_jd(2451545.0); // J2000.0
+let state = kernel.compute_at("earth", &t)?;
+
+println!("Earth position: ({}, {}, {}) AU",
+    state.position.x, state.position.y, state.position.z);
+println!("Earth velocity: ({}, {}, {}) AU/day",
+    state.velocity.x, state.velocity.y, state.velocity.z);
+```
+
+### Auto-Download
+
+```rust
+use starfield::Loader;
+
+let loader = Loader::new();
+let mut kernel = loader.open("de421.bsp")?; // downloads if needed
+
+let ts = loader.timescale();
+let t = ts.tdb_jd(2460000.0);
+let mars = kernel.compute_at("mars", &t)?;
+```
+
+### Raw km/s Access
+
+```rust
+use starfield::jplephem::SpiceKernel;
+use starfield::Timescale;
+
+let ts = Timescale::default();
+let mut kernel = SpiceKernel::open("de421.bsp")?;
+
+let t = ts.tdb_jd(2451545.0);
+let (pos_km, vel_km_s) = kernel.compute_km("moon", &t)?;
+
+println!("Moon position: {} km from SSB", pos_km.norm());
+println!("Moon velocity: {} km/s", vel_km_s.norm());
+```
+
+### Compile-Time Embedded
+
+```rust
+use starfield::jplephem::SpiceKernel;
+
+static BSP: &[u8] = include_bytes!("path/to/de421.bsp");
+let mut kernel = SpiceKernel::from_bytes(BSP)?;
+// Use as normal -- no filesystem access needed
+```
+
+---
+
+## 10. References
+
+- Park, R. S., et al. (2021). "The JPL Planetary and Lunar Ephemerides DE440
+  and DE441." _The Astronomical Journal_, 161(3), 105.
+  https://doi.org/10.3847/1538-3881/abd414
+
+- Folkner, W. M., et al. (2014). "The Planetary and Lunar Ephemerides DE430
+  and DE431." _IPN Progress Report_, 42-196.
+
+- Folkner, W. M., Williams, J. G., & Boggs, D. H. (2009). "The Planetary and
+  Lunar Ephemeris DE421." _IPN Progress Report_, 42-178.
+
+- NAIF SPK Required Reading:
+  https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/spk.html
+
+- NAIF DAF Required Reading:
+  https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/daf.html
+
+- JPL SSD Planetary Ephemeris page:
+  https://ssd.jpl.nasa.gov/planets/eph_export.html
+
+- NAIF Generic Kernels:
+  https://naif.jpl.nasa.gov/pub/naif/generic_kernels/

--- a/docs/data-sources/gaia-catalog.md
+++ b/docs/data-sources/gaia-catalog.md
@@ -1,0 +1,482 @@
+# Gaia Star Catalog
+
+## 1. Overview
+
+Gaia is a space observatory operated by the European Space Agency (ESA), launched on 19 December 2013. Its mission is to create the most precise three-dimensional map of the Milky Way by measuring positions, distances, and motions of stars with unprecedented accuracy.
+
+### Data Releases
+
+| Release | Date | Sources | Notes |
+|---------|------|---------|-------|
+| DR1 | September 2016 | ~1.1 billion | Positions and G-band magnitudes; limited parallaxes and proper motions (TGAS subset of ~2 million) |
+| DR2 | April 2018 | ~1.7 billion | Five-parameter astrometry, radial velocities for ~7 million stars |
+| EDR3 | December 2020 | ~1.8 billion | Improved astrometry and photometry; same source list as full DR3 |
+| DR3 | June 2022 | ~1.8 billion | Full release: astrophysical parameters, variable star classifications, spectra, non-stellar objects |
+| DR4 | Expected ~2026 | TBD | Full mission data, improved time-series, exoplanet orbits |
+
+### Precision
+
+Gaia achieves astrometric precision that varies with source brightness:
+
+| G magnitude | Position precision | Parallax precision | Proper motion precision |
+|-------------|-------------------|-------------------|------------------------|
+| < 15 | ~20 microarcseconds | ~20 microarcseconds | ~20 microarcseconds/yr |
+| 17 | ~100 microarcseconds | ~100 microarcseconds | ~70 microarcseconds/yr |
+| 20 | ~700 microarcseconds | ~700 microarcseconds | ~500 microarcseconds/yr |
+| 21 | ~2000 microarcseconds | ~2000 microarcseconds | ~1500 microarcseconds/yr |
+
+### Reference Epoch
+
+- **DR1**: J2015.0
+- **DR2 and later**: J2016.0
+
+All positions, parallaxes, and proper motions in DR2+ are given at epoch J2016.0 (JD 2457389.0 TDB, which corresponds to 2016-01-01T12:00:00 TDB). To obtain positions at a different epoch, proper motion must be applied.
+
+### Coordinate System
+
+Gaia uses the International Celestial Reference System (ICRS), materialized by the International Celestial Reference Frame (ICRF). Positions are reported as right ascension (ra) and declination (dec) in this frame.
+
+---
+
+## 2. Data Access
+
+### Gaia Archive
+
+The primary access point is the ESA Gaia Archive:
+
+- **Main portal**: https://gea.esac.esa.int/archive/
+- **TAP endpoint**: https://gea.esac.esa.int/tap-server/tap
+- **Bulk download CDN**: https://cdn.gea.esac.esa.int/Gaia/
+
+### Access Methods
+
+#### TAP/ADQL Queries
+
+The archive exposes a Table Access Protocol (TAP) service that accepts queries written in Astronomical Data Query Language (ADQL). This is the most flexible method for obtaining specific subsets of the catalog.
+
+Example using `curl`:
+
+```bash
+curl -X POST "https://gea.esac.esa.int/tap-server/tap/sync" \
+  --data "REQUEST=doQuery" \
+  --data "LANG=ADQL" \
+  --data "FORMAT=csv" \
+  --data "QUERY=SELECT TOP 100 source_id, ra, dec, parallax, phot_g_mean_mag FROM gaiadr3.gaia_source WHERE phot_g_mean_mag < 6.0" \
+  -o bright_stars.csv
+```
+
+#### Bulk Download via HTTP
+
+Pre-partitioned CSV files are available for direct download from the CDN. Files are organized by data release and table:
+
+```
+https://cdn.gea.esac.esa.int/Gaia/gdr3/gaia_source/
+https://cdn.gea.esac.esa.int/Gaia/gdr2/gaia_source/csv/
+https://cdn.gea.esac.esa.int/Gaia/gdr1/gaia_source/csv/
+```
+
+Each release directory contains gzipped CSV files partitioned by HEALPix index or source ID range, along with an `MD5SUM.txt` file for integrity verification.
+
+#### File Naming Conventions
+
+- **DR1**: `GaiaSource_000-000-000.csv.gz` through `GaiaSource_000-020-XXX.csv.gz`
+- **DR3**: `GaiaSource_XXXX.csv.gz` where `XXXX` is a zero-padded partition number
+
+### How Starfield Accesses Gaia Data
+
+The starfield library currently targets **Gaia DR1** via the bulk download CDN. The downloader implementation lives in `src/data/gaia_downloader.rs` and works as follows:
+
+1. **Index discovery**: Fetches the HTML directory listing at the DR1 CSV base URL and parses out filenames matching `GaiaSource_\d{3}-\d{3}-\d{3}\.csv\.gz` using a regex.
+
+2. **Download with caching**: Each gzipped CSV file is downloaded to a local cache directory at `~/.cache/starfield/gaia/`. Files are first written to a `.tmp` path and renamed atomically on completion to prevent partial downloads from corrupting the cache.
+
+3. **MD5 verification**: An `MD5SUM.txt` file is downloaded from the archive and used to verify the integrity of each downloaded file.
+
+4. **Streaming decompression**: The gzipped files are kept in compressed form on disk. The `GaiaCatalog::from_file()` method detects `.gz` extensions and applies `flate2::read::GzDecoder` for transparent streaming decompression during parsing.
+
+5. **Catalog merging**: Multiple downloaded files can be merged into a single `GaiaCatalog` using the `merge()` method. When merging, duplicate `source_id` entries are resolved by keeping the entry from the first catalog (the receiver).
+
+### Cache Layout
+
+```
+~/.cache/starfield/gaia/
+    MD5SUM.txt
+    GaiaSource_000-000-000.csv.gz
+    GaiaSource_000-000-001.csv.gz
+    ...
+```
+
+---
+
+## 3. Data Fields
+
+### Fields Parsed by Starfield
+
+The current `GaiaEntry` struct extracts the following fields from CSV files. All fields listed as "required" cause the row to be skipped if parsing fails.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `source_id` | `u64` | Yes | Unique source identifier within the Gaia catalog |
+| `solution_id` | `u64` | Yes | Identifier of the processing pipeline solution |
+| `ra` | `f64` | Yes | Right ascension in degrees (ICRS, at reference epoch) |
+| `dec` | `f64` | Yes | Declination in degrees (ICRS, at reference epoch) |
+| `ra_error` | `f64` | Yes | Standard error in RA (milliarcseconds) |
+| `dec_error` | `f64` | Yes | Standard error in Dec (milliarcseconds) |
+| `parallax` | `Option<f64>` | No | Absolute stellar parallax (milliarcseconds). Empty for sources without astrometric solution. |
+| `parallax_error` | `Option<f64>` | No | Standard error of parallax (milliarcseconds) |
+| `pmra` | `Option<f64>` | No | Proper motion in RA direction, `mu_alpha * cos(delta)` (milliarcseconds/year) |
+| `pmdec` | `Option<f64>` | No | Proper motion in Dec direction (milliarcseconds/year) |
+| `phot_g_mean_mag` | `f64` | Yes | G-band mean magnitude (Vega system). Used for magnitude filtering. |
+| `phot_g_mean_flux` | `f64` | Yes | G-band mean flux (electrons/second) |
+| `phot_variable_flag` | `String` | Yes | Photometric variability flag: `"NOT_AVAILABLE"`, `"CONSTANT"`, or `"VARIABLE"` |
+| `l` | `f64` | Yes | Galactic longitude (degrees) |
+| `b` | `f64` | Yes | Galactic latitude (degrees) |
+| `ecl_lon` | `f64` | Yes | Ecliptic longitude (degrees) |
+| `ecl_lat` | `f64` | Yes | Ecliptic latitude (degrees) |
+
+### Additional DR3 Fields (Not Yet Parsed)
+
+These fields are available in Gaia DR3 and may be useful for future starfield features:
+
+#### Photometry
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `phot_g_mean_flux_over_error` | `f64` | G-band flux divided by its error (signal-to-noise ratio) |
+| `phot_bp_mean_mag` | `f64` | Integrated BP-band mean magnitude |
+| `phot_bp_mean_flux` | `f64` | Integrated BP-band mean flux (electrons/second) |
+| `phot_rp_mean_mag` | `f64` | Integrated RP-band mean magnitude |
+| `phot_rp_mean_flux` | `f64` | Integrated RP-band mean flux (electrons/second) |
+| `bp_rp` | `f64` | BP - RP color index (mag) |
+| `bp_g` | `f64` | BP - G color index (mag) |
+| `g_rp` | `f64` | G - RP color index (mag) |
+
+The BP/RP color indices are essential for converting Gaia photometry to other photometric systems (e.g., Johnson-Cousins V, B-V). The current `approx_v_magnitude()` method on `GaiaEntry` returns `phot_g_mean_mag` directly, noting that precise V-band conversion requires color information.
+
+#### Astrometric Quality
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `astrometric_excess_noise` | `f64` | Excess noise in the astrometric solution (mas). Non-zero values indicate the source may not be well-modeled as a single point source. |
+| `astrometric_excess_noise_sig` | `f64` | Significance of excess noise (dimensionless). Values > 2 suggest the excess noise is statistically significant. |
+| `ruwe` | `f64` | Renormalized Unit Weight Error. Values near 1.0 indicate a well-behaved single-star solution. Values > 1.4 suggest binarity, extended sources, or problematic solutions. |
+| `astrometric_params_solved` | `i32` | Number of astrometric parameters solved: 2 (position only), 5 (full 5-parameter), 6 (pseudo-color added) |
+| `ipd_gof_harmonic_amplitude` | `f64` | Image Parameter Determination goodness-of-fit harmonic amplitude. High values indicate extended or resolved sources. |
+| `astrometric_chi2_al` | `f64` | Chi-squared value of the astrometric solution |
+| `astrometric_n_good_obs_al` | `i32` | Number of good along-scan observations used |
+
+#### Radial Velocity
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `radial_velocity` | `f64` | Spectroscopic barycentric radial velocity (km/s). Available for ~33 million sources in DR3 (mostly G_RVS < 14). |
+| `radial_velocity_error` | `f64` | Standard error of radial velocity (km/s) |
+| `rv_template_teff` | `f64` | Effective temperature of the template used for RV cross-correlation (K) |
+| `rv_nb_transits` | `i32` | Number of transits used for radial velocity determination |
+
+#### Astrophysical Parameters (GSP-Phot)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `teff_gspphot` | `f64` | Effective temperature from GSP-Phot (K). Available for ~470 million sources in DR3. |
+| `logg_gspphot` | `f64` | Surface gravity from GSP-Phot (log(cm/s^2)). Ranges from ~0 (supergiants) to ~5 (main sequence). |
+| `mh_gspphot` | `f64` | Metallicity [M/H] from GSP-Phot (dex). Solar metallicity = 0.0. |
+| `distance_gspphot` | `f64` | Distance estimate from GSP-Phot (parsecs). Uses both parallax and photometry, so can differ from simple 1/parallax inversion. |
+| `azero_gspphot` | `f64` | Monochromatic extinction A_0 at 541.4 nm from GSP-Phot (mag) |
+| `ag_gspphot` | `f64` | Extinction in G band from GSP-Phot (mag) |
+| `ebpminrp_gspphot` | `f64` | Reddening E(BP-RP) from GSP-Phot (mag) |
+
+#### Source Classification
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `classprob_dsc_combmod_quasar` | `f64` | Probability of being a quasar (0-1) |
+| `classprob_dsc_combmod_galaxy` | `f64` | Probability of being a galaxy (0-1) |
+| `classprob_dsc_combmod_star` | `f64` | Probability of being a star (0-1) |
+| `in_qso_candidates` | `bool` | Whether the source appears in the QSO candidates table |
+| `in_galaxy_candidates` | `bool` | Whether the source appears in the galaxy candidates table |
+
+#### Proper Motion Derived Quantities
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `pm` | `f64` | Total proper motion (mas/yr), computed as `sqrt(pmra^2 + pmdec^2)` |
+| `pmra_error` | `f64` | Standard error of proper motion in RA (mas/yr) |
+| `pmdec_error` | `f64` | Standard error of proper motion in Dec (mas/yr) |
+| `pmra_pmdec_corr` | `f64` | Correlation coefficient between pmra and pmdec |
+| `ra_parallax_corr` | `f64` | Correlation coefficient between RA and parallax |
+| `dec_parallax_corr` | `f64` | Correlation coefficient between Dec and parallax |
+
+---
+
+## 4. How Starfield Uses It
+
+### Parsing Pipeline
+
+The `GaiaCatalog` struct in `src/catalogs/gaia.rs` implements the following parsing approach:
+
+1. **Header-driven column mapping**: The first line of the CSV is parsed to build a column-name-to-index map. This makes the parser resilient to column reordering across different Gaia data files. Column lookup is done via a `find_column()` closure that returns a `Result` with a descriptive error if a required column is missing.
+
+2. **Line-by-line parsing**: Each subsequent line is split on commas and fields are extracted by their column index. Lines with insufficient columns are silently skipped.
+
+3. **Magnitude filtering at parse time**: The G-band magnitude (`phot_g_mean_mag`) is checked against the caller-supplied `mag_limit` immediately after parsing. Stars fainter than the limit are discarded before allocating a `GaiaEntry`, reducing memory usage for large files.
+
+4. **Optional field handling**: Fields like `parallax`, `parallax_error`, `pmra`, and `pmdec` are parsed as `Option<f64>`. Empty CSV fields produce `None` values rather than causing the row to be skipped.
+
+5. **Storage**: Parsed entries are stored in a `HashMap<u64, GaiaEntry>` keyed by `source_id` for O(1) lookup.
+
+### Loading Code Path
+
+```rust
+// Load a single file with magnitude limit
+let catalog = GaiaCatalog::from_file("path/to/GaiaSource_000-000-000.csv.gz", 12.0)?;
+
+// Load and merge multiple files
+let mut catalog = GaiaCatalog::new();
+for path in downloaded_paths {
+    let chunk = GaiaCatalog::from_file(&path, 12.0)?;
+    catalog.merge(chunk)?;
+}
+```
+
+### Download Chunking Strategy
+
+The downloader in `src/data/gaia_downloader.rs` processes files sequentially:
+
+1. `list_gaia_files()` fetches the directory index and extracts all filenames.
+2. `download_gaia_catalog(max_files)` iterates through the file list, downloading and verifying each one. The `max_files` parameter allows limiting downloads for testing or partial catalog use.
+3. Each file is downloaded with a 10-minute HTTP timeout and an 8 KB buffer, with progress reported every 5 MB.
+4. Failed downloads are logged but do not halt the process; remaining files continue downloading.
+
+### StarCatalog Trait Implementation
+
+`GaiaCatalog` implements the `StarCatalog` trait, providing:
+
+- `get_star(id)`: Lookup by `source_id` (cast to `u64`)
+- `stars()`: Iterator over all `GaiaEntry` values
+- `star_data()`: Converts entries to the generic `StarData` format (id, ra, dec, magnitude). Note: `b_v` color index is set to `None` since Gaia does not directly provide Johnson B-V.
+- `brighter_than(magnitude)`: Filter via `StarData` magnitude
+- `stars_in_field(ra, dec, fov)`: Cone search using angular distance
+
+### Derived Calculations
+
+`GaiaEntry` provides two derived computation methods:
+
+- **`unit_vector()`**: Converts RA/Dec to a unit vector in ICRS Cartesian coordinates using the standard spherical-to-Cartesian transformation.
+- **`cartesian_position()`**: Returns a 3D position in parsecs by scaling the unit vector by `1000.0 / parallax_mas`. Returns `None` if parallax is absent or non-positive.
+
+---
+
+## 5. Query Strategies
+
+### ADQL Syntax
+
+ADQL (Astronomical Data Query Language) is a SQL-like language for querying astronomical databases. It extends SQL with geometric functions for celestial coordinates.
+
+#### Cone Search (Circle on the Sky)
+
+Find all sources within a radius of a given position:
+
+```sql
+SELECT source_id, ra, dec, parallax, phot_g_mean_mag
+FROM gaiadr3.gaia_source
+WHERE 1 = CONTAINS(
+    POINT('ICRS', ra, dec),
+    CIRCLE('ICRS', 83.633, -5.55, 1.0)
+)
+```
+
+This queries a 1-degree radius circle centered on the Orion Nebula region.
+
+#### Box Search (Rectangle on the Sky)
+
+```sql
+SELECT source_id, ra, dec, phot_g_mean_mag
+FROM gaiadr3.gaia_source
+WHERE ra BETWEEN 80.0 AND 85.0
+  AND dec BETWEEN -10.0 AND 0.0
+```
+
+For regions not crossing the RA=0/360 boundary this is simpler than a polygon query. For regions crossing RA=0, use `OR` logic or the `POLYGON` function.
+
+#### Magnitude-Limited Query
+
+```sql
+SELECT source_id, ra, dec, parallax, pmra, pmdec,
+       phot_g_mean_mag, phot_bp_mean_mag, phot_rp_mean_mag,
+       radial_velocity, teff_gspphot
+FROM gaiadr3.gaia_source
+WHERE phot_g_mean_mag < 10.0
+ORDER BY phot_g_mean_mag ASC
+```
+
+#### Nearby Stars (Parallax-Based Distance Filter)
+
+```sql
+SELECT source_id, ra, dec, parallax, pmra, pmdec, phot_g_mean_mag,
+       1000.0/parallax AS distance_pc
+FROM gaiadr3.gaia_source
+WHERE parallax > 0
+  AND parallax_over_error > 10
+  AND parallax > 50.0  -- closer than 20 parsecs
+ORDER BY parallax DESC
+```
+
+The `parallax_over_error > 10` filter ensures reliable distance estimates.
+
+#### Cross-Match with Other Catalogs
+
+Gaia DR3 provides pre-computed cross-matches with other major catalogs:
+
+```sql
+-- Cross-match with Hipparcos
+SELECT g.source_id, g.ra, g.dec, g.phot_g_mean_mag,
+       h.hip, h.hpmag
+FROM gaiadr3.gaia_source AS g
+JOIN gaiadr3.hipparcos2_best_neighbour AS h
+  ON g.source_id = h.source_id
+WHERE g.phot_g_mean_mag < 6.0
+
+-- Cross-match with Tycho-2
+SELECT g.source_id, t.original_ext_source_id AS tycho_id
+FROM gaiadr3.gaia_source AS g
+JOIN gaiadr3.tycho2tdsc_merge_best_neighbour AS t
+  ON g.source_id = t.source_id
+```
+
+Available cross-match tables include:
+- `hipparcos2_best_neighbour`
+- `tycho2tdsc_merge_best_neighbour`
+- `panstarrs1_best_neighbour`
+- `sdssdr13_best_neighbour`
+- `allwise_best_neighbour`
+- `tmass_psc_best_neighbour` (2MASS)
+
+#### High Proper Motion Stars
+
+```sql
+SELECT source_id, ra, dec, pmra, pmdec,
+       SQRT(pmra*pmra + pmdec*pmdec) AS total_pm,
+       phot_g_mean_mag
+FROM gaiadr3.gaia_source
+WHERE pmra IS NOT NULL
+  AND pmdec IS NOT NULL
+  AND SQRT(pmra*pmra + pmdec*pmdec) > 500.0
+ORDER BY total_pm DESC
+```
+
+### Pagination for Large Results
+
+The Gaia TAP service limits synchronous queries to relatively small result sets (~3 million rows). For larger queries, use asynchronous mode:
+
+1. Submit an asynchronous job via the TAP `/async` endpoint.
+2. Poll the job status until completion.
+3. Download the result file.
+
+Alternatively, partition queries by sky region (HEALPix level) or source ID range:
+
+```sql
+-- Partition by HEALPix level 5 pixel
+SELECT source_id, ra, dec, phot_g_mean_mag
+FROM gaiadr3.gaia_source
+WHERE source_id BETWEEN 0 AND 562949953421311  -- First HEALPix L12 range
+  AND phot_g_mean_mag < 15.0
+```
+
+The `source_id` in Gaia encodes the HEALPix level-12 pixel index in its most significant bits, so range queries on `source_id` correspond to spatial regions on the sky.
+
+---
+
+## 6. Data Volume Considerations
+
+### Full Catalog Sizes
+
+| Release | Table | Compressed Size | Uncompressed Size | Sources |
+|---------|-------|----------------|-------------------|---------|
+| DR1 | `gaia_source` | ~12 GB (gzipped CSV) | ~55 GB | ~1.1 billion |
+| DR3 | `gaia_source` | ~650 GB (gzipped CSV) | ~2.5 TB | ~1.8 billion |
+
+### Practical Subsets by Magnitude Limit
+
+Approximate source counts and download sizes for magnitude-limited subsets of DR3:
+
+| G magnitude limit | Approx. sources | Approx. CSV size (uncompressed) | Approx. CSV size (gzipped) |
+|-------------------|-----------------|-------------------------------|--------------------------|
+| < 6.0 | ~9,000 | ~5 MB | ~1 MB |
+| < 8.0 | ~80,000 | ~40 MB | ~8 MB |
+| < 10.0 | ~650,000 | ~350 MB | ~70 MB |
+| < 12.0 | ~5 million | ~2.5 GB | ~500 MB |
+| < 14.0 | ~40 million | ~20 GB | ~4 GB |
+| < 16.0 | ~250 million | ~120 GB | ~25 GB |
+| < 18.0 | ~800 million | ~400 GB | ~80 GB |
+| < 21.0 (full) | ~1.8 billion | ~2.5 TB | ~650 GB |
+
+These numbers are approximate. For starfield's use cases (star field rendering, astrometry), magnitude limits of 12-16 are typically sufficient and keep data volumes manageable.
+
+### Strategies for Reducing Data Volume
+
+1. **Column selection**: Query only the columns you need. The full `gaia_source` table has 152 columns; starfield uses 17. Requesting fewer columns via ADQL dramatically reduces download size.
+
+2. **Spatial partitioning**: Download only the sky regions relevant to your use case rather than the full sky.
+
+3. **Quality filters**: Exclude low-quality measurements:
+   ```sql
+   WHERE parallax_over_error > 5
+     AND ruwe < 1.4
+     AND astrometric_excess_noise < 1.0
+   ```
+
+4. **Source type filtering**: Exclude non-stellar sources if only stars are needed:
+   ```sql
+   WHERE classprob_dsc_combmod_star > 0.9
+   ```
+
+---
+
+## 7. Practical Notes
+
+### Rate Limits and Etiquette
+
+The Gaia Archive does not publish strict rate limits, but users should follow these guidelines:
+
+- **Synchronous queries**: Limited to results under ~3 million rows (configurable by the archive). Queries exceeding this limit will fail and should be resubmitted as asynchronous jobs.
+- **Concurrent connections**: Keep concurrent downloads to a reasonable number (2-4 simultaneous connections). The CDN can handle more, but aggressive parallelism may result in throttling or IP bans.
+- **Query complexity**: Avoid extremely complex JOIN operations on the full `gaia_source` table. Use indexed columns (`source_id`, `ra`, `dec`, `phot_g_mean_mag`, `parallax`) in WHERE clauses.
+- **Large result sets**: Use asynchronous TAP jobs for queries expected to return more than a few hundred thousand rows.
+
+### Download Strategies for Large Datasets
+
+1. **Incremental download**: The starfield downloader processes files sequentially, which is resilient to interruptions. Already-downloaded files are detected by the cache and skipped on retry. Use the `max_files` parameter to limit batch sizes.
+
+2. **Checksum verification**: Always verify downloads against the `MD5SUM.txt` file provided in each data release directory. The starfield downloader does this automatically.
+
+3. **Temporary file pattern**: Write downloads to a `.tmp` file first, then rename atomically. This prevents partially downloaded files from being treated as complete. The starfield downloader implements this pattern.
+
+4. **Compression**: Keep gzipped files on disk and decompress during parsing. This roughly halves storage requirements with minimal performance cost due to the I/O-bound nature of CSV parsing.
+
+### Cache Management
+
+Starfield stores cached Gaia files at `~/.cache/starfield/gaia/`. To manage this cache:
+
+- **List cached files**: Use `list_cached_gaia_files()` from `src/data/gaia_downloader.rs` to enumerate all cached `.csv` and `.csv.gz` files.
+- **Clear cache**: Delete the `~/.cache/starfield/gaia/` directory to force re-download.
+- **Disk usage**: Monitor cache size, especially if downloading large portions of the catalog. A full DR1 download is ~12 GB compressed.
+
+### Known Limitations in Current Implementation
+
+1. **DR1 only**: The downloader currently targets Gaia DR1 (`gdr1`). DR3 data must be obtained through manual download or ADQL queries and loaded via `GaiaCatalog::from_file()`.
+
+2. **No ADQL client**: Starfield does not include a TAP/ADQL client. For custom queries, use external tools (e.g., `curl`, TOPCAT, `astroquery` in Python) to obtain CSV files, then load them with `GaiaCatalog::from_file()`.
+
+3. **No B-V color**: The `StarData` conversion sets `b_v` to `None` because Gaia's native photometric bands (G, BP, RP) do not directly map to the Johnson B-V system. Conversion requires BP-RP color, which is not currently parsed.
+
+4. **Sequential downloads**: Files are downloaded one at a time. Parallel downloads would improve throughput for full-catalog retrieval.
+
+5. **No incremental merge during download**: The downloader returns a list of file paths. Building a catalog from many files requires loading and merging each one separately after download.
+
+### Useful External Tools
+
+- **TOPCAT** (http://www.star.bris.ac.uk/~mbt/topcat/): Desktop application for interactive catalog exploration and TAP queries.
+- **astroquery** (Python): `astroquery.gaia` module provides programmatic TAP access.
+- **Aladin Lite** (https://aladin.u-strasbg.fr/AladinLite/): Browser-based sky viewer with Gaia overlay support.
+- **VizieR** (https://vizier.u-strasbg.fr/): Alternative access point for Gaia tables with pre-built queries.

--- a/docs/data-sources/hipparcos-catalog.md
+++ b/docs/data-sources/hipparcos-catalog.md
@@ -1,0 +1,333 @@
+# Hipparcos Star Catalog
+
+## 1. Overview
+
+The Hipparcos catalog is the product of the European Space Agency's (ESA) **Hipparcos** space astrometry mission, which operated from 1989 to 1993. The satellite performed high-precision measurements of stellar positions, proper motions, and parallaxes from a heliocentric orbit, free from the atmospheric distortions that limit ground-based astrometry.
+
+Key facts:
+
+- **Stars cataloged:** 118,218 entries in the main catalog (`hip_main.dat`)
+- **Positional accuracy:** ~1 milliarcsecond (mas) for bright stars
+- **Reference epoch:** J1991.25 (the mean observation epoch)
+- **Coordinate system:** ICRS (International Celestial Reference System)
+- **Original publication:** 1997 (ESA SP-1200)
+- **Revised reduction:** 2007 by Floor van Leeuwen, improving parallaxes by up to a factor of 4 for bright stars
+- **Superseded by:** Gaia DR3 for most applications, though Hipparcos remains the reference for bright-star proper motions over a ~25-year baseline when combined with Gaia
+
+The Hipparcos catalog served as the primary positional reference for stellar astronomy from 1997 until the Gaia mission published its first data release in 2016.
+
+## 2. Data Format
+
+The main catalog file is `hip_main.dat`, a fixed-width ASCII text file with one record per star. Each line contains 78 fields separated by pipe (`|`) characters. Fields that have no measured value for a given star are left blank.
+
+### Format characteristics
+
+- **Encoding:** ASCII text
+- **Record separator:** newline (`\n`)
+- **Field separator:** pipe (`|`)
+- **Total fields per record:** 78 (H0 through H77)
+- **Typical line length:** ~450 characters
+- **Total records:** 118,218
+- **File size:** approximately 51 MB uncompressed
+
+### Reference epoch
+
+All positional data (RA, Dec, proper motions) are referred to epoch **J1991.25** in the **ICRS** frame. The ICRS is essentially aligned with the FK5/J2000 equatorial system to within the uncertainties of the FK5 catalog. To propagate positions to another epoch, apply proper motion corrections:
+
+```
+RA(t)  = RA(J1991.25)  + pmRA  * (t - 1991.25) / cos(Dec)
+Dec(t) = Dec(J1991.25) + pmDE  * (t - 1991.25)
+```
+
+where `pmRA` is the proper motion in RA already multiplied by `cos(Dec)` (field H12), and time `t` is in Julian years.
+
+## 3. Download Source
+
+### Primary URL (used by starfield)
+
+```
+https://cdsarc.cds.unistra.fr/ftp/cats/I/239/hip_main.dat
+```
+
+This is the CDS (Centre de Donnees astronomiques de Strasbourg) FTP mirror, accessed over HTTPS. The starfield downloader stores this URL as the constant `HIPPARCOS_URL` in `src/data/downloader.rs`.
+
+### Mirror URLs
+
+| Source | URL |
+|--------|-----|
+| CDS FTP (primary) | `https://cdsarc.cds.unistra.fr/ftp/cats/I/239/hip_main.dat` |
+| CDS VizieR catalog page | `https://vizier.cds.unistra.fr/viz-bin/VizieR?-source=I/239` |
+| ESA Hipparcos archive | `https://www.cosmos.esa.int/web/hipparcos/catalogues` |
+
+### File sizes
+
+| File | Size |
+|------|------|
+| `hip_main.dat` (uncompressed) | ~51 MB |
+| `hip_main.dat.gz` (gzipped) | ~15 MB |
+
+The starfield downloader fetches the uncompressed `.dat` file directly. The download function reports approximately 36 MB to the user (this varies depending on transfer encoding).
+
+### Cache location
+
+Starfield caches the file at:
+
+```
+~/.cache/starfield/hip_main.dat
+```
+
+The downloader also checks for a `hip_main.dat` in the project root (useful for CI environments) and copies it to the cache if found.
+
+## 4. Field Reference
+
+The following table documents all 78 fields in `hip_main.dat`. The "Pipe Index" column gives the zero-based index when the line is split on the `|` character, which is how the starfield parser accesses fields. The "Bytes" column gives the 1-based byte positions from the original CDS format specification.
+
+| Pipe Index | Field ID | Bytes | Format | Units | Label | Description |
+|:----------:|:--------:|:-----:|:------:|:-----:|:-----:|:------------|
+| 0 | H0 | 1 | A1 | --- | Catalog | Catalogue identifier (always `H`) |
+| 1 | H1 | 9-14 | I6 | --- | HIP | Hipparcos identifier number |
+| 2 | H2 | 16 | A1 | --- | Proxy | Proximity flag (`H` = HIP, `T` = Tycho) |
+| 3 | H3 | 18-28 | A11 | --- | RAhms | Right ascension in h m s (ICRS, J1991.25) |
+| 4 | H4 | 30-40 | A11 | --- | DEdms | Declination in d ' " (ICRS, J1991.25) |
+| 5 | H5 | 42-46 | F5.2 | mag | Vmag | Johnson V magnitude |
+| 6 | H6 | 48 | I1 | --- | VarFlag | Coarse variability flag (1, 2, or 3) |
+| 7 | H7 | 50 | A1 | --- | r_Vmag | Source of V magnitude (`G`=ground, `H`=HIP, `T`=Tycho) |
+| 8 | H8 | 52-63 | F12.8 | deg | RAdeg | Right ascension in decimal degrees (ICRS, J1991.25) |
+| 9 | H9 | 65-76 | F12.8 | deg | DEdeg | Declination in decimal degrees (ICRS, J1991.25) |
+| 10 | H10 | 78 | A1 | --- | AstroRef | Reference flag for astrometry |
+| 11 | H11 | 80-86 | F7.2 | mas | Plx | Trigonometric parallax |
+| 12 | H12 | 88-95 | F8.2 | mas/yr | pmRA | Proper motion in RA (mu_alpha * cos(delta)) |
+| 13 | H13 | 97-104 | F8.2 | mas/yr | pmDE | Proper motion in Dec (mu_delta) |
+| 14 | H14 | 106-111 | F6.2 | mas | e_RAdeg | Standard error in RA*cos(Dec) |
+| 15 | H15 | 113-118 | F6.2 | mas | e_DEdeg | Standard error in Dec |
+| 16 | H16 | 120-125 | F6.2 | mas | e_Plx | Standard error in parallax |
+| 17 | H17 | 127-132 | F6.2 | mas/yr | e_pmRA | Standard error in pmRA |
+| 18 | H18 | 134-139 | F6.2 | mas/yr | e_pmDE | Standard error in pmDE |
+| 19 | H19 | 141-145 | F5.2 | --- | DE:RA | Correlation coefficient, Dec/RA*cos(delta) |
+| 20 | H20 | 147-151 | F5.2 | --- | Plx:RA | Correlation coefficient, Plx/RA*cos(delta) |
+| 21 | H21 | 153-157 | F5.2 | --- | Plx:DE | Correlation coefficient, Plx/Dec |
+| 22 | H22 | 159-163 | F5.2 | --- | pmRA:RA | Correlation coefficient, pmRA/RA*cos(delta) |
+| 23 | H23 | 165-169 | F5.2 | --- | pmRA:DE | Correlation coefficient, pmRA/Dec |
+| 24 | H24 | 171-175 | F5.2 | --- | pmRA:Plx | Correlation coefficient, pmRA/Plx |
+| 25 | H25 | 177-181 | F5.2 | --- | pmDE:RA | Correlation coefficient, pmDE/RA*cos(delta) |
+| 26 | H26 | 183-187 | F5.2 | --- | pmDE:DE | Correlation coefficient, pmDE/Dec |
+| 27 | H27 | 189-193 | F5.2 | --- | pmDE:Plx | Correlation coefficient, pmDE/Plx |
+| 28 | H28 | 195-199 | F5.2 | --- | pmDE:pmRA | Correlation coefficient, pmDE/pmRA |
+| 29 | H29 | 201-203 | I3 | % | F1 | Percentage of rejected data |
+| 30 | H30 | 205-209 | F5.2 | --- | F2 | Goodness-of-fit parameter |
+| 31 | H31 | 211-216 | I6 | --- | HIP (rep) | HIP number (repeated for convenience) |
+| 32 | H32 | 218-223 | F6.3 | mag | BTmag | Mean BT magnitude (Tycho photometry) |
+| 33 | H33 | 225-229 | F5.3 | mag | e_BTmag | Standard error on BTmag |
+| 34 | H34 | 231-236 | F6.3 | mag | VTmag | Mean VT magnitude (Tycho photometry) |
+| 35 | H35 | 238-242 | F5.3 | mag | e_VTmag | Standard error on VTmag |
+| 36 | H36 | 244 | A1 | --- | m_BTmag | Reference flag for BT and VT mag |
+| 37 | H37 | 246-251 | F6.3 | mag | B-V | Johnson B-V color index |
+| 38 | H38 | 253-257 | F5.3 | mag | e_B-V | Standard error on B-V |
+| 39 | H39 | 259 | A1 | --- | r_B-V | Source of B-V (`G`=ground, `T`=Tycho) |
+| 40 | H40 | 261-264 | F4.2 | mag | V-I | Cousins V-I color index |
+| 41 | H41 | 266-269 | F4.2 | mag | e_V-I | Standard error on V-I |
+| 42 | H42 | 271 | A1 | --- | r_V-I | Source of V-I |
+| 43 | H43 | 273 | A1 | --- | CombMag | Flag for combined V mag, B-V, V-I |
+| 44 | H44 | 275-281 | F7.4 | mag | Hpmag | Median magnitude in Hipparcos system |
+| 45 | H45 | 283-288 | F6.4 | mag | e_Hpmag | Standard error on Hpmag |
+| 46 | H46 | 290-294 | F5.3 | mag | Hpscat | Scatter of Hpmag |
+| 47 | H47 | 296-298 | I3 | --- | o_Hpmag | Number of observations for Hpmag |
+| 48 | H48 | 300 | A1 | --- | m_Hpmag | Reference flag for Hpmag |
+| 49 | H49 | 302-306 | F5.2 | mag | Hpmax | Hpmag at maximum brightness (5th percentile) |
+| 50 | H50 | 308-312 | F5.2 | mag | HPmin | Hpmag at minimum brightness (95th percentile) |
+| 51 | H51 | 314-320 | F7.2 | d | Period | Variability period in days |
+| 52 | H52 | 322 | A1 | --- | HvarType | Variability type (C/D/M/P/R/U) |
+| 53 | H53 | 324 | A1 | --- | moreVar | Additional variability data flag (1/2) |
+| 54 | H54 | 326 | A1 | --- | morePhoto | Light curve annex flag (A/B/C) |
+| 55 | H55 | 328-337 | A10 | --- | CCDM | CCDM (Catalog of Components of Double and Multiple Stars) identifier |
+| 56 | H56 | 339 | A1 | --- | n_CCDM | Historical status flag for CCDM |
+| 57 | H57 | 341-342 | I2 | --- | Nsys | Number of entries with same CCDM |
+| 58 | H58 | 344-345 | I2 | --- | Ncomp | Number of components in this entry |
+| 59 | H59 | 347 | A1 | --- | MultFlag | Double/multiple systems flag (C/G/O/V/X) |
+| 60 | H60 | 349 | A1 | --- | Source | Astrometric source flag (P/F/I/L/S) |
+| 61 | H61 | 351 | A1 | --- | Qual | Solution quality flag (A/B/C/D/S) |
+| 62 | H62 | 353-354 | A2 | --- | m_HIP | Component identifiers |
+| 63 | H63 | 356-358 | I3 | deg | theta | Position angle between components |
+| 64 | H64 | 360-366 | F7.3 | arcsec | rho | Angular separation between components |
+| 65 | H65 | 368-372 | F5.3 | arcsec | e_rho | Standard error on angular separation |
+| 66 | H66 | 374-378 | F5.2 | mag | dHp | Magnitude difference of components |
+| 67 | H67 | 380-383 | F4.2 | mag | e_dHp | Standard error on magnitude difference |
+| 68 | H68 | 385 | A1 | --- | Survey | Survey star flag (`S` if survey star) |
+| 69 | H69 | 387 | A1 | --- | Chart | Identification chart flag (`D`/`G`) |
+| 70 | H70 | 389 | A1 | --- | Notes | Notes existence flag |
+| 71 | H71 | 391-396 | I6 | --- | HD | Henry Draper catalog number |
+| 72 | H72 | 398-407 | A10 | --- | BD | Bonner Durchmusterung identifier |
+| 73 | H73 | 409-418 | A10 | --- | CoD | Cordoba Durchmusterung identifier |
+| 74 | H74 | 420-429 | A10 | --- | CPD | Cape Photographic Durchmusterung identifier |
+| 75 | H75 | 431-434 | F4.2 | mag | (V-I)red | V-I color index used for reductions |
+| 76 | H76 | 436-447 | A12 | --- | SpType | Spectral type string |
+| 77 | H77 | 449 | A1 | --- | r_SpType | Source of spectral type |
+
+### Variability type codes (H52)
+
+| Code | Meaning |
+|:----:|:--------|
+| C | Constant (no detected variability) |
+| D | Duplicity-induced variability |
+| M | Micro-variable |
+| P | Periodic variable |
+| R | Revised color index |
+| U | Unsolved variable |
+
+### Double/multiple systems flag (H59)
+
+| Code | Meaning |
+|:----:|:--------|
+| C | Component solution (individual positions) |
+| G | Acceleration (orbital motion detected) |
+| O | Orbital solution available |
+| V | Variability-induced mover (VIM) |
+| X | Stochastic solution |
+
+### Solution quality (H61)
+
+| Code | Meaning |
+|:----:|:--------|
+| A | Reliable (percentage of rejected data < 10%) |
+| B | Moderately reliable |
+| C | Unreliable |
+| D | Very unreliable |
+| S | Suspected non-single star |
+
+## 5. How Starfield Uses It
+
+### Parsing approach
+
+The Hipparcos parser lives in `src/catalogs/hipparcos.rs`. It reads `hip_main.dat` line by line using a buffered reader, splitting each line on the `|` delimiter and extracting fields by their pipe-delimited index.
+
+```rust
+let fields: Vec<&str> = line.split('|').collect();
+```
+
+Lines are skipped if they:
+- Are shorter than 110 characters (insufficient data)
+- Have fewer than 10 pipe-delimited fields
+- Have an unparseable HIP number (field index 1)
+- Have an unparseable magnitude (field index 5)
+- Have unparseable RA or Dec (field indices 8 and 9)
+
+### Fields extracted
+
+The parser extracts 8 fields into a `HipparcosEntry` struct:
+
+| Struct Field | Pipe Index | Catalog Field | Type | Required |
+|:------------|:----------:|:--------------|:----:|:--------:|
+| `hip` | 1 | HIP | `usize` | Yes |
+| `mag` | 5 | Vmag | `f64` | Yes |
+| `ra` | 8 | RAdeg | `f64` | Yes |
+| `dec` | 9 | DEdeg | `f64` | Yes |
+| `parallax` | 11 | Plx | `Option<f64>` | No |
+| `pm_ra` | 12 | pmRA | `Option<f64>` | No |
+| `pm_dec` | 13 | pmDE | `Option<f64>` | No |
+| `b_v` | 37 | B-V | `Option<f64>` | No |
+
+Required fields cause the line to be skipped if they cannot be parsed. Optional fields default to `None` when absent or unparseable.
+
+### Magnitude filtering
+
+The `from_dat_file` method accepts a `mag_limit` parameter. Stars with `Vmag > mag_limit` are silently excluded (they are not counted as "skipped" in the diagnostic output). The default magnitude limit used by `CatalogSource::Hipparcos` is **8.0**, which retains approximately 40,000 stars visible to the naked eye and binoculars.
+
+### StarData conversion
+
+The `StarCatalog` trait implementation maps each `HipparcosEntry` to a `StarData` struct:
+
+```rust
+StarData::new(star.hip as u64, star.ra, star.dec, star.mag, star.b_v)
+```
+
+This provides a uniform interface across catalog types. The `StarData` struct stores the position as an `Equatorial` coordinate (internally in radians), plus magnitude and optional B-V color index.
+
+### StarCatalog trait
+
+`HipparcosCatalog` implements the full `StarCatalog` trait, providing:
+
+- `get_star(id)` -- lookup by HIP number
+- `stars()` -- iterate over all loaded entries
+- `len()` -- count of loaded entries
+- `filter(predicate)` -- filter entries by arbitrary predicate
+- `star_data()` -- iterate entries as `StarData`
+- `filter_star_data(predicate)` -- filter as `StarData`
+- `brighter_than(magnitude)` -- convenience filter by magnitude
+- `stars_in_field(ra, dec, fov)` -- find stars within a circular field of view
+
+### Cartesian positions
+
+`HipparcosEntry` provides `unit_vector()` and `cartesian_position()` methods. The `cartesian_position()` method converts parallax to distance in parsecs (`1000 / parallax_mas`) and scales the unit direction vector. Returns `None` if parallax is missing or non-positive.
+
+### Storage
+
+Stars are stored in a `HashMap<usize, HipparcosEntry>` keyed by HIP number, providing O(1) lookup by identifier.
+
+## 6. Related Catalogs
+
+### Tycho-2 Catalog
+
+- **Stars:** 2,539,913
+- **Positional accuracy:** ~25 mas at mean epoch, ~60 mas at J2000
+- **Proper motion accuracy:** ~2.5 mas/yr
+- **Origin:** Derived from Hipparcos satellite star mapper data combined with ground-based Astrographic Catalogue
+- **Relation to Hipparcos:** Includes all Hipparcos stars plus additional fainter stars. Tycho-2 proper motions are derived from the ~100-year baseline between the Astrographic Catalogue and the Hipparcos epoch
+- **CDS identifier:** I/259
+
+### Gaia DR3
+
+- **Stars:** ~1.8 billion sources
+- **Positional accuracy:** ~0.01-0.5 mas (depending on magnitude)
+- **Parallax accuracy:** ~0.01-0.5 mas
+- **Proper motion accuracy:** ~0.01-0.5 mas/yr
+- **Reference epoch:** J2016.0
+- **Relation to Hipparcos:** Gaia supersedes Hipparcos for nearly all applications. However, combining Hipparcos (epoch ~1991.25) with Gaia (epoch ~2016.0) provides a ~25-year proper motion baseline that can reveal long-period astrometric binaries and improve acceleration solutions. The Hipparcos-Gaia Catalog of Accelerations (HGCA) exploits this baseline.
+- **In starfield:** Gaia support exists in `src/catalogs/gaia.rs` with `GaiaCatalog` and `GaiaEntry` types
+
+### Bright Star Catalogue (HR/Yale)
+
+- **Stars:** 9,110 (all stars visible to the naked eye, V < 6.5)
+- **Relation to Hipparcos:** A subset. Hipparcos provides much more precise positions and proper motions for these stars.
+
+## 7. Practical Notes
+
+### Auto-download and caching
+
+Calling `starfield::data::downloader::download_hipparcos()` will:
+
+1. Check `~/.cache/starfield/hip_main.dat` -- return immediately if present and non-empty
+2. Check `./hip_main.dat` (project root) -- copy to cache if found
+3. Download from the CDS URL and save to cache
+
+This means the first run on a new machine will download ~51 MB, and subsequent runs use the cached copy.
+
+### Parsing robustness
+
+The parser is deliberately tolerant:
+
+- Lines shorter than 110 characters are silently skipped
+- Lines with fewer than 10 pipe-separated fields are skipped
+- Missing optional fields (`parallax`, `pm_ra`, `pm_dec`, `b_v`) result in `None` rather than errors
+- IO errors on individual lines are logged and skipped
+- An empty file or a file where zero stars pass validation returns an explicit error
+
+### Known data quirks
+
+- **Missing positions:** A small number of catalog entries have blank RA/Dec fields. These are entries where the astrometric solution failed. The parser skips them.
+- **Negative parallaxes:** The catalog contains negative parallax measurements (a statistical artifact for distant stars). The parser stores these as `Option<f64>`, and `cartesian_position()` returns `None` for non-positive parallaxes.
+- **Duplicate HIP numbers:** Not present in the original catalog. The parser uses `HashMap::insert` which would overwrite any duplicates, but this is not expected to occur in practice.
+- **Epoch J1991.25 vs J2000:** The catalog positions are at J1991.25, not J2000. Accurate work requires propagating positions forward using proper motions. The starfield parser currently stores positions as-is at J1991.25.
+- **Proper motion convention:** Field H12 (`pmRA`) is `mu_alpha * cos(delta)`, the proper motion in RA already corrected for the cos(Dec) projection factor. This is the standard convention in modern astrometric catalogs.
+
+### Performance considerations
+
+- Parsing the full catalog (118,218 stars) takes on the order of 100ms on modern hardware
+- The `HashMap` storage allows O(1) lookups by HIP number but does not support spatial indexing natively
+- For field-of-view queries, `stars_in_field()` performs a linear scan with a dot-product angular distance check -- adequate for the catalog size but not optimal for repeated queries over many fields
+- Applying a magnitude limit at load time (e.g., `mag_limit = 8.0`) reduces memory usage by excluding the faintest ~60% of catalog entries
+
+### References
+
+- ESA, 1997, *The Hipparcos and Tycho Catalogues*, ESA SP-1200
+- van Leeuwen, F., 2007, *Hipparcos, the New Reduction of the Raw Data*, Astrophysics and Space Science Library, Vol. 350
+- CDS catalog page: `https://cdsarc.cds.unistra.fr/viz-bin/cat/I/239`

--- a/docs/data-sources/horizons-api.md
+++ b/docs/data-sources/horizons-api.md
@@ -1,0 +1,1435 @@
+# NASA JPL HORIZONS System -- Implementation Reference
+
+This document serves as a comprehensive technical reference for implementing a Rust client
+for the NASA JPL HORIZONS on-line solar system ephemeris computation service.
+
+---
+
+## 1. System Overview
+
+**HORIZONS** is an on-line solar system data and ephemeris computation service provided and
+maintained by the **Solar System Dynamics Group (SSD)** at NASA's **Jet Propulsion Laboratory
+(JPL)**. It provides access to high-precision ephemerides for solar system objects via
+multiple interfaces.
+
+The system computes positions, velocities, and observational quantities for solar system
+bodies as functions of time, from the perspective of any specified observer location.
+
+### Object Coverage
+
+| Category | Count | Notes |
+|----------|-------|-------|
+| Asteroids | 1,479,000+ | All except single-opposition objects with <30-day arcs (NEOs/PHAs excepted) |
+| Comets | 4,043+ | All apparitions with solutions |
+| Natural Satellites (Moons) | 424+ | All known moons with trajectory models |
+| Spacecraft | 239+ | Active and historical missions |
+| Planets | 8 | Mercury through Neptune (plus Pluto) |
+| Dwarf Planets | 5+ | Ceres, Pluto, Eris, Makemake, Haumea |
+| Lagrange Points | 8 | Earth-Sun L1/L2/L4/L5, Earth-Moon L1/L2/L4/L5 |
+| Barycenters | 10 | Solar System Barycenter + 9 planetary system barycenters |
+| Sun | 1 | |
+
+### Update Frequency
+
+- PHAs/NEOs: typically within 2 hours of new observations
+- Other small bodies: few days to 2 weeks
+- Database refresh: hourly with new orbital solutions
+
+### Key Properties
+
+- **No API key required** -- free public service
+- **No authentication** -- all endpoints are open
+- Planetary ephemeris: JPL DE441 (13200 BC to AD 17191 for barycenters)
+- Coordinate frame: ICRF (aligned with J2000 to ~0.0002 arcsec)
+
+---
+
+## 2. API Endpoints
+
+### 2.1 URL API (GET)
+
+```
+GET https://ssd.jpl.nasa.gov/api/horizons.api?{params}
+```
+
+All parameters are passed as URL query string key-value pairs. This is the primary
+programmatic interface.
+
+**Practical URL length limit:** ~2000 characters (browser/proxy dependent). Use the File
+API for larger requests.
+
+### 2.2 File API (POST)
+
+```
+POST https://ssd.jpl.nasa.gov/api/horizons_file.api
+```
+
+For requests that exceed URL length limits (large TLIST arrays, TLE data, etc.).
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `input` | string | Yes | Horizons input file content (key-value pairs between `!$$SOF` and `!$$EOF`) |
+| `format` | string | No | `json` (default) or `text` |
+
+**Input file format:**
+```
+!$$SOF
+COMMAND='499'
+MAKE_EPHEM='YES'
+EPHEM_TYPE='VECTORS'
+CENTER='500@0'
+START_TIME='2024-01-01'
+STOP_TIME='2024-02-01'
+STEP_SIZE='1 d'
+!$$EOF
+```
+
+### 2.3 Lookup API (GET)
+
+```
+GET https://ssd.jpl.nasa.gov/api/horizons_lookup.api?{params}
+```
+
+Resolves names, designations, SPK-IDs, IAU numbers, and MPC packed designations to
+standardized HORIZONS identifiers.
+
+**Parameters:**
+
+| Parameter | Type | Default | Values | Description |
+|-----------|------|---------|--------|-------------|
+| `sstr` | string | *required* | alphanumeric, space, `/`, `'`, `-`, `!`, `=`, `\|`, `.` | Search term |
+| `group` | string | (none) | `ast`, `com`, `pln`, `sat`, `sct`, `mb`, `sb` | Filter by object type |
+| `format` | string | `json` | `json`, `text` | Output format |
+
+**Group codes:**
+
+| Code | Meaning |
+|------|---------|
+| `ast` | Asteroids only |
+| `com` | Comets only |
+| `pln` | Planets only |
+| `sat` | Natural satellites only |
+| `sct` | Spacecraft only |
+| `mb` | All major bodies (planets + satellites + spacecraft) |
+| `sb` | All small bodies (asteroids + comets) |
+
+**Response fields (JSON):**
+
+| Field | Description |
+|-------|-------------|
+| `count` | Number of matches |
+| `name` | Object identifier |
+| `type` | Object category |
+| `pdes` | Primary provisional designation |
+| `spkid` | Primary SPK-ID |
+| `alias` | List of alternate designations |
+| `signature` | API version metadata |
+
+### 2.4 Response Format
+
+All endpoints support `format=json` (default) and `format=text`.
+
+**JSON response structure (ephemeris):**
+```json
+{
+  "signature": {
+    "source": "NASA/JPL Horizons API",
+    "version": "1.3"
+  },
+  "result": "...full text output..."
+}
+```
+
+**JSON response structure (SPK file):**
+```json
+{
+  "signature": {
+    "source": "NASA/JPL Horizons API",
+    "version": "1.3"
+  },
+  "spk": "base64-encoded-binary-data...",
+  "spk_file_id": "suggested_filename.bsp"
+}
+```
+
+**JSON response structure (error):**
+```json
+{
+  "signature": {
+    "source": "NASA/JPL Horizons API",
+    "version": "1.3"
+  },
+  "result": "...error text from Horizons..."
+}
+```
+
+Note: HORIZONS-level errors (invalid object, bad time range, etc.) are returned as HTTP 200
+with the error text inside the `result` field. The client must parse `result` to detect
+these.
+
+### 2.5 HTTP Status Codes
+
+| Code | Meaning | Notes |
+|------|---------|-------|
+| 200 | OK | Check `result` payload for Horizons-level errors |
+| 400 | Bad Request | Invalid keywords, content, or incorrect HTTP method |
+| 405 | Method Not Allowed | Wrong HTTP method (e.g., POST to URL API) |
+| 500 | Internal Server Error | Database unavailable |
+| 503 | Service Unavailable | Server overloaded or maintenance |
+
+---
+
+## 3. Object Identification (`COMMAND` Parameter)
+
+The `COMMAND` parameter selects the target body. Different syntax applies to major bodies
+vs. small bodies.
+
+### 3.1 Major Bodies
+
+Major bodies have pre-computed trajectories interpolated to millimeter-level accuracy from
+stored ephemeris files (DE441). They can serve as both targets and coordinate centers.
+
+| Syntax | Example | Object |
+|--------|---------|--------|
+| Numeric ID | `'499'` | Mars center |
+| Numeric ID | `'301'` | Moon |
+| Numeric ID | `'10'` | Sun |
+| Numeric ID | `'0'` | Solar System Barycenter |
+| Name | `'Mars'` | Mars (case-insensitive) |
+| Name | `'Io'` | Io (501) |
+| List command | `'MB'` | List all major bodies |
+
+### 3.2 Small Bodies (Asteroids and Comets)
+
+Small bodies have statistically estimated orbital elements that are numerically integrated
+on-demand. They **cannot** be used as coordinate centers.
+
+**The semicolon (`;`) suffix is required** to distinguish small bodies from major bodies
+with the same numeric ID. In URLs, encode as `%3B`.
+
+| Syntax | Example (raw) | Example (URL-encoded) | Object |
+|--------|---------------|----------------------|--------|
+| IAU number + `;` | `'1;'` | `COMMAND='1%3B'` | 1 Ceres |
+| IAU number + `;` | `'433;'` | `COMMAND='433%3B'` | 433 Eros |
+| Designation | `'DES=1999 AN10;'` | `COMMAND='DES%3D1999+AN10%3B'` | 1999 AN10 |
+| Designation | `'DES=2020 F3;'` | `COMMAND='DES%3D2020+F3%3B'` | C/2020 F3 (NEOWISE) |
+| Name | `'Apophis;'` | `COMMAND='Apophis%3B'` | 99942 Apophis |
+| SPK-ID | `'DES=2099942;'` | `COMMAND='DES%3D2099942%3B'` | 99942 Apophis (by SPK-ID) |
+| List command | `'SB'` | `COMMAND='SB'` | List small-body search fields |
+
+### 3.3 Search Flags
+
+Append these to the `COMMAND` value for comets:
+
+| Flag | Description |
+|------|-------------|
+| `NOFRAG` | Exclude comet fragments from results |
+| `CAP` | Select closest apparition to current date |
+| `CAP < JD#` | Closest apparition before specified Julian Day |
+| `CAP < YEAR` | Closest apparition before specified year |
+
+Example: `COMMAND='DES=73P; NOFRAG; CAP'`
+
+### 3.4 User-Defined Objects
+
+Set `COMMAND=';'` (URL: `COMMAND='%3B'`) and provide orbital elements via additional
+parameters. See Section 9 for full details.
+
+### 3.5 TLE Objects
+
+Set `COMMAND='TLE'` and provide Two-Line Element data. Up to 600 TLE pairs (1200 lines).
+Newlines encoded as `%0A` in URLs.
+
+### 3.6 Body ID Numbering Scheme
+
+#### Solar System Barycenter and Sun
+
+| ID | Object |
+|----|--------|
+| 0 | Solar System Barycenter (SSB) |
+| 10 | Sun |
+
+#### Planetary System Barycenters
+
+| ID | System |
+|----|--------|
+| 1 | Mercury Barycenter |
+| 2 | Venus Barycenter |
+| 3 | Earth-Moon Barycenter (EMB) |
+| 4 | Mars Barycenter |
+| 5 | Jupiter Barycenter |
+| 6 | Saturn Barycenter |
+| 7 | Uranus Barycenter |
+| 8 | Neptune Barycenter |
+| 9 | Pluto Barycenter |
+
+#### Planet Centers
+
+| ID | Planet |
+|----|--------|
+| 199 | Mercury |
+| 299 | Venus |
+| 399 | Earth |
+| 499 | Mars |
+| 599 | Jupiter |
+| 699 | Saturn |
+| 799 | Uranus |
+| 899 | Neptune |
+| 999 | Pluto |
+
+The pattern is `X99` where `X` is the planetary system number (1-9).
+
+#### Natural Satellites (Moons)
+
+Moons are numbered `X01` through `X99` within each planetary system:
+
+| ID Range | System | Examples |
+|----------|--------|----------|
+| 301 | Earth | 301 = Moon |
+| 401-402 | Mars | 401 = Phobos, 402 = Deimos |
+| 501-599 | Jupiter | 501 = Io, 502 = Europa, 503 = Ganymede, 504 = Callisto |
+| 601-699 | Saturn | 601 = Mimas, 602 = Enceladus, 603 = Tethys, 606 = Titan |
+| 701-799 | Uranus | 701 = Ariel, 702 = Umbriel, 703 = Titania, 704 = Oberon |
+| 801-899 | Neptune | 801 = Triton |
+| 901-999 | Pluto | 901 = Charon |
+
+#### Lagrange Points
+
+| ID | Point |
+|----|-------|
+| 391 | Earth-Sun L1 |
+| 392 | Earth-Sun L2 |
+| 393 | Earth-Sun L4 (leading) |
+| 394 | Earth-Sun L5 (trailing) |
+| 395 | Earth-Moon L1 |
+| 396 | Earth-Moon L2 |
+| 397 | Earth-Moon L4 |
+| 398 | Earth-Moon L5 |
+
+#### Spacecraft (Negative IDs)
+
+| ID | Spacecraft |
+|----|------------|
+| -31 | Voyager 1 |
+| -32 | Voyager 2 |
+| -48 | Hubble Space Telescope (HST) |
+| -64 | OSIRIS-REx (OSIRIS-APEX) |
+| -82 | Cassini |
+| -98 | New Horizons |
+| -143 | Mars Odyssey |
+| -170 | James Webb Space Telescope (JWST) |
+| -227 | Kepler |
+| -234 | STEREO-A |
+| -236 | STEREO-B |
+
+Use `COMMAND='MB'` to get a full listing.
+
+#### Asteroids and Comets (SPK-IDs)
+
+| SPK-ID Range | Type |
+|-------------|------|
+| 2000001+ | Numbered asteroids (SPK-ID = 2000000 + IAU number) |
+| 3000001+ | Unnumbered asteroids |
+| 1000001+ | Comets |
+
+Note: When using the API, reference asteroids by IAU number with semicolon suffix (e.g.,
+`'1;'` for Ceres) rather than by SPK-ID.
+
+---
+
+## 4. Five Ephemeris Types (`EPHEM_TYPE`)
+
+### 4.1 OBSERVER -- Plane-of-Sky Observables
+
+Generates sky-plane observational quantities from a specified observer location.
+
+**Key parameters:**
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `QUANTITIES` | `'A'` | Comma-separated list of quantity codes (1-48) or preset group letter |
+| `CENTER` | geocentric | Observer location |
+| `ANG_FORMAT` | `HMS` | `HMS` or `DEG` for RA/Dec format |
+| `APPARENT` | `AIRLESS` | `AIRLESS` or `REFRACTED` |
+| `EXTRA_PREC` | `NO` | Extra decimal digits in RA/Dec |
+| `CSV_FORMAT` | `NO` | Comma-separated output |
+| `R_T_S_ONLY` | `NO` | Only rise/transit/set events |
+
+#### All 48 Observer Quantity Codes
+
+| Code | Name | Description |
+|------|------|-------------|
+| 1 | Astrometric RA & Dec | ICRF right ascension and declination, corrected for light-time |
+| 2 | Apparent RA & Dec | Apparent RA/Dec in ICRF or of-date frame, with aberration and light deflection |
+| 3 | Rates: RA & Dec | Angular rates of change: `dRA*cos(Dec)` and `d(Dec)/dt` in arcsec/hour |
+| 4 | Apparent Az & El | Apparent azimuth (N=0, E=90) and elevation, topocentric |
+| 5 | Rates: Az & El | Angular rates: `dAz*cos(El)` and `d(El)/dt` in arcsec/minute |
+| 6 | Satellite X & Y | Differential RA/Dec of satellite relative to primary body center, and position angle |
+| 7 | Local Apparent Sidereal Time | Local apparent sidereal time at observer site (HH:MM:SS.ff) |
+| 8 | Airmass & Extinction | Optical airmass and visual magnitude extinction |
+| 9 | Visual Mag & Surface Brightness | Apparent visual magnitude (V-band) and surface brightness (mag/arcsec^2) |
+| 10 | Illuminated Fraction | Fraction of target disk illuminated by Sun (0.0 to 1.0) |
+| 11 | Defect of Illumination | Maximum angular extent of dark limb, in arcsec |
+| 12 | Satellite Angular Separation/Visibility | Satellite-to-primary angular separation with visibility code |
+| 13 | Target Angular Diameter | Apparent angular diameter of target body, in arcsec |
+| 14 | Observer Sub-Longitude & Sub-Latitude | Planetographic/planetocentric longitude and latitude of sub-observer point |
+| 15 | Sun Sub-Longitude & Sub-Latitude | Planetographic/planetocentric longitude and latitude of sub-solar point |
+| 16 | Sub-Sun Position Angle & Distance | Position angle and angular distance of sub-solar point from disk center |
+| 17 | North Pole Position Angle & Distance | Position angle and angular distance of target north pole from disk center |
+| 18 | Heliocentric Ecliptic Lon & Lat | Target heliocentric ecliptic longitude and latitude (J2000 ecliptic) |
+| 19 | Heliocentric Range & Range-Rate | Distance from Sun (AU) and radial velocity (km/s) |
+| 20 | Observer Range & Range-Rate | Distance from observer (AU or km) and radial velocity (km/s) |
+| 21 | One-Way Light-Time | Down-leg light travel time from target to observer (minutes) |
+| 22 | Speed wrt Sun & Observer | Target speed relative to Sun and relative to observer (km/s) |
+| 23 | Sun-Observer-Target Elongation | Solar elongation angle (degrees) with `/r` leading/trailing indicator |
+| 24 | Sun-Target-Observer Phase Angle | Phase angle: Sun-Target-Observer (degrees) |
+| 25 | Target-Observer-Moon / Moon Illumination | Lunar elongation from target (degrees) and Moon illuminated fraction (%) |
+| 26 | Observer-Primary-Target Angle | For satellites: angle between observer, primary body center, and satellite |
+| 27 | Sun-Target Radial & Velocity Position Angle | Position angle of Sun-to-target radius vector and velocity vector |
+| 28 | Orbit Plane Angle | Angle between observer line of sight and target orbital plane |
+| 29 | Constellation ID | 3-letter IAU constellation abbreviation containing the target |
+| 30 | Delta-T (TDB - UT) | Difference TDB minus UT in seconds |
+| 31 | Observer Ecliptic Lon & Lat | Target ecliptic longitude and latitude as seen from observer |
+| 32 | North Pole RA & Dec | Target body north pole ICRF right ascension and declination |
+| 33 | Galactic Longitude & Latitude | Target galactic coordinates (degrees) |
+| 34 | Local Apparent Solar Time | Solar time at observer site (HH:MM:SS.ff) |
+| 35 | Earth-to-Observer-Site Light-Time | Light travel time from Earth center to observer site (seconds); zero for geocentric |
+| 36 | RA & Dec Uncertainty | 1-sigma position uncertainties in RA and Dec (arcsec); small bodies only |
+| 37 | Plane-of-Sky Error Ellipse | 1-sigma POS error ellipse: semi-major axis, semi-minor axis, position angle |
+| 38 | POS Uncertainty (RSS) | Root-sum-square of POS error ellipse axes (arcsec) |
+| 39 | Range & Range-Rate 3-Sigma | 3-sigma uncertainties in range (km) and range-rate (km/s) |
+| 40 | Doppler & Delay 3-Sigma | 3-sigma uncertainties in Doppler shift (Hz) and round-trip delay (seconds) |
+| 41 | True Anomaly Angle | Instantaneous true anomaly angle (degrees) |
+| 42 | Local Apparent Hour Angle | Hour angle of target at observer site |
+| 43 | Phase Angle & Bisector | Phase angle and phase angle bisector longitude/latitude |
+| 44 | Apparent Longitude of Sun (L_s) | Apparent sub-solar longitude on target body; season indicator for Mars |
+| 45 | Inertial Apparent RA & Dec | Apparent RA/Dec in inertial ICRF frame (for spacecraft observers) |
+| 46 | Rate: Inertial RA & Dec | Angular rates of inertial apparent RA/Dec |
+| 47 | Sky Motion: Rate & Angles | Total sky-plane angular rate, position angle of motion, and path angle |
+| 48 | Lunar Sky Brightness & SNR | Estimated V-band sky brightness from scattered moonlight and resulting SNR |
+
+#### Preset Quantity Groups
+
+| Group | Description |
+|-------|-------------|
+| `A` | All available quantities (default) |
+| `B` | Geocentric: custom set for geocentric observer |
+| `C` | Small-body geocentric |
+| `D` | Small-body topocentric |
+| `E` | Spacecraft geocentric |
+| `F` | Spacecraft topocentric |
+
+#### Filtering Options
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `ELEV_CUT` | `-90` | Minimum elevation angle in degrees; range [-90, 90] |
+| `SKIP_DAYLT` | `NO` | Skip output when Sun above horizon (`YES`/`NO`) |
+| `SOLAR_ELONG` | `0,180` | Solar elongation bounds in degrees (min,max) |
+| `AIRMASS` | `38.0` | Maximum airmass cutoff value |
+| `LHA_CUTOFF` | `0.0` | Local hour angle limit (0.0 to 12.0 hours) |
+| `ANG_RATE_CUTOFF` | `0.0` | Minimum plane-of-sky angular rate cutoff (arcsec/hour) |
+| `R_T_S_ONLY` | `NO` | Only output rise/transit/set events |
+
+### 4.2 VECTORS -- Cartesian State Vectors
+
+Generates Cartesian position and velocity vectors in a specified reference frame.
+
+**Key parameters:**
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `VEC_TABLE` | `3` | Table content type (1-6, with optional uncertainty modifiers) |
+| `VEC_CORR` | `NONE` | Aberration correction |
+| `OUT_UNITS` | `KM-S` | Output distance and time units |
+| `REF_PLANE` | `ECLIPTIC` | Reference plane for coordinates |
+| `VEC_LABELS` | `YES` | Include component labels (X, Y, Z, etc.) |
+| `VEC_DELTA_T` | `NO` | Include TDB-UT difference |
+| `CSV_FORMAT` | `NO` | Comma-separated output |
+
+#### VEC_TABLE Types
+
+| Value | Output Columns |
+|-------|---------------|
+| `1` | Position only: X, Y, Z |
+| `2` | State vector: X, Y, Z, VX, VY, VZ |
+| `3` | State + extras: X, Y, Z, VX, VY, VZ, LT, RG, RR (default) |
+| `4` | Position + extras: X, Y, Z, LT, RG, RR |
+| `5` | Velocity only: VX, VY, VZ |
+| `6` | Extras only: LT, RG, RR |
+
+Where the "extras" are:
+- **LT** -- One-way light-time (seconds)
+- **RG** -- Range; distance from coordinate center (km or AU)
+- **RR** -- Range-rate; radial velocity (km/s or AU/day)
+
+#### Uncertainty Modifiers (Small Bodies Only)
+
+Append to VEC_TABLE value (e.g., `'2xa'`):
+
+| Modifier | Uncertainty Coordinate System |
+|----------|-------------------------------|
+| `x` | Cartesian XYZ (sigma_X, sigma_Y, sigma_Z, ...) |
+| `a` | Along-track / Cross-track / Normal (ACN) |
+| `r` | Radial / Transverse / Normal (RTN) |
+| `p` | Plane-of-sky (POS_RA, POS_DEC, POS_range) |
+
+Multiple modifiers can be combined: `'2xarp'` outputs state vector plus all four
+uncertainty systems.
+
+#### VEC_CORR Aberration Corrections
+
+| Value | Description |
+|-------|-------------|
+| `NONE` | Geometric (no correction) |
+| `LT` | Light-time corrected (astrometric) |
+| `LT+S` | Light-time + stellar aberration corrected (apparent) |
+
+#### OUT_UNITS
+
+| Value | Distance | Time |
+|-------|----------|------|
+| `KM-S` | Kilometers | Seconds |
+| `AU-D` | Astronomical Units | Days |
+| `KM-D` | Kilometers | Days |
+
+### 4.3 ELEMENTS -- Keplerian Orbital Elements
+
+Generates osculating orbital elements at each timestep, referenced to a major body center.
+
+**Constraint:** The `CENTER` parameter must be a major body (not a topocentric site).
+
+**Key parameters:**
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `TP_TYPE` | `ABSOLUTE` | Periapsis time format |
+| `OUT_UNITS` | `KM-S` | Output units |
+| `REF_PLANE` | `ECLIPTIC` | Reference plane |
+| `ELM_LABELS` | `YES` | Include element labels |
+| `CSV_FORMAT` | `NO` | Comma-separated output |
+
+#### Output Elements (13 per timestep)
+
+| Symbol | Name | Unit | Description |
+|--------|------|------|-------------|
+| JDTDB | Epoch | Julian Day (TDB) | Julian Date of osculating elements |
+| EC | Eccentricity | dimensionless | 0=circle, <1=ellipse, 1=parabola, >1=hyperbola |
+| QR | Periapsis Distance | AU or km | Closest approach distance to center body |
+| IN | Inclination | degrees | Angle of orbit plane to reference plane |
+| OM | Longitude of Ascending Node | degrees | Direction of orbit plane intersection |
+| W | Argument of Perihelion | degrees | Direction of periapsis within orbit plane |
+| Tp | Periapsis Time | Julian Day (TDB) | Time of periapsis passage |
+| N | Mean Motion | degrees/unit-time | Angular rate: `360/period` |
+| MA | Mean Anomaly | degrees | Position along orbit at epoch |
+| TA | True Anomaly | degrees | True angular position at epoch |
+| A | Semi-Major Axis | AU or km | Mean orbital radius |
+| AD | Apoapsis Distance | AU or km | Farthest distance from center body |
+| PR | Orbital Period | unit-time | Time for one complete orbit |
+
+**TP_TYPE values:**
+
+| Value | Description |
+|-------|-------------|
+| `ABSOLUTE` | Tp as absolute Julian Day number (default) |
+| `RELATIVE` | Tp as days relative to epoch |
+
+### 4.4 SPK -- Binary Ephemeris File Generation
+
+Generates SPICE SPK binary trajectory files for **small bodies only** (asteroids and
+comets).
+
+**Response:**
+
+| JSON Field | Description |
+|------------|-------------|
+| `spk` | Base64-encoded binary SPK file content |
+| `spk_file_id` | Suggested output filename (e.g., `2099942.bsp`) |
+
+**Decoding procedure:**
+1. Parse JSON response
+2. Extract the `spk` field (base64 string)
+3. Base64-decode to raw bytes
+4. Write bytes to a `.bsp` file
+
+**Key details:**
+- Generates **Type 21** SPK segments (Extended Modified Difference Arrays)
+- Provides time-continuous trajectory (not discrete steps)
+- `START_TIME` and `STOP_TIME` are interpreted as **TDB** (not UT)
+- The resulting file can be loaded by the SPICE Toolkit (NAIF)
+- Only `COMMAND`, `START_TIME`, and `STOP_TIME` are meaningful parameters
+
+### 4.5 APPROACH -- Close-Approach Tables
+
+Generates tables of close approaches between a small body and major solar system bodies.
+
+**Key parameters:**
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `CA_TABLE_TYPE` | `STANDARD` | `STANDARD` or `EXTENDED` |
+| `TCA3SG_LIMIT` | `14400` | Max 3-sigma time uncertainty (minutes) |
+| `CALIM_SB` | `0.05` | Small-body close-approach distance limit (AU) |
+| `CALIM_PL` | (see below) | Per-planet distance limits (AU) |
+
+**Default CALIM_PL values** (Mercury through Pluto, comma-separated):
+```
+.1,.1,.1,.1,1.0,1.0,1.0,1.0,.1,.003
+```
+
+| Planet | Default Limit (AU) |
+|--------|-------------------|
+| Mercury | 0.1 |
+| Venus | 0.1 |
+| Earth | 0.1 |
+| Mars | 0.1 |
+| Jupiter | 1.0 |
+| Saturn | 1.0 |
+| Uranus | 1.0 |
+| Neptune | 1.0 |
+| Pluto | 0.1 |
+| Moon | 0.003 |
+
+#### STANDARD Table Fields
+
+| Field | Description |
+|-------|-------------|
+| Date (TDB) | Time of closest approach |
+| Body | Name of close-approach body |
+| CA Dist (AU) | Nominal minimum distance |
+| MinDist (AU) | Minimum possible distance (3-sigma) |
+| MaxDist (AU) | Maximum possible distance (3-sigma) |
+| Vrel (km/s) | Relative velocity at closest approach |
+
+#### EXTENDED Table Fields (15 fields)
+
+| Field | Description |
+|-------|-------------|
+| Date (TDB) | Time of closest approach |
+| Body | Name of close-approach body |
+| CA Dist (AU) | Nominal minimum distance |
+| MinDist (AU) | Minimum possible distance (3-sigma) |
+| MaxDist (AU) | Maximum possible distance (3-sigma) |
+| Vrel (km/s) | Relative velocity at closest approach |
+| TCA3Sg (min) | 3-sigma time-of-CA uncertainty |
+| SMaA-1Sg (km) | B-plane semi-major axis (1-sigma) |
+| SMiA-1Sg (km) | B-plane semi-minor axis (1-sigma) |
+| B.T (km) | B-plane B dot T component |
+| B.R (km) | B-plane B dot R component |
+| Theta (deg) | B-plane orientation angle |
+| Nsig | Number of sigma to LOV intersection |
+| P_i/p | Linearized impact probability |
+| GeoFlag | Flag for geocentric vs. heliocentric |
+
+---
+
+## 5. Reference Systems
+
+### 5.1 REF_SYSTEM
+
+| Value | Description |
+|-------|-------------|
+| `ICRF` | International Celestial Reference Frame (default). Aligned with J2000 to ~0.0002 arcsec. Based on extragalactic radio sources (quasars). |
+| `B1950` | FK4/B1950 dynamical frame. For historical data and older catalogs. |
+
+### 5.2 REF_PLANE (VECTORS and ELEMENTS only)
+
+| Value | Description |
+|-------|-------------|
+| `ECLIPTIC` | Ecliptic and mean equinox of reference epoch (default). For ICRF: IAU76 obliquity at J2000 (84381.448 arcsec). |
+| `FRAME` | Earth mean equator and equinox of reference epoch (equatorial). |
+| `BODY EQUATOR` | IAU body-fixed equatorial frame of the coordinate center body. |
+
+### 5.3 Full Frame List
+
+| Frame | Description | Use Case |
+|-------|-------------|----------|
+| ICRF | Fixed inertial frame; VLBI quasar-based | Default for all computations |
+| Earth True Equator of Date | Precession + nutation (IAU76/80 model) | Apparent RA/Dec for Earth observers |
+| Earth Ecliptic of Date | Dynamic ecliptic plane | Some observer quantities |
+| Ecliptic at J2000 | Fixed ecliptic (IAU76 obliquity) | Asteroid/comet orbital elements |
+| IAU Body-Frame | Body-fixed rotation model | Cartographic coordinates |
+| Lunar Mean Earth Frame | Moon-centric (DE421), 1550-2650 AD | Lunar surface coordinates |
+| FK4/B1950 | Older dynamical frame | Historical data |
+| ITRF93 | Earth body frame + polar motion | Earth station coordinates |
+
+### 5.4 Obliquity Constants
+
+| Frame | Obliquity (arcsec) |
+|-------|-------------------|
+| J2000 ecliptic (with ICRF) | 84381.448 |
+| B1950 ecliptic (with FK4) | 84404.836 |
+
+---
+
+## 6. Coordinate Centers (`CENTER`)
+
+The `CENTER` parameter specifies the observer or coordinate origin location.
+
+### 6.1 Syntax
+
+| Syntax | Example | Meaning |
+|--------|---------|---------|
+| Body ID | `'500'` | Geocenter (Earth center) |
+| Body ID @ Body | `'500@0'` | Solar System Barycenter |
+| Body ID @ Body | `'500@10'` | Heliocenter (Sun center) |
+| Site code | `'675'` | Palomar Mountain Observatory (Earth) |
+| Site @ Body | `'675@399'` | Palomar Mountain on Earth (explicit) |
+| Custom coords | `'coord@399'` | Custom Earth coordinates |
+| Custom coords | `'coord@499'` | Custom Mars coordinates |
+| Geocenter shorthand | `'geo'` or `'g@399'` | Earth geocenter |
+
+### 6.2 Predefined Sites
+
+- **2,300+** predefined Earth observation sites (matches Minor Planet Center list)
+- Includes radar and radio telescope sites (some with negative ID numbers)
+- Sites on other bodies: Apollo landing sites on Moon, Viking on Mars, etc.
+
+**Listing sites:**
+
+| Command | Result |
+|---------|--------|
+| `CENTER='*@399'` | List all Earth sites |
+| `CENTER='*@301'` | List all Moon sites |
+| `CENTER='*@499'` | List all Mars sites |
+
+### 6.3 Custom Coordinates
+
+When `CENTER='coord@BODYID'`, specify the location via:
+
+| Parameter | Description |
+|-----------|-------------|
+| `COORD_TYPE` | `GEODETIC` or `CYLINDRICAL` |
+| `SITE_COORD` | Comma-separated coordinate triplet |
+
+**GEODETIC** (for bodies with defined ellipsoids):
+```
+SITE_COORD = 'East-Longitude, Latitude, Altitude(km)'
+```
+- East-Longitude: degrees east of prime meridian
+- Latitude: geodetic latitude in degrees
+- Altitude: height above reference ellipsoid in km
+
+**CYLINDRICAL** (universal, works for any body):
+```
+SITE_COORD = 'East-Longitude, DXY(km), DZ(km)'
+```
+- East-Longitude: degrees east of prime meridian
+- DXY: distance from spin-axis in km
+- DZ: distance above equator plane in km
+
+**Important longitude conventions:**
+- Earth, Sun, Moon: positive = east longitude (despite prograde rotation)
+- Retrograde rotators (Venus, Uranus moons): positive = east longitude
+- Most prograde bodies: use negative east-longitude (= west-longitude - 360)
+
+### 6.4 Topocentric Sites on Other Bodies
+
+Any body with an IAU rotation model can serve as a topocentric site. The system computes
+local horizon, airmass, rise/set, etc. relative to that body's surface.
+
+---
+
+## 7. Time Specification
+
+### 7.1 TIME_TYPE
+
+| Value | Description |
+|-------|-------------|
+| `UT` | Universal Time. Before 1962: UT1 (Earth rotation). After 1962: UTC with leap seconds. Default for OBSERVER. |
+| `TT` | Terrestrial Time. Proper atomic time on Earth geoid. Differs from TDB by <= 0.002 sec. |
+| `TDB` | Barycentric Dynamical Time. Independent variable of planetary equations. Default for VECTORS, ELEMENTS, APPROACH. |
+
+### 7.2 Input Formats
+
+| Format | Example | Notes |
+|--------|---------|-------|
+| Calendar (recommended) | `'2027-May-5 12:30:23.3348'` | Unambiguous month name |
+| Calendar (numeric) | `'2028-05-04 18:00'` | ISO-like |
+| Calendar (reversed) | `'04-05-2028 18:00'` | DD-MM-YYYY |
+| Calendar (informal) | `'2 jan 1991 3:00:12.2'` | Flexible parsing |
+| Julian Day | `'JD 2451545.0'` | Prefix with "JD" |
+| Julian Day (compact) | `'JD2451545'` | No space |
+| Day-of-Year | `'2016-365//12:00'` | Double-slash separates time |
+| Ancient (BC) | `'278bc-jan-12 12:34'` | "bc" suffix required |
+| Ancient (AD) | `'99ad-Aug-30'` | "ad" suffix for early dates |
+
+### 7.3 STEP_SIZE Modes
+
+| Mode | Syntax | Description |
+|------|--------|-------------|
+| Fixed days | `'1d'`, `'30 days'` | Uniform time step in days |
+| Fixed hours | `'3 h'`, `'12h'` | Uniform time step in hours |
+| Fixed minutes | `'10m'`, `'10 min'` | Uniform time step in minutes |
+| Calendar year | `'1 year'`, `'1 y'` | Calendar-aware stepping |
+| Calendar month | `'1 mo'`, `'3 mo'` | Calendar-aware stepping |
+| N-step | `'100'` | Divide time range into 100 equal intervals |
+| Rise/transit/set | `'1m TVH'` | True visual horizon with refraction |
+| Rise/transit/set | `'5m GEO'` | Geometric horizon with refraction |
+| Rise/transit/set | `'3m RAD'` | Radar horizon (no refraction) |
+| Variable angular | `'VAR 600'` | Output after 600 arcsec sky-plane motion |
+
+**Variable angular range:** 60 to 3600 arcseconds.
+
+**Minimum step size:** 0.5 seconds (achieved via N-step mode for small time ranges).
+
+### 7.4 Discrete Time Lists (TLIST)
+
+Instead of START_TIME/STOP_TIME/STEP_SIZE, provide up to **10,000** discrete times:
+
+| Parameter | Description |
+|-----------|-------------|
+| `TLIST` | Comma-separated list of times |
+| `TLIST_TYPE` | `JD` (Julian Day), `MJD` (Modified Julian Day), or `CAL` (calendar) |
+
+Example:
+```
+TLIST='2451545.0,2451546.0,2451547.5'
+TLIST_TYPE='JD'
+```
+
+When using TLIST, `START_TIME`, `STOP_TIME`, and `STEP_SIZE` are ignored.
+
+### 7.5 Output Format Parameters
+
+| Parameter | Default | Values | Description |
+|-----------|---------|--------|-------------|
+| `TIME_DIGITS` | `MINUTES` | `MINUTES`, `SECONDS`, `FRACSEC` | Timestamp precision |
+| `CAL_FORMAT` | `CAL` | `CAL`, `JD`, `BOTH` | Date column format |
+| `CAL_TYPE` | `MIXED` | `MIXED`, `GREGORIAN` | Calendar system |
+| `TIME_ZONE` | `+00:00` | UTC offset string | Time zone for output |
+
+`CAL_TYPE` values:
+- `MIXED`: Julian calendar before Oct 15 1582, Gregorian after
+- `GREGORIAN`: Gregorian calendar throughout (default for modern work)
+
+### 7.6 Ephemeris Coverage
+
+| Object Class | Coverage |
+|-------------|----------|
+| Planetary barycenters (DE441) | 13200 BC to AD 17191 |
+| Planet centers (e.g., 199, 299) | ~1600 to ~2500 (varies) |
+| Moon (301) | ~13200 BC to AD 17191 (reduced accuracy outside 1550-2650) |
+| Asteroids | Depends on orbit quality; typically decades from epoch |
+| Comets | Depends on apparition; may be single-apparition only |
+| Spacecraft | Mission-specific only; check individual time spans |
+| Lagrange points | Same as parent system |
+
+---
+
+## 8. Physical Constants (`OBJ_DATA=YES`)
+
+When `OBJ_DATA='YES'` (default), the response includes a physical data block before the
+ephemeris table. The available fields depend on the object type.
+
+### Returned Fields (when available)
+
+| Field | Unit | Description |
+|-------|------|-------------|
+| Radius | km | Mean volumetric radius (equatorial, polar, or triaxial) |
+| Density | g/cm^3 | Mean bulk density |
+| Mass | kg | Total mass |
+| GM | km^3/s^2 | Gravitational parameter (mass x G) |
+| Flattening | dimensionless | Oblateness: (R_eq - R_pol) / R_eq |
+| Rotation Period | hours | Sidereal rotation period |
+| Rotation Rate | rad/s | Angular rotation rate |
+| Solar Day | hours | Synodic day length |
+| Surface Gravity | m/s^2 | Equatorial surface gravity |
+| Geometric Albedo | dimensionless | Geometric visual albedo |
+| V(1,0) | mag | Absolute visual magnitude at 1 AU |
+| Obliquity | degrees | Axial tilt to orbital plane |
+| Orbital Period | years or days | Sidereal orbital period |
+| Orbital Speed | km/s | Mean orbital velocity |
+| Escape Speed | km/s | Surface escape velocity |
+| Hill Sphere Radius | AU or km | Gravitational sphere of influence |
+| Angular Diameter | arcsec | As seen from 1 AU |
+| Mean Temperature | K | Surface or cloud-top temperature |
+| Atmospheric Pressure | bar | Surface atmospheric pressure |
+| H (asteroids) | mag | Absolute magnitude parameter |
+| G (asteroids) | dimensionless | Magnitude slope parameter |
+| B-V | mag | Color index |
+| Spectral Type | string | Tholen/SMASSII taxonomic class |
+| Rotation Period | hours | For asteroids |
+| M1, M2 (comets) | mag | Total and nuclear absolute magnitudes |
+| K1, K2 (comets) | dimensionless | Magnitude scaling factors |
+
+### Reference Constants
+
+| Constant | Value | Unit |
+|----------|-------|------|
+| Sun GM | 1.32712440018 x 10^11 | km^3/s^2 |
+| Earth GM | 3.986004418 x 10^5 | km^3/s^2 |
+| Moon GM | 4.9028005821 x 10^3 | km^3/s^2 |
+| AU | 149,597,870.700 | km |
+
+---
+
+## 9. User-Defined Objects
+
+User-defined objects allow ephemeris generation for hypothetical bodies or objects not in
+the HORIZONS database.
+
+### 9.1 Heliocentric Ecliptic Orbital Elements
+
+Set `COMMAND=';'` and provide the following parameters:
+
+#### Required
+
+| Parameter | Unit | Description |
+|-----------|------|-------------|
+| `OBJECT` | string | User-chosen name for the object |
+| `EPOCH` | JD (TDB) | Julian Day of osculating elements (TDB timescale) |
+| `ECLIP` | string | `J2000` or `B1950` -- ecliptic reference |
+| `EC` | dimensionless | Eccentricity |
+
+Plus **one** of these element sets:
+
+**Set A: Periapsis time + distance**
+
+| Parameter | Unit |
+|-----------|------|
+| `TP` | JD (TDB) |
+| `QR` | AU |
+
+**Set B: Mean anomaly + semi-major axis**
+
+| Parameter | Unit |
+|-----------|------|
+| `MA` | degrees |
+| `A` | AU |
+
+**Set C: Mean anomaly + mean motion**
+
+| Parameter | Unit |
+|-----------|------|
+| `MA` | degrees |
+| `N` | degrees/day |
+
+#### Optional Orientation
+
+| Parameter | Unit | Default | Description |
+|-----------|------|---------|-------------|
+| `OM` | degrees | 0.0 | Longitude of ascending node |
+| `W` | degrees | 0.0 | Argument of perihelion |
+| `IN` | degrees | 0.0 | Inclination |
+| `RAD` | km | 0.0 | Object radius |
+
+#### Optional Magnitude Parameters (Asteroids)
+
+| Parameter | Description |
+|-----------|-------------|
+| `H` | Absolute magnitude parameter |
+| `G` | Magnitude slope parameter (default 0.15) |
+
+#### Optional Magnitude Parameters (Comets)
+
+| Parameter | Description |
+|-----------|-------------|
+| `M1` | Total absolute magnitude |
+| `M2` | Nuclear absolute magnitude |
+| `K1` | Total magnitude scaling factor |
+| `K2` | Nuclear magnitude scaling factor |
+| `PHCOF` | Phase coefficient for K2=5 |
+
+#### Optional Non-Gravitational Parameters
+
+| Parameter | Unit | Default | Description |
+|-----------|------|---------|-------------|
+| `A1` | AU/d^2 | 0 | Radial non-gravitational acceleration |
+| `A2` | AU/d^2 | 0 | Transverse non-gravitational acceleration |
+| `A3` | AU/d^2 | 0 | Normal non-gravitational acceleration |
+| `R0` | AU | 2.808 | Normalizing heliocentric distance |
+| `ALN` | dimensionless | 0.1112620426 | Normalizing factor |
+| `NM` | dimensionless | 2.15 | Radial exponent |
+| `NN` | dimensionless | 5.093 | Fall-off exponent |
+| `NK` | dimensionless | 4.6142 | Normalization exponent |
+| `DT` | days | 0 | Non-grav lag/delay (comets) |
+| `AMRAT` | m^2/kg | 0 | Solar radiation pressure area-to-mass ratio |
+
+#### Optional Covariance
+
+| Parameter | Description |
+|-----------|-------------|
+| `SRC` | JPL square-root covariance matrix (upper-triangular, space-separated) |
+| `EST` | Estimated non-gravitational parameter names |
+
+### 9.2 Two-Line Elements (TLE)
+
+Set `COMMAND='TLE'` and provide SGP4/SDP4 geocentric elements:
+
+```
+TLE='ISS (ZARYA)
+1 25544U 98067A   24001.50000000  .00016717  00000-0  10270-3 0  9993
+2 25544  51.6420  30.2134 0002345 210.5678 149.4246 15.49456789123456'
+```
+
+- **Maximum:** 600 TLE pairs (1200 lines + optional name lines)
+- **URL encoding:** Newlines as `%0A`, spaces as `%20`
+- **Propagation:** Standard SGP4/SDP4 model; limited to ~few days forecast accuracy
+
+---
+
+## 10. Small-Body Search/Filter
+
+The `COMMAND` parameter accepts search expressions to find small bodies matching orbital and
+physical criteria. Results are then selectable for ephemeris generation.
+
+### 10.1 Search Syntax
+
+```
+COMMAND='search_expression_1; search_expression_2; ...'
+```
+
+Each expression is `KEYWORD operator VALUE`. Operators: `<`, `>`, `<>` (not equal), `=`.
+
+### 10.2 All Search Keywords
+
+#### Common (Asteroids and Comets)
+
+| Type | Keyword | Description |
+|------|---------|-------------|
+| C | `NAME` | Name fragment (wildcard with `*`) |
+| C | `DES` | Designation (e.g., `1990 MU`, `1993*`) |
+| R | `EPOCH` | Julian Date of osculating elements |
+| R | `A` | Semi-major axis (AU) |
+| R | `EC` | Eccentricity |
+| R | `IN` | Inclination (degrees) |
+| R | `OM` | Longitude of ascending node (degrees) |
+| R | `W` | Argument of perihelion (degrees) |
+| R | `TP` | Perihelion Julian Date |
+| R | `MA` | Mean anomaly (degrees) |
+| R | `PER` | Orbital period (years) |
+| R | `RAD` | Object radius (km) |
+| R | `GM` | Gravitational parameter (km^3/s^2) |
+| R | `QR` | Perihelion distance (AU) |
+| R | `ADIST` | Aphelion distance (AU) |
+| R | `ANGMOM` | Specific angular momentum (AU^2/day) |
+| R | `N` | Mean motion (degrees/day) |
+| R | `DAN` | Distance at ascending node (AU) |
+| R | `DDN` | Distance at descending node (AU) |
+| R | `L` | Ecliptic longitude (degrees) |
+| R | `B` | Ecliptic latitude (degrees) |
+| I | `NOBS` | Number of astrometric observations |
+| C | `SOLN` | Solution ID |
+
+Type key: **C** = character/string, **R** = real/numeric, **I** = integer
+
+#### Asteroid-Specific
+
+| Type | Keyword | Description |
+|------|---------|-------------|
+| C | `ASTNAM` | Asteroid name fragment |
+| R | `B-V` | B-V color index |
+| R | `H` | Absolute magnitude parameter |
+| R | `G` | Magnitude slope parameter |
+| R | `ROTPER` | Rotation period (hours) |
+| R | `ALBEDO` | Geometric albedo |
+| C | `STYP` | Spectral type (Tholen taxonomy) |
+
+#### Comet-Specific
+
+| Type | Keyword | Description |
+|------|---------|-------------|
+| C | `COMNAM` | Comet name fragment |
+| I | `COMNUM` | Comet number |
+| R | `M1` | Total absolute magnitude |
+| R | `M2` | Nuclear absolute magnitude |
+| R | `K1` | Total magnitude scaling factor |
+| R | `K2` | Nuclear magnitude scaling factor |
+| R | `PHCOF` | Phase coefficient |
+| R | `A1` | Radial non-grav acceleration (AU/day^2) |
+| R | `A2` | Transverse non-grav acceleration (AU/day^2) |
+| R | `A3` | Normal non-grav acceleration (AU/day^2) |
+| R | `DT` | Non-grav lag/delay (days) |
+
+### 10.3 Search Directives
+
+| Directive | Description |
+|-----------|-------------|
+| `COM` | Limit search to comets only |
+| `AST` | Limit search to asteroids only |
+| `LIST` | Display parameter values for matching objects |
+| `NOFRAG` | Exclude comet fragments from results |
+| `CAP` | Select closest apparition to current date |
+| `CAP < JD#` | Closest apparition before specified Julian Day |
+| `CAP < YEAR` | Closest apparition before specified integer year |
+
+### 10.4 Search Examples
+
+```
+# S-type asteroids with a < 2.5 AU and i > 7.8 degrees, with known GM
+COMMAND='A < 2.5; IN > 7.8; STYP = S; GM <> 0;'
+
+# Comet 73P, closest apparition, no fragments
+COMMAND='DES = 73P; NOFRAG; CAP'
+
+# All objects with names starting with "mua"
+COMMAND='NAME = mua*;'
+
+# All comets with names containing "her"
+COMMAND='COMNAM = HER*;'
+
+# Asteroids with rotation period < 3 hours
+COMMAND='AST; ROTPER < 3;'
+```
+
+---
+
+## 11. Response Format
+
+### 11.1 JSON Structure
+
+Standard ephemeris responses:
+```json
+{
+  "signature": {
+    "source": "NASA/JPL Horizons API",
+    "version": "1.3"
+  },
+  "result": "full text output including headers, ephemeris data, and footers"
+}
+```
+
+SPK file responses:
+```json
+{
+  "signature": {
+    "source": "NASA/JPL Horizons API",
+    "version": "1.3"
+  },
+  "spk": "base64-encoded-binary-content",
+  "spk_file_id": "suggested_filename.bsp"
+}
+```
+
+### 11.2 Parsing the `result` Field
+
+The `result` field contains the full Horizons text output as a single string. Key
+delimiters for parsing:
+
+| Delimiter | Meaning |
+|-----------|---------|
+| `$$SOE` | **Start Of Ephemeris** -- data rows begin on the next line |
+| `$$EOE` | **End Of Ephemeris** -- data rows end on the previous line |
+
+**Parsing algorithm:**
+1. Split `result` on newlines
+2. Find the line containing `$$SOE`
+3. Find the line containing `$$EOE`
+4. Extract all lines between these delimiters as data rows
+5. Parse each row according to the column format
+
+### 11.3 CSV Output
+
+When `CSV_FORMAT='YES'`:
+- Column headers are included as the first row after `$$SOE`
+- Data values are comma-separated
+- Easier to parse programmatically than fixed-width format
+
+### 11.4 Text (Non-JSON) Format
+
+When `format=text`:
+- First two lines: `API VERSION: X.X` and `API SOURCE: NASA/JPL Horizons API`
+- Followed by blank lines
+- Then the standard Horizons output (same content as `result` field in JSON)
+
+---
+
+## 12. Rate Limits and Practical Concerns
+
+### Rate Limits
+
+- **No API key required**
+- **No published rate limits**
+- Free public service; NASA expects "reasonable use"
+- The service is shared infrastructure; excessive requests may trigger HTTP 503
+
+### Request Size Limits
+
+| Limit | Value |
+|-------|-------|
+| URL length (GET) | ~2000 characters practical limit |
+| TLIST entries | 10,000 maximum |
+| TLE pairs | 600 maximum (1200 lines) |
+| Ephemeris time range | No hard limit, but large requests take time |
+
+### Implementation Recommendations
+
+- Use the File API (POST) for requests that would exceed ~1500 characters in the URL
+- Implement exponential backoff for HTTP 503 responses
+- Cache results where appropriate (ephemeris data is deterministic for given inputs)
+- Use `CSV_FORMAT='YES'` for easier parsing
+- Always check the `result` field for error messages even on HTTP 200 responses
+- Use `OBJ_DATA='NO'` when physical constants are not needed (faster parsing)
+- Set `QUANTITIES` to only the codes actually needed (reduces response size)
+- Prefer `format=json` for programmatic access
+
+### Error Detection
+
+HORIZONS errors in the result text can be identified by patterns such as:
+- `"No ephemeris for target"` -- object not found or time out of range
+- `"Cannot find central body"` -- invalid CENTER
+- `"Ambiguous target name"` -- COMMAND matches multiple objects
+- `"No matches found"` -- search returned no results
+
+For ambiguous matches, the response includes a numbered list of candidates that the client
+can present for disambiguation.
+
+---
+
+## 13. Complete Parameter Reference Table
+
+### Core Parameters (All Ephemeris Types)
+
+| Parameter | Default | Valid Values | Description |
+|-----------|---------|--------------|-------------|
+| `format` | `json` | `json`, `text` | API output format |
+| `COMMAND` | *(required)* | See Section 3 | Target body selection |
+| `OBJ_DATA` | `YES` | `YES`, `NO` | Include physical/orbital data summary |
+| `MAKE_EPHEM` | `YES` | `YES`, `NO` | Generate ephemeris table |
+| `EPHEM_TYPE` | `OBSERVER` | `OBSERVER`, `VECTORS`, `ELEMENTS`, `SPK`, `APPROACH` | Ephemeris type |
+
+### Time Parameters (OBSERVER, VECTORS, ELEMENTS, SPK)
+
+| Parameter | Default | Valid Values | Description |
+|-----------|---------|--------------|-------------|
+| `CENTER` | geocentric | Site code, body ID, `coord@body` | Observer/coordinate center |
+| `START_TIME` | *(required)* | Date string or `JD #` | Ephemeris start time |
+| `STOP_TIME` | *(required)* | Date string or `JD #` | Ephemeris stop time |
+| `STEP_SIZE` | `60 min` | Time step, N-steps, `VAR #` | Output interval |
+| `TLIST` | *(none)* | Comma-separated times | Discrete time list (up to 10,000) |
+| `TLIST_TYPE` | *(none)* | `JD`, `MJD`, `CAL` | Time list format |
+| `TIME_TYPE` | varies | `UT`, `TT`, `TDB` | Input/output timescale |
+| `TIME_DIGITS` | `MINUTES` | `MINUTES`, `SECONDS`, `FRACSEC` | Timestamp precision |
+| `CAL_FORMAT` | `CAL` | `CAL`, `JD`, `BOTH` | Date output format |
+| `CAL_TYPE` | `MIXED` | `MIXED`, `GREGORIAN` | Calendar system |
+| `REF_SYSTEM` | `ICRF` | `ICRF`, `B1950` | Reference frame |
+| `COORD_TYPE` | `GEODETIC` | `GEODETIC`, `CYLINDRICAL` | Custom site coordinate type |
+| `SITE_COORD` | `0,0,0` | Coordinate triplet | Custom site coordinates |
+| `CSV_FORMAT` | `NO` | `YES`, `NO` | Comma-separated output |
+
+### OBSERVER-Specific Parameters
+
+| Parameter | Default | Valid Values | Description |
+|-----------|---------|--------------|-------------|
+| `QUANTITIES` | `A` | `1`-`48` (comma-sep), or `A`-`F` | Observable quantity selection |
+| `ANG_FORMAT` | `HMS` | `HMS`, `DEG` | RA/Dec angle format |
+| `APPARENT` | `AIRLESS` | `AIRLESS`, `REFRACTED` | Refraction correction |
+| `TIME_ZONE` | `+00:00` | UTC offset string | Time zone offset |
+| `RANGE_UNITS` | `AU` | `AU`, `KM` | Range output units |
+| `SUPPRESS_RANGE_RATE` | `NO` | `YES`, `NO` | Suppress range-rate column |
+| `ELEV_CUT` | `-90` | -90 to 90 (integer) | Minimum elevation filter (degrees) |
+| `SKIP_DAYLT` | `NO` | `YES`, `NO` | Skip daylight hours |
+| `SOLAR_ELONG` | `0,180` | Min,Max (degrees) | Solar elongation filter |
+| `AIRMASS` | `38.0` | Decimal value | Maximum airmass cutoff |
+| `LHA_CUTOFF` | `0.0` | 0.0 to 12.0 | Local hour angle limit (hours) |
+| `ANG_RATE_CUTOFF` | `0.0` | Decimal (arcsec/hr) | Minimum angular rate filter |
+| `EXTRA_PREC` | `NO` | `YES`, `NO` | Extra RA/Dec decimal digits |
+| `R_T_S_ONLY` | `NO` | `YES`, `NO` | Only rise/transit/set events |
+
+### VECTORS-Specific Parameters
+
+| Parameter | Default | Valid Values | Description |
+|-----------|---------|--------------|-------------|
+| `VEC_TABLE` | `3` | `1`-`6`, with `x`/`a`/`r`/`p` modifiers | Vector table format |
+| `VEC_CORR` | `NONE` | `NONE`, `LT`, `LT+S` | Aberration correction |
+| `OUT_UNITS` | `KM-S` | `KM-S`, `AU-D`, `KM-D` | Distance/time units |
+| `REF_PLANE` | `ECLIPTIC` | `ECLIPTIC`, `FRAME`, `BODY EQUATOR` | Reference plane |
+| `VEC_LABELS` | `YES` | `YES`, `NO` | Column labels in output |
+| `VEC_DELTA_T` | `NO` | `YES`, `NO` | Include TDB-UT delta |
+
+### ELEMENTS-Specific Parameters
+
+| Parameter | Default | Valid Values | Description |
+|-----------|---------|--------------|-------------|
+| `TP_TYPE` | `ABSOLUTE` | `ABSOLUTE`, `RELATIVE` | Periapsis time format |
+| `OUT_UNITS` | `KM-S` | `KM-S`, `AU-D`, `KM-D` | Output units |
+| `REF_PLANE` | `ECLIPTIC` | `ECLIPTIC`, `FRAME`, `BODY EQUATOR` | Reference plane |
+| `ELM_LABELS` | `YES` | `YES`, `NO` | Element labels in output |
+
+### APPROACH-Specific Parameters
+
+| Parameter | Default | Valid Values | Description |
+|-----------|---------|--------------|-------------|
+| `CA_TABLE_TYPE` | `STANDARD` | `STANDARD`, `EXTENDED` | Table detail level |
+| `TCA3SG_LIMIT` | `14400` | Integer (minutes) | Max 3-sigma time uncertainty |
+| `CALIM_SB` | `0.05` | Decimal (AU) | Small-body distance limit |
+| `CALIM_PL` | `.1,.1,.1,.1,1,1,1,1,.1,.003` | 10 comma-separated AU values | Per-planet distance limits |
+
+### SPK-Specific Parameters
+
+SPK requests only use `COMMAND`, `START_TIME`, and `STOP_TIME`. All other ephemeris
+parameters are ignored. The output is always a Type 21 SPK binary file.
+
+---
+
+## 14. Example Requests
+
+### 14.1 Vector Ephemeris for Mars (from SSB, in AU-D)
+
+```
+GET https://ssd.jpl.nasa.gov/api/horizons.api?format=json&COMMAND='499'&OBJ_DATA='NO'&MAKE_EPHEM='YES'&EPHEM_TYPE='VECTORS'&CENTER='500@0'&START_TIME='2024-01-01'&STOP_TIME='2024-02-01'&STEP_SIZE='1%20d'&OUT_UNITS='AU-D'&REF_PLANE='ECLIPTIC'&VEC_TABLE='2'&VEC_CORR='LT'&CSV_FORMAT='YES'
+```
+
+**Parameters explained:**
+- `COMMAND='499'` -- Mars center
+- `CENTER='500@0'` -- Solar System Barycenter
+- `EPHEM_TYPE='VECTORS'` -- Cartesian state vectors
+- `OUT_UNITS='AU-D'` -- AU and days
+- `VEC_TABLE='2'` -- Position + velocity (X,Y,Z,VX,VY,VZ)
+- `VEC_CORR='LT'` -- Light-time corrected
+- `CSV_FORMAT='YES'` -- CSV output for easy parsing
+
+### 14.2 Orbital Elements for Ceres (heliocentric)
+
+```
+GET https://ssd.jpl.nasa.gov/api/horizons.api?format=json&COMMAND='1%3B'&OBJ_DATA='YES'&MAKE_EPHEM='YES'&EPHEM_TYPE='ELEMENTS'&CENTER='500@10'&START_TIME='2024-01-01'&STOP_TIME='2025-01-01'&STEP_SIZE='30%20d'&REF_PLANE='ECLIPTIC'&TP_TYPE='ABSOLUTE'&CSV_FORMAT='YES'
+```
+
+**Parameters explained:**
+- `COMMAND='1%3B'` -- Ceres (1;) -- semicolon marks small body
+- `CENTER='500@10'` -- Heliocenter (Sun center)
+- `EPHEM_TYPE='ELEMENTS'` -- Keplerian orbital elements
+- `TP_TYPE='ABSOLUTE'` -- Periapsis time as absolute JD
+
+### 14.3 Observer Table for Apophis from Palomar
+
+```
+GET https://ssd.jpl.nasa.gov/api/horizons.api?format=json&COMMAND='Apophis%3B'&OBJ_DATA='YES'&MAKE_EPHEM='YES'&EPHEM_TYPE='OBSERVER'&CENTER='675@399'&START_TIME='2029-04-01'&STOP_TIME='2029-04-30'&STEP_SIZE='1%20h'&QUANTITIES='1,2,9,20,23,24,36,37,47'&ANG_FORMAT='DEG'&EXTRA_PREC='YES'&CSV_FORMAT='YES'
+```
+
+**Parameters explained:**
+- `COMMAND='Apophis%3B'` -- Asteroid Apophis (name search, small-body)
+- `CENTER='675@399'` -- Palomar Mountain Observatory
+- `QUANTITIES='1,2,9,20,23,24,36,37,47'` -- Astrometric RA/Dec, apparent RA/Dec, magnitude, range, elongation, phase angle, uncertainty, error ellipse, sky motion
+- `EXTRA_PREC='YES'` -- Extra decimal digits for precise astrometry
+
+### 14.4 Close-Approach Data for a Near-Earth Object
+
+```
+GET https://ssd.jpl.nasa.gov/api/horizons.api?format=json&COMMAND='99942%3B'&OBJ_DATA='YES'&MAKE_EPHEM='YES'&EPHEM_TYPE='APPROACH'&START_TIME='2024-01-01'&STOP_TIME='2050-01-01'&CA_TABLE_TYPE='EXTENDED'&CALIM_SB='0.2'&TCA3SG_LIMIT='14400'
+```
+
+**Parameters explained:**
+- `COMMAND='99942%3B'` -- Apophis by IAU number
+- `EPHEM_TYPE='APPROACH'` -- Close-approach table
+- `CA_TABLE_TYPE='EXTENDED'` -- Full B-plane details
+- `CALIM_SB='0.2'` -- Show approaches within 0.2 AU
+
+### 14.5 SPK File Generation for an Asteroid
+
+```
+GET https://ssd.jpl.nasa.gov/api/horizons.api?format=json&COMMAND='433%3B'&MAKE_EPHEM='YES'&EPHEM_TYPE='SPK'&START_TIME='2024-01-01'&STOP_TIME='2025-01-01'
+```
+
+**Parameters explained:**
+- `COMMAND='433%3B'` -- 433 Eros
+- `EPHEM_TYPE='SPK'` -- Generate binary SPK file
+- Response will contain `spk` (base64) and `spk_file_id` fields
+
+**Decoding the response (conceptual Rust pseudocode):**
+```rust
+let response: serde_json::Value = client.get(url).send()?.json()?;
+let spk_b64 = response["spk"].as_str().unwrap();
+let spk_bytes = base64::decode(spk_b64)?;
+let filename = response["spk_file_id"].as_str().unwrap();
+std::fs::write(filename, &spk_bytes)?;
+```
+
+### 14.6 Lookup API Query
+
+```
+GET https://ssd.jpl.nasa.gov/api/horizons_lookup.api?sstr=Apophis&group=ast
+```
+
+**Response example:**
+```json
+{
+  "signature": {"source": "NASA/JPL ...", "version": "1.1"},
+  "count": "1",
+  "result": [
+    {
+      "pdes": "99942",
+      "name": "Apophis",
+      "spkid": "2099942",
+      "alias": ["2004 MN4"]
+    }
+  ]
+}
+```
+
+---
+
+## 15. URL Encoding Quick Reference
+
+Characters that must be encoded in URL query parameters:
+
+| Character | Encoding | Common Context |
+|-----------|----------|----------------|
+| `;` (semicolon) | `%3B` | Small-body suffix |
+| ` ` (space) | `%20` or `+` | Designations, step sizes |
+| `=` (equals) | `%3D` | DES= prefix |
+| `@` (at) | `%40` | CENTER site specs |
+| `#` (hash) | `%23` | Fragment identifiers |
+| `&` (ampersand) | `%26` | Would conflict with param separator |
+| `+` (plus) | `%2B` | Would be interpreted as space |
+| `,` (comma) | `%2C` | Usually OK unencoded in values |
+| `/` (slash) | `%2F` | Path separator |
+| `\n` (newline) | `%0A` | TLE line breaks |
+
+---
+
+## 16. Implementation Notes for a Rust Client
+
+### Recommended Crate Dependencies
+
+- `reqwest` -- HTTP client (async or blocking)
+- `serde` / `serde_json` -- JSON deserialization
+- `base64` -- Decoding SPK file responses
+- `url` -- URL construction and encoding
+- `chrono` -- Date/time handling for time parameters
+- `thiserror` -- Error type definitions
+
+### Suggested Type Structure
+
+```
+HorizonsClient
+  |- query(params: EphemerisRequest) -> Result<HorizonsResponse>
+  |- lookup(name: &str, group: Option<ObjectGroup>) -> Result<LookupResponse>
+
+EphemerisRequest
+  |- command: Command (enum: MajorBody(i32), SmallBody(String), TLE(String), UserDefined(...))
+  |- ephem_type: EphemType (enum: Observer, Vectors, Elements, Spk, Approach)
+  |- center: Center (enum: BodyCenter(i32), Site(String), Coordinates{...})
+  |- time_spec: TimeSpec (enum: Range{start, stop, step}, DiscreteList{times, format})
+  |- ... type-specific options ...
+
+HorizonsResponse
+  |- signature: Signature { source: String, version: String }
+  |- result: Option<String>     // text output
+  |- spk: Option<Vec<u8>>       // decoded binary SPK
+  |- spk_file_id: Option<String>
+
+Command
+  |- MajorBody(i32)              // e.g., 499 for Mars
+  |- Asteroid { number: u32 }    // appends semicolon
+  |- Comet { designation: String, flags: Vec<SearchFlag> }
+  |- Designation(String)         // DES=...
+  |- Name(String)                // name search
+  |- TLE(String)                 // two-line elements
+  |- UserDefined(OrbitalElements)
+  |- Search(Vec<SearchCriterion>)
+```
+
+### Key Implementation Considerations
+
+1. **Semicolon handling:** Always append `;` for small bodies; URL-encode as `%3B`
+2. **Error detection:** HTTP 200 does not mean success; always parse `result` for error patterns
+3. **Ambiguity handling:** When HORIZONS returns a disambiguation list, parse it and either auto-select or propagate to the user
+4. **Large requests:** Switch from GET to POST (File API) when the encoded URL would exceed ~1500 characters
+5. **Response parsing:** The `$$SOE` / `$$EOE` delimiters are the primary mechanism for extracting data rows
+6. **SPK decoding:** The `spk` field is standard base64; decode and write as binary
+7. **Time formats:** Support at least ISO calendar format and Julian Day input; handle TDB/TT/UT correctly
+8. **CSV mode:** Strongly prefer `CSV_FORMAT='YES'` for all programmatic parsing; fixed-width format is fragile

--- a/docs/data-sources/sbdb-api.md
+++ b/docs/data-sources/sbdb-api.md
@@ -1,0 +1,1883 @@
+# JPL Small-Body Database (SBDB) API Ecosystem
+
+Implementation reference for building a Rust client crate targeting the JPL SSD/CNEOS API
+service. All information derived from the official JPL documentation at
+<https://ssd-api.jpl.nasa.gov/>.
+
+---
+
+## 1. Overview
+
+The JPL Small-Body Database (SBDB) is the authoritative database of orbital elements,
+physical parameters, and discovery circumstances for all known asteroids and comets
+(approximately 1.5 million objects as of 2026). It is maintained by NASA's Jet Propulsion
+Laboratory Solar System Dynamics (SSD) group and the Center for Near-Earth Object Studies
+(CNEOS).
+
+The API ecosystem exposes 17 individual endpoints. All share these properties:
+
+- **Base URL:** `https://ssd-api.jpl.nasa.gov/`
+- **Method:** HTTP GET (all endpoints)
+- **Auth:** None required. No API keys.
+- **Format:** All responses are JSON
+- **Rate limits:** No published rate limits. Reasonable use expected (avoid aggressive polling)
+- **CORS:** Responses include appropriate CORS headers for browser use
+
+### Common Response Envelope
+
+Every API response includes a `signature` object:
+
+```json
+{
+  "signature": {
+    "version": "string",
+    "source": "string"
+  }
+}
+```
+
+### Common HTTP Status Codes
+
+| Code | Meaning |
+|------|---------|
+| 200  | OK (may include empty results or soft errors) |
+| 300  | Multiple Choices (ambiguous object query matched multiple objects) |
+| 400  | Bad Request (invalid parameters) |
+| 405  | Method Not Allowed (must use GET) |
+| 500  | Internal Server Error (database unavailable) |
+| 503  | Service Unavailable (temporary overload/maintenance) |
+
+### API Catalog
+
+| API | Endpoint | Description |
+|-----|----------|-------------|
+| SBDB | `sbdb.api` | Single object lookup with full detail |
+| SBDB Query | `sbdb_query.api` | Bulk filtered queries across all objects |
+| Close Approach (CAD) | `cad.api` | Asteroid/comet close approaches to planets |
+| Fireball | `fireball.api` | Atmospheric impact events from US Government sensors |
+| Sentry | `sentry.api` | Earth impact risk monitoring |
+| Scout | `scout.api` | NEOCP unconfirmed object analysis |
+| NHATS | `nhats.api` | Human-accessible NEA mission data |
+| Mission Design | `mdesign.api` | Small-body trajectory design |
+| SB Identification | `sb_ident.api` | Identify objects in a field of view |
+| SB Observability | `sbwobs.api` | Observable small bodies for a given night |
+| SB Radar | `sb_radar.api` | Radar astrometry measurements |
+| Horizons | `horizons.api` | Ephemeris generation (query-parameter interface) |
+| Horizons File | `horizons_file.api` | Ephemeris generation (file-based interface) |
+| Horizons Lookup | `horizons_lookup.api` | Horizons body lookup |
+| JD Converter | `jdconv.api` | Julian Day / calendar date converter |
+| Periodic Orbits | `periodic_orbits.api` | Periodic orbit database |
+| SB Satellites | (via `sbdb.api?sat=true`) | Small-body satellite data |
+
+---
+
+## 2. SBDB API (Single Object Lookup)
+
+**Endpoint:** `GET https://ssd-api.jpl.nasa.gov/sbdb.api`
+
+Retrieves comprehensive data for a single small body: orbital elements, physical parameters,
+close-approach data, discovery circumstances, virtual impactor data, radar observations,
+satellite data, and alternate designations.
+
+### 2.1 Request Parameters
+
+#### Object Selection (exactly one required)
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `sstr` | string | Search string: designation, MPC packed form, case-insensitive name, SPK-ID. Wildcard `*` allowed |
+| `spk` | integer | SPK-ID (e.g., `2000433` for Eros) |
+| `des` | string | Designation or IAU number (e.g., `2015 AB`, `141P`, `433`) |
+
+#### Optional Parameters
+
+| Parameter | Type | Default | Values | Description |
+|-----------|------|---------|--------|-------------|
+| `neo` | integer | `0` | `0`, `1`, `2` | NEO filter: 0=all, 1=NEO only, 2=non-NEO match returns minimal data |
+| `alt-des` | boolean | `false` | | Include alternate designations |
+| `alt-spk` | boolean | `false` | | Include alternate SPK-IDs |
+| `full-prec` | boolean | `false` | | Full precision output (16 significant digits) |
+| `soln-epoch` | boolean | `false` | | Orbit at JPL solution epoch instead of MPC epoch |
+| `cd-epoch` | boolean | `false` | | Add calendar date/time of orbit epoch |
+| `cd-tp` | boolean | `false` | | Add calendar date/time of perihelion passage |
+| `cov` | string | (none) | `mat`, `vec`, `src` | Orbital covariance: matrix, vector, or square-root form |
+| `nv-fmt` | string | (none) | `jd`, `cd` | Format for `not_valid_before`/`not_valid_after` |
+| `anc-data` | boolean | `false` | | Output ancillary data availability summary |
+| `no-orbit` | boolean | `false` | | Suppress default orbit output |
+| `alt-orbits` | boolean | `false` | | Output alternate non-default orbit solutions |
+| `orbit-defs` | boolean | `false` | | Output orbit parameter definitions |
+| `sat` | boolean | `false` | | Output satellite data |
+| `phys-par` | boolean | `false` | | Output physical parameters |
+| `ca-data` | boolean | `false` | | Output close-approach data |
+| `ca-body` | string | (all) | `Merc`, `Venus`, `Earth`, `Mars`, `Juptr`, `Satrn`, `Urnus`, `Neptn`, `Pluto`, `Moon` | Limit close approaches to specified body |
+| `ca-time` | string | `cd` | `cd`, `jd`, `both` | Close approach time format |
+| `ca-tunc` | string | `num` | `num`, `fmt`, `both` | Close approach time uncertainty format |
+| `ca-unc` | boolean | `false` | | Include close approach distance uncertainty ellipse |
+| `radar-obs` | boolean | `false` | | Output radar astrometry data |
+| `r-name` | boolean | `false` | | Include radar station names |
+| `r-observer` | boolean | `false` | | Include observer field in radar data |
+| `r-notes` | boolean | `false` | | Include notes field in radar data |
+| `vi-data` | boolean | `false` | | Output virtual impactor (Sentry) data |
+| `discovery` | boolean | `false` | | Output discovery circumstances |
+| `raw-citation` | boolean | `false` | | Output IAU citation in raw LaTeX format |
+
+### 2.2 Response Structure
+
+#### `object` (always present)
+
+```json
+{
+  "object": {
+    "des": "string",
+    "spkid": "string",
+    "fullname": "string",
+    "shortname": "string",
+    "prefix": "string | null",
+    "kind": "string",
+    "neo": true,
+    "pha": true,
+    "orbit_class": {
+      "name": "string",
+      "code": "string"
+    },
+    "orbit_id": "string",
+    "des_alt": [
+      { "des": "string" }
+    ],
+    "spkid_alt": ["string"],
+    "anc_data": {
+      "ca_data": { "count": 0, "ref_url": "string" },
+      "ra_data": { "count": 0, "ref_url": "string" },
+      "vi_data": { "count": 0, "ref_url": "string" },
+      "nhats_data": { "count": 0, "ref_url": "string" }
+    }
+  }
+}
+```
+
+**`kind` values:**
+
+| Code | Meaning |
+|------|---------|
+| `an` | Numbered asteroid |
+| `au` | Unnumbered asteroid |
+| `cn` | Numbered comet |
+| `cu` | Unnumbered comet |
+
+#### `orbit` (default, suppressed with `no-orbit=true`)
+
+```json
+{
+  "orbit": {
+    "orbit_id": "string",
+    "epoch": "string (JD TDB)",
+    "cd_epoch": "string (YYYY-MMM-DD.D, if cd-epoch=true)",
+    "equinox": "string",
+    "elements": [
+      {
+        "name": "string",
+        "label": "string",
+        "title": "string",
+        "value": "string",
+        "sigma": "string",
+        "units": "string | null"
+      }
+    ],
+    "model_pars": [
+      {
+        "n": 0,
+        "kind": "SET | EST | CON",
+        "name": "string",
+        "value": "string",
+        "title": "string",
+        "desc": "string",
+        "sigma": "string",
+        "units": "string | null"
+      }
+    ],
+    "covariance": {
+      "epoch": "string (JD)",
+      "data": [0.0],
+      "labels": ["string"],
+      "elements": []
+    },
+    "cov_epoch": "string (JD)",
+    "moid": "string (AU)",
+    "moid_jup": "string (AU)",
+    "t_jup": "string",
+    "condition_code": "string (0-9 or D)",
+    "rms": "string",
+    "first_obs": "string (YYYY-MM-DD)",
+    "last_obs": "string (YYYY-MM-DD)",
+    "data_arc": "string (days)",
+    "n_obs_used": "string",
+    "n_del_obs_used": "string",
+    "n_dop_obs_used": "string",
+    "pe_used": "string",
+    "sb_used": "string",
+    "two_body": "boolean | null",
+    "soln_date": "string (datetime)",
+    "source": "string (JPL | MPC | SAO)",
+    "producer": "string",
+    "not_valid_before": "string | null",
+    "not_valid_after": "string | null",
+    "comment": "string | null"
+  }
+}
+```
+
+**Orbital elements (`elements` array, by `name`):**
+
+| Name | Label | Units | Description |
+|------|-------|-------|-------------|
+| `e` | Eccentricity | (none) | Orbital eccentricity |
+| `a` | Semi-major axis | AU | Semi-major axis (not defined for parabolic orbits) |
+| `q` | Perihelion distance | AU | Perihelion distance |
+| `i` | Inclination | deg | Orbital inclination w.r.t. ecliptic |
+| `om` | Longitude of ascending node | deg | Longitude of the ascending node |
+| `w` | Argument of perihelion | deg | Argument of perihelion |
+| `tp` | Time of perihelion | JD (TDB) | Time of perihelion passage |
+| `cd_tp` | Time of perihelion (cal.) | (date) | Calendar date of perihelion (if `cd-tp=true`) |
+| `ma` | Mean anomaly | deg | Mean anomaly at epoch |
+| `n` | Mean motion | deg/d | Mean motion |
+| `per` | Orbital period | d | Sidereal orbital period |
+| `ad` | Aphelion distance | AU | Aphelion distance |
+
+#### `phys_par` (if `phys-par=true`)
+
+Array of physical parameter objects:
+
+```json
+{
+  "phys_par": [
+    {
+      "name": "string",
+      "value": "string",
+      "sigma": "string | null",
+      "units": "string | null",
+      "ref": "string | null",
+      "notes": "string | null",
+      "title": "string | null",
+      "desc": "string | null"
+    }
+  ]
+}
+```
+
+**Common physical parameter names:**
+
+| Name | Units | Description |
+|------|-------|-------------|
+| `H` | mag | Absolute magnitude (V-band) |
+| `G` | (none) | Magnitude slope parameter |
+| `diameter` | km | Effective diameter |
+| `extent` | km | Tri-axial body extents |
+| `albedo` | (none) | Geometric albedo |
+| `rot_per` | h | Rotation period |
+| `BV` | mag | Color index B-V |
+| `UB` | mag | Color index U-B |
+| `IR` | (none) | IR albedo |
+| `spec_T` | (none) | Tholen spectral type |
+| `spec_B` | (none) | SMASSII spectral type |
+| `GM` | km^3/s^2 | Standard gravitational parameter |
+| `density` | g/cm^3 | Bulk density |
+| `pole` | (none) | Spin pole direction |
+
+#### `ca_data` (if `ca-data=true`)
+
+Array of close-approach records:
+
+```json
+{
+  "ca_data": [
+    {
+      "body": "string",
+      "jd": "string (JD TDB)",
+      "cd": "string (YYYY-MMM-DD hh:mm)",
+      "sigma_t": "string (minutes)",
+      "sigma_tf": "string (d_hh:mm format)",
+      "dist": "string (AU)",
+      "dist_min": "string (AU)",
+      "dist_max": "string (AU)",
+      "v_rel": "string (km/s)",
+      "v_inf": "string (km/s)",
+      "unc_major": "string (km)",
+      "unc_minor": "string (km)",
+      "unc_angle": "string (deg)",
+      "orbit_ref": "string"
+    }
+  ]
+}
+```
+
+#### `vi_data` (if `vi-data=true`)
+
+Array of virtual impactor records:
+
+```json
+{
+  "vi_data": [
+    {
+      "date": "string (YYYY-MM-DD.DD UTC)",
+      "dt": 0.0,
+      "ps": "string (Palermo scale)",
+      "ts": "string (Torino scale)",
+      "ip": "string (impact probability)",
+      "width": "string (Earth radii)",
+      "energy": "string (Mt TNT)",
+      "stretch": "string (Earth radii/sigma)",
+      "dist": "string (Earth radii)",
+      "sigma_vi": "string",
+      "sigma_lov": "string",
+      "sigma_imp": "string",
+      "v_inf": "string (km/s)",
+      "v_imp": "string (km/s)",
+      "h": "string",
+      "diam": "string (km)",
+      "mass": "string (kg)",
+      "method": "IOBS | LOV | MC"
+    }
+  ]
+}
+```
+
+#### `radar_obs` (if `radar-obs=true`)
+
+```json
+{
+  "radar_obs": [
+    {
+      "epoch": "string (YYYY-MM-DD hh:mm:ss UT)",
+      "value": "string",
+      "sigma": "string",
+      "units": "us | Hz",
+      "freq": "string (MHz)",
+      "rcvr": "string (station code)",
+      "xmit": "string (station code)",
+      "rcvr_name": "string (if r-name=true)",
+      "xmit_name": "string (if r-name=true)",
+      "bp": "C | P",
+      "observer": "string | null (if r-observer=true)",
+      "notes": "string | null (if r-notes=true)"
+    }
+  ]
+}
+```
+
+#### `discovery` (if `discovery=true`)
+
+```json
+{
+  "discovery": {
+    "date": "string (YYYY-MMM-DD)",
+    "location": "string | null",
+    "site": "string | null",
+    "who": "string",
+    "ref": "string",
+    "name": "string | null",
+    "discovery": "string | null",
+    "citation": "string | null",
+    "cref": "string | null"
+  }
+}
+```
+
+#### `sat` (if `sat=true`)
+
+Array of satellite objects:
+
+```json
+{
+  "sat": [
+    {
+      "fullname": "string",
+      "prov_des": "string",
+      "year": 0,
+      "iau_num": 0,
+      "iau_name": "string | null",
+      "oid": "string",
+      "orbit": {},
+      "notes": "string | null",
+      "ref": "string | null"
+    }
+  ]
+}
+```
+
+Satellite orbital elements use meters (not AU) for `a` and `q`.
+
+#### Multiple Object Match (HTTP 300)
+
+```json
+{
+  "code": 300,
+  "message": "specified query matched more than one object",
+  "list": [
+    { "pdes": "string", "name": "string" }
+  ]
+}
+```
+
+---
+
+## 3. SBDB Query API (Bulk Filtered Queries)
+
+**Endpoint:** `GET https://ssd-api.jpl.nasa.gov/sbdb_query.api`
+
+Powerful bulk query interface supporting SQL-like filtering across the entire small-body
+database. Returns tabular data with user-selected columns.
+
+### 3.1 Request Parameters
+
+#### Information Mode
+
+| Parameter | Type | Values | Description |
+|-----------|------|--------|-------------|
+| `info` | string | `count`, `field`, `all` | Returns dataset statistics (`count`), field metadata (`field`), or both (`all`) |
+
+#### Query Mode
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `fields` | string | (none) | Comma-separated field names to return (case-sensitive) |
+| `sort` | string | (none) | Up to 3 fields comma-separated; prefix `-` for descending |
+| `limit` | integer | (none) | Max records to return |
+| `limit-from` | integer | (none) | Pagination offset (requires `limit`) |
+| `full-prec` | boolean | `false` | Full precision output |
+
+#### SBDB Filter Parameters
+
+| Parameter | Type | Values | Description |
+|-----------|------|--------|-------------|
+| `sb-ns` | string | `n`, `u` | Numbered (`n`) or unnumbered (`u`) only |
+| `sb-kind` | string | `a`, `c` | Asteroids (`a`) or comets (`c`) only |
+| `sb-group` | string | see below | Predefined orbital group |
+| `sb-class` | string | see below | Orbit class code(s), comma-separated |
+| `sb-sat` | boolean | | Only objects with known satellites |
+| `sb-xfrag` | boolean | | Exclude comet fragments |
+| `sb-cdata` | string | JSON | Custom field constraints (max 2048 chars) |
+
+**`sb-group` values:**
+
+| Value | Description |
+|-------|-------------|
+| `neo` | Near-Earth Objects |
+| `pha` | Potentially Hazardous Asteroids |
+| `atira` | Atira-class (IEO) |
+| `aten` | Aten-class |
+| `apollo` | Apollo-class |
+| `amor` | Amor-class |
+| `mars-crosser` | Mars-crossing asteroids |
+| `MBA` | Main Belt asteroids (all sub-classes) |
+| `trojan` | Jupiter Trojans |
+| `centaur` | Centaurs |
+| `TNO` | Trans-Neptunian Objects |
+
+### 3.2 Filter Constraint Syntax (`sb-cdata`)
+
+JSON-formatted constraint expressions. Structure:
+
+```json
+{"AND": ["field|operator|value", "field|operator|value"]}
+```
+
+or
+
+```json
+{"OR": ["field|operator|value", "field|operator|value"]}
+```
+
+Individual constraint format: `"FIELD|OPERATOR|VALUE"` or `"FIELD|OPERATOR|VALUE1|VALUE2"`
+for range operators.
+
+**Operators:**
+
+| Code | Meaning | Values Required |
+|------|---------|-----------------|
+| `EQ` | Equal to | 1 |
+| `NE` | Not equal to | 1 |
+| `LT` | Less than | 1 |
+| `GT` | Greater than | 1 |
+| `LE` | Less than or equal to | 1 |
+| `GE` | Greater than or equal to | 1 |
+| `RG` | Inclusive range | 2 (min and max) |
+| `RE` | Regular expression match | 1 (regex pattern) |
+| `DF` | Value is defined (not NULL) | 0 |
+| `ND` | Value is undefined (NULL) | 0 |
+
+**Example:** All PHAs with diameter > 1 km:
+
+```
+sb-group=pha&sb-cdata={"AND":["diameter|GT|1"]}
+```
+
+### 3.3 Queryable Fields
+
+#### Object Identity
+
+| Field | Type | Units | Description |
+|-------|------|-------|-------------|
+| `spkid` | string | | SPK-ID |
+| `full_name` | string | | Full name/designation |
+| `pdes` | string | | Primary designation |
+| `name` | string | | IAU name (if assigned) |
+| `prefix` | string | | Name prefix (e.g., comet type) |
+| `kind` | string | | Object kind: `an`, `au`, `cn`, `cu` |
+| `class` | string | | Orbit classification code |
+| `neo` | string | | `Y` if NEO |
+| `pha` | string | | `Y` if PHA |
+| `orbit_id` | string | | Orbit solution identifier |
+
+#### Orbital Elements
+
+| Field | Type | Units | Description |
+|-------|------|-------|-------------|
+| `epoch` | float | JD (TDB) | Osculation epoch |
+| `equinox` | string | | Reference equinox |
+| `e` | float | (none) | Eccentricity |
+| `a` | float | AU | Semi-major axis |
+| `q` | float | AU | Perihelion distance |
+| `i` | float | deg | Inclination |
+| `om` | float | deg | Longitude of ascending node |
+| `w` | float | deg | Argument of perihelion |
+| `ma` | float | deg | Mean anomaly |
+| `tp` | float | JD (TDB) | Time of perihelion passage |
+| `per` | float | d | Orbital period |
+| `n` | float | deg/d | Mean motion |
+| `ad` | float | AU | Aphelion distance |
+
+#### Orbital Element Uncertainties
+
+| Field | Type | Units | Description |
+|-------|------|-------|-------------|
+| `sigma_e` | float | | 1-sigma uncertainty in eccentricity |
+| `sigma_a` | float | AU | 1-sigma uncertainty in semi-major axis |
+| `sigma_q` | float | AU | 1-sigma uncertainty in perihelion distance |
+| `sigma_i` | float | deg | 1-sigma uncertainty in inclination |
+| `sigma_om` | float | deg | 1-sigma uncertainty in node |
+| `sigma_w` | float | deg | 1-sigma uncertainty in arg. perihelion |
+| `sigma_tp` | float | d | 1-sigma uncertainty in perihelion time |
+| `sigma_ma` | float | deg | 1-sigma uncertainty in mean anomaly |
+| `sigma_per` | float | d | 1-sigma uncertainty in period |
+| `sigma_n` | float | deg/d | 1-sigma uncertainty in mean motion |
+| `sigma_ad` | float | AU | 1-sigma uncertainty in aphelion distance |
+
+#### Derived Orbital Properties
+
+| Field | Type | Units | Description |
+|-------|------|-------|-------------|
+| `t_jup` | float | | Tisserand parameter w.r.t. Jupiter |
+| `moid` | float | AU | Minimum orbit intersection distance (Earth) |
+| `moid_jup` | float | AU | MOID w.r.t. Jupiter |
+| `moid_ld` | float | LD | MOID in lunar distances |
+
+#### Orbit Quality
+
+| Field | Type | Units | Description |
+|-------|------|-------|-------------|
+| `source` | string | | Orbit source (`JPL`, `MPC`, `SAO`) |
+| `soln_date` | string | | Solution date |
+| `producer` | string | | Orbit producer |
+| `data_arc` | float | d | Observational data arc span |
+| `first_obs` | string | | First observation date |
+| `last_obs` | string | | Last observation date |
+| `n_obs_used` | integer | | Number of optical observations used |
+| `n_del_obs_used` | integer | | Number of radar delay observations used |
+| `n_dop_obs_used` | integer | | Number of radar Doppler observations used |
+| `condition_code` | string | | Orbit condition code (0-9, D) |
+| `rms` | float | | Weighted RMS residual of fit |
+| `two_body` | string | | `Y` if 2-body mechanics used |
+
+#### Non-gravitational Parameters
+
+| Field | Type | Units | Description |
+|-------|------|-------|-------------|
+| `A1` | float | AU/d^2 | Radial non-gravitational parameter |
+| `A2` | float | AU/d^2 | Transverse non-gravitational parameter |
+| `A3` | float | AU/d^2 | Normal non-gravitational parameter |
+| `DT` | float | d | Non-gravitational delay parameter |
+
+#### Physical Parameters
+
+| Field | Type | Units | Description |
+|-------|------|-------|-------------|
+| `H` | float | mag | Absolute magnitude |
+| `G` | float | | Magnitude slope parameter |
+| `M1` | float | mag | Total comet magnitude parameter |
+| `M2` | float | mag | Nuclear comet magnitude parameter |
+| `K1` | float | | Total comet magnitude slope |
+| `K2` | float | | Nuclear comet magnitude slope |
+| `PC` | float | | Comet phase coefficient |
+| `diameter` | float | km | Effective body diameter |
+| `extent` | string | km | Tri-axial extents |
+| `GM` | float | km^3/s^2 | Standard gravitational parameter |
+| `density` | float | g/cm^3 | Bulk density |
+| `rot_per` | float | h | Rotation period |
+| `pole` | string | | Spin-pole direction |
+| `albedo` | float | | Geometric albedo |
+| `BV` | float | mag | Color index B-V |
+| `UB` | float | mag | Color index U-B |
+| `IR` | float | | IR albedo |
+| `spec_T` | string | | Tholen spectral type |
+| `spec_B` | string | | SMASSII spectral type |
+
+### 3.4 Orbit Classifications
+
+#### Asteroid Classes
+
+| Code | Name | Definition |
+|------|------|------------|
+| `IEO` | Atira | Interior Earth Object: a < 1.0 AU, Q (aphelion) < 0.983 AU |
+| `ATE` | Aten | a < 1.0 AU, Q > 0.983 AU (Earth-crossing from inside) |
+| `APO` | Apollo | a > 1.0 AU, q < 1.017 AU (Earth-crossing from outside) |
+| `AMO` | Amor | 1.017 AU < q < 1.3 AU (Earth-approaching, non-crossing) |
+| `MCA` | Mars-crosser | 1.3 AU < q < 1.666 AU |
+| `IMB` | Inner Main Belt | 2.0 AU < a < 2.5 AU, q > 1.666 AU |
+| `MBA` | Main Belt | 2.5 AU < a < 2.82 AU, q > 1.666 AU |
+| `OMB` | Outer Main Belt | 2.82 AU < a < 3.27 AU, q > 1.666 AU |
+| `TJN` | Jupiter Trojan | Near Jupiter L4/L5 Lagrange points |
+| `CEN` | Centaur | 5.5 AU < a < 30.1 AU |
+| `TNO` | Trans-Neptunian Object | a > 30.1 AU |
+| `HUN` | Hungaria | 1.78 AU < a < 2.0 AU, e < 0.18, i: 16-34 deg |
+| `HIL` | Hilda | 3.7 AU < a < 4.1 AU (3:2 resonance with Jupiter) |
+| `AST` | Asteroid | Generic asteroid (not otherwise classified) |
+| `PAA` | Parabolic Asteroid | e approximately 1.0 |
+| `HYA` | Hyperbolic Asteroid | e > 1.0 |
+
+#### Comet Classes
+
+| Code | Name | Definition |
+|------|------|------------|
+| `COM` | Comet | Generic long-period comet (P > 200 yr) |
+| `HYP` | Hyperbolic Comet | e > 1.0 (unbound orbit) |
+| `PAR` | Parabolic Comet | e approximately 1.0 |
+| `JFc` | Jupiter-family Comet | 2 < T_Jupiter < 3 |
+| `JFC` | Jupiter-family Comet (alt) | Alternative JFC classification |
+| `HTC` | Halley-type Comet | T_Jupiter < 2, P < 200 yr |
+| `ETc` | Encke-type Comet | a < 2.0 AU, T_Jupiter > 3 (only 2P/Encke) |
+| `CTc` | Chiron-type Comet | T_Jupiter > 3, a > 5.5 AU |
+
+**NEO Definition:** An object with q < 1.3 AU.
+
+**PHA Definition:** An asteroid with MOID <= 0.05 AU and H <= 22.0.
+
+### 3.5 Response Structure
+
+#### Info Mode (`info=count`)
+
+```json
+{
+  "info": {
+    "count": {
+      "au": "string (count of unnumbered asteroids)",
+      "cu": "string (count of unnumbered comets)",
+      "cn": "string (count of numbered comets)",
+      "an": "string (count of numbered asteroids)"
+    }
+  }
+}
+```
+
+#### Query Mode
+
+```json
+{
+  "signature": { "version": "string", "source": "string" },
+  "count": "string",
+  "fields": ["string"],
+  "data": [
+    ["value", "value", ...]
+  ]
+}
+```
+
+Values in the `data` array are strings. The `fields` array provides the column names
+matching the requested `fields` parameter.
+
+---
+
+## 4. Close Approach Data API (CAD)
+
+**Endpoint:** `GET https://ssd-api.jpl.nasa.gov/cad.api`
+
+Returns close-approach data for asteroids and comets approaching the major planets, the Moon,
+and Pluto.
+
+### 4.1 Request Parameters
+
+#### Date Filters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `date-min` | string | `now` | Start date: `YYYY-MM-DD`, `YYYY-MM-DDThh:mm:ss`, or `now` |
+| `date-max` | string | `+60` | End date: same formats, or `+D` for D days from now (max 36525). URL-encode `+` as `%2B` |
+
+#### Distance Filters
+
+| Parameter | Type | Default | Units | Description |
+|-----------|------|---------|-------|-------------|
+| `dist-min` | string | (none) | AU or LD | Minimum approach distance (append `LD` for lunar distances) |
+| `dist-max` | string | `0.05` | AU or LD | Maximum approach distance |
+| `min-dist-min` | string | (none) | AU or LD | Lower bound on 3-sigma minimum possible distance |
+| `min-dist-max` | string | (none) | AU or LD | Upper bound on 3-sigma minimum possible distance |
+
+#### Magnitude/Velocity Filters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `h-min` | float | (none) | Minimum absolute magnitude H |
+| `h-max` | float | (none) | Maximum absolute magnitude H (e.g., 17.75 for larger objects) |
+| `v-inf-min` | float | (none) | Minimum velocity at infinity (km/s) |
+| `v-inf-max` | float | (none) | Maximum velocity at infinity (km/s) |
+| `v-rel-min` | float | (none) | Minimum relative velocity (km/s) |
+| `v-rel-max` | float | (none) | Maximum relative velocity (km/s) |
+
+#### Object Type Filters
+
+| Parameter | Type | Default | Values | Description |
+|-----------|------|---------|--------|-------------|
+| `class` | string | (none) | Orbit class code | Filter by orbit classification |
+| `pha` | boolean | `false` | | PHAs only |
+| `nea` | boolean | `false` | | NEAs only |
+| `comet` | boolean | `false` | | Comets only |
+| `nea-comet` | boolean | `false` | | NEAs and comets |
+| `neo` | boolean | `true` | | NEOs only (default ON) |
+| `kind` | string | (none) | `a`, `an`, `au`, `c`, `cn`, `cu`, `n`, `u` | Object kind filter |
+
+#### Target Body
+
+| Parameter | Type | Default | Values | Description |
+|-----------|------|---------|--------|-------------|
+| `body` | string | `Earth` | `Merc`, `Venus`, `Earth`, `Mars`, `Juptr`, `Satrn`, `Urnus`, `Neptn`, `Pluto`, `Moon`, `ALL` | Close-approach body |
+
+#### Output Control
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `sort` | string | `date` | Sort field: `date`, `dist`, `dist-min`, `v-inf`, `v-rel`, `h`, `object`. Prefix `-` for descending |
+| `limit` | integer | (none) | Max results |
+| `limit-from` | integer | (none) | Pagination offset (requires `limit`) |
+| `total-only` | boolean | `false` | Return only count, no data |
+| `diameter` | boolean | `false` | Include diameter and diameter_sigma |
+| `fullname` | boolean | `false` | Include full object name/designation |
+
+#### Object Selection (optional, for single-object queries)
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `spk` | integer | SPK-ID |
+| `des` | string | Designation (use `%20` for spaces) |
+
+### 4.2 Response Structure
+
+```json
+{
+  "signature": { "version": "1.5", "source": "NASA/JPL SBDB Close Approach Data API" },
+  "count": 0,
+  "total": 0,
+  "fields": ["des", "orbit_id", "jd", "cd", "dist", "dist_min", "dist_max", "v_rel", "v_inf", "t_sigma_f", "h"],
+  "data": [
+    ["string", "string", "string", "string", "string", "string", "string", "string", "string", "string", "string"]
+  ]
+}
+```
+
+**Data fields (positional in arrays):**
+
+| Index | Field | Type | Units | Description |
+|-------|-------|------|-------|-------------|
+| 0 | `des` | string | | Primary designation |
+| 1 | `orbit_id` | string | | Orbit solution ID |
+| 2 | `jd` | string | JD (TDB) | Julian date of close approach |
+| 3 | `cd` | string | | Calendar date/time (TDB) |
+| 4 | `dist` | string | AU | Nominal approach distance |
+| 5 | `dist_min` | string | AU | 3-sigma minimum distance |
+| 6 | `dist_max` | string | AU | 3-sigma maximum distance |
+| 7 | `v_rel` | string | km/s | Relative velocity at close approach |
+| 8 | `v_inf` | string | km/s | Velocity at infinity (v_rel for massless body) |
+| 9 | `t_sigma_f` | string | | Time uncertainty formatted (e.g., `13:02`, `2_09:08`) |
+| 10 | `h` | string | mag | Absolute magnitude |
+| 11 | `diameter` | string/null | km | Diameter (if `diameter=true`) |
+| 12 | `diameter_sigma` | string/null | km | Diameter uncertainty (if `diameter=true`) |
+| 13 | `fullname` | string | | Full name (if `fullname=true`) |
+| 14 | `body` | string | | Approach body name (if `body=ALL`) |
+
+The `fields` array in the response reflects which columns are present based on optional
+output parameters.
+
+---
+
+## 5. Fireball API
+
+**Endpoint:** `GET https://ssd-api.jpl.nasa.gov/fireball.api`
+
+Returns atmospheric fireball (bolide) events detected by US Government sensors.
+
+### 5.1 Request Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `date-min` | string | (none) | Start date: `YYYY-MM-DD` or `YYYY-MM-DDThh:mm:ss` |
+| `date-max` | string | (none) | End date (same format) |
+| `energy-min` | float | (none) | Minimum total radiated energy (joules x 10^10) |
+| `energy-max` | float | (none) | Maximum total radiated energy (joules x 10^10) |
+| `impact-e-min` | float | (none) | Minimum estimated total impact energy (kt TNT) |
+| `impact-e-max` | float | (none) | Maximum estimated total impact energy (kt TNT) |
+| `vel-min` | float | (none) | Minimum velocity (km/s) |
+| `vel-max` | float | (none) | Maximum velocity (km/s) |
+| `alt-min` | float | (none) | Minimum altitude (km) |
+| `alt-max` | float | (none) | Maximum altitude (km) |
+| `req-loc` | boolean | `false` | Require lat/lon data |
+| `req-alt` | boolean | `false` | Require altitude data |
+| `req-vel-comp` | boolean | `false` | Require velocity component data |
+| `vel-comp` | boolean | `false` | Include velocity components in output |
+| `sort` | string | `-date` | Sort field: `date`, `energy`, `impact-e`, `vel`, `alt`. Prefix `-` for descending |
+| `limit` | integer | (none) | Max records |
+
+### 5.2 Response Structure
+
+```json
+{
+  "signature": { "version": "1.2", "source": "NASA/JPL Fireball Data API" },
+  "count": 0,
+  "fields": ["date", "lat", "lat-dir", "lon", "lon-dir", "alt", "energy", "impact-e"],
+  "data": [
+    ["string", "string", "string", "string", "string", "string", "string", "string"]
+  ]
+}
+```
+
+**Data fields:**
+
+| Field | Type | Units | Nullable | Description |
+|-------|------|-------|----------|-------------|
+| `date` | string | | No | Peak brightness date/time `YYYY-MM-DD hh:mm:ss` (GMT) |
+| `lat` | string | deg | Yes | Latitude at peak brightness (decimal degrees) |
+| `lat-dir` | string | | Yes | `N` or `S` |
+| `lon` | string | deg | Yes | Longitude at peak brightness (decimal degrees) |
+| `lon-dir` | string | | Yes | `E` or `W` |
+| `alt` | string | km | Yes | Altitude above geoid |
+| `energy` | string | J x 10^10 | No | Total radiated energy |
+| `impact-e` | string | kt TNT | No | Estimated total impact energy |
+
+**Velocity component fields (if `vel-comp=true`):**
+
+| Field | Type | Units | Nullable | Description |
+|-------|------|-------|----------|-------------|
+| `vx` | string | km/s | Yes | Earth-centered velocity X component |
+| `vy` | string | km/s | Yes | Earth-centered velocity Y component |
+| `vz` | string | km/s | Yes | Earth-centered velocity Z component |
+
+Only `date`, `energy`, and `impact-e` are guaranteed non-null. All other fields may be null.
+
+---
+
+## 6. Sentry API (Impact Risk Monitoring)
+
+**Endpoint:** `GET https://ssd-api.jpl.nasa.gov/sentry.api`
+
+Provides access to the Sentry impact monitoring system, which continuously scans the catalog
+of known asteroids for potential future Earth impacts. Monitors approximately 1,500 objects
+at any given time.
+
+### 6.1 Request Parameters
+
+| Parameter | Type | Default | Range | Description |
+|-----------|------|---------|-------|-------------|
+| `spk` | integer | (none) | | Select specific object by SPK-ID |
+| `des` | string | (none) | | Select specific object by designation |
+| `h-max` | float | (none) | [-10, 100] | Maximum absolute magnitude H |
+| `ps-min` | integer | (none) | [-20, 20] | Minimum cumulative Palermo Scale |
+| `ip-min` | float | (none) | [1e-10, 1] | Minimum impact probability |
+| `days` | integer | (none) | abs > 6 | Observation recency filter (negative inverts) |
+| `all` | boolean | `false` | | Request complete virtual impactor dataset |
+| `removed` | boolean | `false` | | Request list of removed objects |
+
+### 6.2 Query Modes
+
+The mode is determined by parameter combinations:
+
+- **Mode O** (Object): `des` or `spk` specified. Returns detailed data for one object.
+- **Mode S** (Summary): No object selector, no `all` flag. Returns summary table.
+- **Mode V** (Virtual Impactors): `all=true`. Returns full VI table.
+- **Mode R** (Removed): `removed=true`. Returns previously-monitored objects.
+
+### 6.3 Response Structure
+
+#### Mode O: Object Detail
+
+```json
+{
+  "signature": { "version": "2.0", "source": "NASA/JPL Sentry Data API" },
+  "summary": {
+    "des": "string",
+    "fullname": "string",
+    "method": "IOBS | LOV | MC",
+    "ps_cum": "string",
+    "ps_max": "string",
+    "ts_max": "string",
+    "ip": "string",
+    "n_imp": 0,
+    "energy": "string (Mt TNT)",
+    "h": "string",
+    "diameter": "string (km)",
+    "mass": "string (kg)",
+    "v_inf": "string (km/s)",
+    "v_imp": "string (km/s)",
+    "pdate": "string (UTC)",
+    "cdate": "string (Pacific)",
+    "first_obs": "string (UTC)",
+    "last_obs": "string (UTC)",
+    "darc": "string (days)",
+    "nobs": 0,
+    "ndel": 0,
+    "ndop": 0,
+    "nsat": 0
+  },
+  "data": [
+    {
+      "date": "string (YYYY-MM-DD.DD)",
+      "ip": "string",
+      "ps": "string",
+      "ts": "string",
+      "energy": "string (Mt)",
+      "dist": "string (Earth radii, LOV only)",
+      "width": "string (Earth radii, LOV only)",
+      "sigma_imp": "string (LOV only)",
+      "sigma_lov": "string (LOV only)",
+      "stretch": "string (Earth radii/sigma, LOV only)",
+      "sigma_mc": "string (MC only)",
+      "sigma_vi": "string (IOBS only)"
+    }
+  ]
+}
+```
+
+#### Mode S: Summary Table
+
+```json
+{
+  "signature": { "version": "2.0", "source": "NASA/JPL Sentry Data API" },
+  "count": 0,
+  "data": [
+    {
+      "des": "string",
+      "fullname": "string",
+      "id": "string",
+      "h": "string",
+      "diameter": "string (km)",
+      "ip": "string",
+      "ps_cum": "string",
+      "ps_max": "string",
+      "ts_max": "string",
+      "n_imp": 0,
+      "range": "string (year range)",
+      "last_obs": "string",
+      "last_obs_jd": "string",
+      "v_inf": "string (km/s)"
+    }
+  ]
+}
+```
+
+#### Mode R: Removed Objects
+
+```json
+{
+  "signature": { "version": "2.0", "source": "NASA/JPL Sentry Data API" },
+  "count": 0,
+  "data": [
+    {
+      "des": "string",
+      "removed": "string (YYYY-MM-DD HH:MM:SS UTC)"
+    }
+  ]
+}
+```
+
+### 6.4 Palermo Technical Impact Hazard Scale
+
+A logarithmic scale comparing the probability of a detected potential impact to the
+"background" annual probability of an impact of equal or greater energy:
+
+```
+PS = log10(Pi / fB)
+```
+
+Where:
+- `Pi` = impact probability for the detected event
+- `fB` = annual background frequency of impacts at the same energy or greater
+
+| Range | Interpretation |
+|-------|----------------|
+| PS < -2 | No likely consequences; no concern |
+| -2 < PS < 0 | Situation merits careful monitoring |
+| PS > 0 | Impact probability exceeds background; warrants concern |
+
+### 6.5 Torino Impact Hazard Scale
+
+An integer 0-10 scale combining impact probability and kinetic energy, intended for
+public communication:
+
+| Range | Category |
+|-------|----------|
+| 0 | No hazard: negligible collision chance, or object too small to penetrate atmosphere |
+| 1 | Normal: meriting careful monitoring; chance of collision extremely unlikely |
+| 2-4 | Meriting attention by astronomers: uncommon close encounter |
+| 5-7 | Threatening: close encounter posing serious, but uncertain, threat |
+| 8-10 | Certain collision: ranging from local damage (8) to global catastrophe (10) |
+
+---
+
+## 7. Scout API (NEOCP Analysis)
+
+**Endpoint:** `GET https://ssd-api.jpl.nasa.gov/scout.api`
+
+Analyzes unconfirmed objects on the Minor Planet Center's Near-Earth Object Confirmation
+Page (NEOCP). Provides orbit analysis, impact risk assessment, and ephemerides for recently
+discovered objects awaiting confirmation.
+
+### 7.1 Request Parameters
+
+| Parameter | Type | Default | Values | Description |
+|-----------|------|---------|--------|-------------|
+| `tdes` | string | (none) | | NEOCP temporary designation (e.g., `P10uUSw`) |
+| `plot` | string | (none) | `el`, `ca`, `sr`, colon-delimited combos | Plot type(s) for specified object |
+| `file` | string | (none) | `list`, `mpc` | Get list of data files or MPC-format data file |
+| `orbits` | boolean | `false` | | Include sampled orbit data |
+| `n-orbits` | integer | 1000 | [1, 1000] | Max sampled orbits to return |
+| `eph-start` | string | `now` | | Ephemeris start time (YYYY-MM-DD or ISO 8601 or `now`) |
+| `eph-stop` | string | (none) | | Ephemeris stop time |
+| `eph-step` | string | (auto) | `#d`, `#h`, `#m` | Ephemeris step size |
+| `obs-code` | string | `500` | MPC code | Observatory code for ephemeris |
+| `fov-diam` | float | (none) | (0, 1800] | Field-of-view diameter (arcmin) |
+| `fov-ra` | string | median RA | | FOV center RA |
+| `fov-dec` | string | median Dec | | FOV center Dec |
+| `fov-vmag` | float | (none) | [0, 40] | V-magnitude limit for ephemeris |
+| `ranges` | boolean | `false` | | Include topocentric/heliocentric ranges |
+
+### 7.2 Query Modes
+
+- **Mode S** (Summary): No `tdes` specified. Returns summary of all NEOCP objects.
+- **Mode O** (Object): `tdes` specified. Returns detailed data for one object.
+- **Mode E** (Ephemeris): `tdes` + `eph-start` specified. Returns ephemeris data.
+
+### 7.3 Response Structure
+
+#### Mode S: Summary
+
+```json
+{
+  "signature": { "version": "string", "source": "string" },
+  "count": "string",
+  "data": [
+    {
+      "objectName": "string",
+      "nObs": 0,
+      "arc": 0.0,
+      "rmsN": 0.0,
+      "H": 0.0,
+      "rating": 0,
+      "moid": 0.0,
+      "caDist": 0.0,
+      "vInf": 0.0,
+      "phaScore": 0,
+      "neoScore": 0,
+      "geocentricScore": 0,
+      "ieoScore": 0,
+      "tisserandScore": 0,
+      "lastRun": "string (YYYY-MM-DD HH:mm:ss)",
+      "ra": "string",
+      "dec": "string",
+      "elong": "string",
+      "rate": 0.0,
+      "Vmag": 0.0,
+      "unc": 0.0,
+      "uncP1": 0.0
+    }
+  ]
+}
+```
+
+**Key summary fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `objectName` | string | NEOCP temporary designation |
+| `nObs` | integer | Number of observations |
+| `arc` | float | Observation arc (days) |
+| `rmsN` | float | Normalized RMS residual |
+| `H` | float | Estimated absolute magnitude |
+| `rating` | integer | Interest rating (0-100). Higher = more interesting |
+| `moid` | float | Minimum orbit intersection distance (AU) |
+| `caDist` | float | Close approach distance (AU) |
+| `vInf` | float | Velocity at infinity (km/s) |
+| `phaScore` | integer | PHA likelihood score |
+| `neoScore` | integer | NEO likelihood score |
+| `geocentricScore` | integer | Geocentric orbit likelihood |
+| `ieoScore` | integer | Interior Earth orbit likelihood |
+| `tisserandScore` | integer | Tisserand parameter score (comet vs asteroid) |
+| `Vmag` | float | Estimated visual magnitude |
+| `unc` | float | Positional uncertainty (arcsec) |
+| `uncP1` | float | Positional uncertainty at +1 day (arcsec) |
+
+#### Mode O: Object Detail
+
+Same fields as summary plus:
+
+```json
+{
+  "neo1kmScore": "string",
+  "tEphem": "string",
+  "file": {
+    "size": "string | null",
+    "mpc": { "name": "string" }
+  },
+  "orbits": {
+    "count": "string",
+    "fields": ["string"],
+    "data": [["mixed"]]
+  }
+}
+```
+
+**Orbit data fields:** `idx`, `epoch`, `ec`, `qr`, `tp`, `om`, `w`, `inc`, `H`, `dca`,
+`tca`, `moid`, `vinf`, `geoEcc`, `impFlag`
+
+#### Plot Types (base64-encoded PNG)
+
+| Code | Plots Generated |
+|------|----------------|
+| `el` | qr_e_fig, qr_in_fig, qr_H_fig, H_hist_fig |
+| `ca` | moid_hist_fig, ca_dist_cdf_fig, tca_hist_fig, ca_dist_hist_fig |
+| `sr` | rms_sysran_fig, H_sysran_fig |
+
+---
+
+## 8. NHATS API (Near-Earth Asteroid Accessibility)
+
+**Endpoint:** `GET https://ssd-api.jpl.nasa.gov/nhats.api`
+
+Provides data on near-Earth asteroids that are potentially accessible for future human
+exploration missions, based on round-trip trajectory analysis.
+
+### 8.1 Request Parameters
+
+| Parameter | Type | Default | Values | Description |
+|-----------|------|---------|--------|-------------|
+| `dv` | integer | 12 | 4-12 | Maximum total mission delta-v (km/s) |
+| `dur` | integer | 450 | 60-450 in steps of 30 | Maximum total mission duration (days) |
+| `stay` | integer | 8 | 8, 16, 24, 32 | Minimum stay time at asteroid (days) |
+| `launch` | string | `2020-2045` | `2020-2025`, `2025-2030`, `2030-2035`, `2035-2040`, `2040-2045`, `2020-2045` | Launch window |
+| `h` | integer | (none) | 16-30 | Maximum absolute magnitude H (Mode S only) |
+| `occ` | integer | (none) | 0-8 | Maximum orbit condition code (Mode S only) |
+| `spk` | integer | (none) | | Select by SPK-ID (triggers Mode O) |
+| `des` | string | (none) | | Select by designation (triggers Mode O) |
+| `plot` | boolean | `false` | | Include base64-encoded plot image (Mode O only) |
+
+### 8.2 Query Modes
+
+- **Mode S** (Summary): No `des`/`spk`. Returns list of accessible asteroids.
+- **Mode O** (Object): `des` or `spk` specified. Returns detailed trajectory data.
+
+### 8.3 Response Structure
+
+#### Mode S: Summary
+
+```json
+{
+  "signature": { "version": "string", "source": "string" },
+  "count": 0,
+  "data": [
+    {
+      "des": "string",
+      "fullname": "string",
+      "orbit_id": "string",
+      "h": "string",
+      "min_size": "string (meters)",
+      "max_size": "string (meters)",
+      "size": "string (meters) | null",
+      "size_sigma": "string | null",
+      "occ": "string (orbit condition code)",
+      "min_dv": { "dv": "string (km/s)", "dur": "string (days)" },
+      "min_dur": { "dv": "string (km/s)", "dur": "string (days)" },
+      "n_via_traj": 0,
+      "obs_start": "string (YYYY-MM-DD)",
+      "obs_end": "string (YYYY-MM-DD)",
+      "obs_mag": "string",
+      "obs_flag": "string",
+      "radar_obs_a": "string (YYYY-MM-DD) | null",
+      "radar_snr_a": "string | null",
+      "radar_obs_g": "string (YYYY-MM-DD) | null",
+      "radar_snr_g": "string | null"
+    }
+  ]
+}
+```
+
+#### Mode O: Object Detail
+
+Includes all summary fields at top level plus detailed trajectory information:
+
+```json
+{
+  "computed": "string (YYYY-MM-DD)",
+  "min_dv_traj": {
+    "tid": "string",
+    "dv_total": "string (km/s)",
+    "dur_total": "string (days)",
+    "dur_out": "string (days)",
+    "dur_at": "string (days)",
+    "dur_ret": "string (days)",
+    "launch": "string (YYYY-MM-DD)",
+    "c3": "string (km^2/s^2)",
+    "v_dep_earth": "string (km/s)",
+    "dv_dep_park": "string (km/s)",
+    "vrel_arr_neo": "string (km/s)",
+    "vrel_dep_neo": "string (km/s)",
+    "vrel_arr_earth": "string (km/s)",
+    "v_arr_earth": "string (km/s)",
+    "dec_dep": "string (deg)",
+    "dec_arr": "string (deg)"
+  },
+  "min_dur_traj": { }
+}
+```
+
+`min_dur_traj` has the same structure as `min_dv_traj`.
+
+---
+
+## 9. Mission Design API
+
+**Endpoint:** `GET https://ssd-api.jpl.nasa.gov/mdesign.api`
+
+Provides trajectory parameters for planning missions to small bodies. Supports four modes:
+accessible target search, pre-computed mission lookup, porkchop plot generation, and
+flyby/extension target search.
+
+### 9.1 Mode A: Accessible Targets
+
+Find the most accessible small bodies for a given launch window.
+
+| Parameter | Type | Default | Values | Description |
+|-----------|------|---------|--------|-------------|
+| `crit` | integer | (required) | 1-6 | Optimality criterion |
+| `year` | integer | current+4 | | Launch year(s), comma-separated |
+| `lim` | integer | 200 | >0 | Max records |
+
+**Optimality criteria (`crit`):**
+
+| Value | Criterion |
+|-------|-----------|
+| 1 | Minimum departure V-infinity |
+| 2 | Minimum arrival V-infinity |
+| 3 | Minimum total delta-v |
+| 4 | Minimum TOF + minimum departure V-infinity |
+| 5 | Minimum TOF + minimum arrival V-infinity |
+| 6 | Minimum TOF + minimum total delta-v |
+
+**Response fields:** `name`, `date0`, `MJD0`, `datef`, `MJDF`, `c3_dep` (km^2/s^2),
+`vinf_dep` (km/s), `vinf_arr` (km/s), `dv_tot` (km/s), `tof` (days), `class`, `H`,
+`condition_code`, `neo` (Y/N), `pha` (Y/N), `bin` (Y/N), `pdes`
+
+### 9.2 Mode Q: Pre-Computed Missions
+
+Look up pre-computed mission parameters for a specific object.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `des` | string | Designation (one of `des`/`spk`/`sstr` required) |
+| `spk` | integer | SPK-ID |
+| `sstr` | string | Search string |
+| `class` | boolean | If true, return full orbit class name instead of 3-letter code |
+
+**Response:**
+
+```json
+{
+  "object": {
+    "des": "string",
+    "fullname": "string",
+    "spkid": "string",
+    "orbit_class": "string",
+    "condition_code": "string",
+    "data_arc": "string (days)",
+    "orbit_id": "string",
+    "md_orbit_id": "string",
+    "computed_on": "string"
+  },
+  "fields": ["MJD0", "MJDf", "vinf_dep", "vinf_arr", "phase_ang", "earth_dist", "elong_arr", "decl_dep", "approach_ang"],
+  "selectedMissions": [[]]
+}
+```
+
+**Field units:** MJD0/MJDf (Modified Julian Date), vinf_dep/vinf_arr (km/s), phase_ang (deg),
+earth_dist (AU), elong_arr (deg), decl_dep (deg), approach_ang (deg)
+
+### 9.3 Mode M: Porkchop Plot Maps
+
+Generate 2D trajectory parameter grids for visualization.
+
+Additional parameters beyond Mode Q:
+
+| Parameter | Type | Range | Description |
+|-----------|------|-------|-------------|
+| `mjd0` | integer | 33282-73459 | First launch date (MJD) |
+| `span` | integer | 10-9200 | Launch date period duration (days) |
+| `tof-min` | integer | 10-9200 | Minimum time of flight (days) |
+| `tof-max` | integer | 10-9200 | Maximum time of flight (days) |
+| `step` | integer | 1,2,5,10,15,20,30 | Time step (days) |
+
+**Response includes 2D arrays:** `vinf_dep`, `vinf_arr`, `phase_ang`, `earth_dist`,
+`elong_arr`, `decl_dep`, `approach_ang` -- each n x m where n = TOF steps, m = departure date steps.
+
+### 9.4 Mode T: Flyby/Extension Target Search
+
+Find small bodies that pass near a given trajectory.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ec` | float | Eccentricity of reference orbit |
+| `qr` | float | Perihelion distance (AU) |
+| `tp` | float | Time of perihelion passage (JD) |
+| `in` | float | Inclination (deg) |
+| `om` | float | Longitude of ascending node (deg) |
+| `w` | float | Argument of periapsis (deg) |
+| `jd0` | float | Start of time span (JD) |
+| `jdf` | float | End of time span (JD); max span 1 year |
+| `maxout` | integer | Max output records |
+| `maxdist` | float | Max close-approach distance (AU) |
+
+**Response data fields:** `full_name`, `date`, `jd`, `min_dist_au`, `min_dist_km`,
+`rel_vel` (km/s), `class`, `H`, `condition_code`, `neo`, `pha`, `sats`, `spkid`, `pdes`
+
+---
+
+## 10. Small-Body Identification API
+
+**Endpoint:** `GET https://ssd-api.jpl.nasa.gov/sb_ident.api`
+
+Identifies known small bodies within a specified field of view at a given observation time.
+Useful for image analysis and observation planning.
+
+### 10.1 Request Parameters
+
+#### Observer Location (one method required)
+
+**Method 1: MPC Observatory Code**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `mpc-code` | string | MPC observer location code |
+
+**Method 2: Geodetic Coordinates**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `lat` | float | | Latitude (deg, north-positive) [-90, 90] |
+| `lon` | float | | Longitude (deg, east-positive) [-180, 180] |
+| `alt` | float | 0 | Altitude above WGS-84 ellipsoid (km) |
+
+**Method 3: Parallax Constants**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `lon` | float | Longitude (deg, east-positive) |
+| `dxy` | float | Parallax constant perpendicular to spin axis (AU x 10^7) |
+| `dz` | float | Parallax constant along spin axis (AU x 10^7) |
+
+**Method 4: Geocentric State Vector**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `xobs` | string | Position (km) and optional velocity (km/s), J2000 equatorial, comma-separated |
+
+**Method 5: Heliocentric State Vector**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `xobs-hel` | string | Position (AU) and optional velocity (AU/d), J2000 equatorial, comma-separated |
+
+#### Observation Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `obs-time` | string | (required) | `YYYY-MM-DD[_hh:mm:ss]` or Julian Date |
+| `vmag-lim` | float | (none) | Visual magnitude threshold |
+
+#### Field of View (one method required)
+
+**Method 1: FOV Edges**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `fov-ra-lim` | string | RA edges: `hh-mm-ss[.ss]` comma-separated. Use `M` prefix for negative |
+| `fov-dec-lim` | string | Dec edges: `dd-mm-ss[.ss]` comma-separated. Use `M` prefix for negative |
+
+**Method 2: FOV Center + Half-Width**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `fov-ra-center` | string | | Center RA: `hh-mm-ss[.ss]` |
+| `fov-dec-center` | string | | Center Dec: `dd-mm-ss[.ss]` |
+| `fov-ra-hwidth` | float | 0.5 | Half-width in RA (deg) |
+| `fov-dec-hwidth` | float | 0.5 | Half-width in Dec (deg) |
+
+#### Filtering
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `two-pass` | boolean | `false` | Second pass with high-fidelity numerical integration |
+| `mag-required` | boolean | `true` | Skip objects lacking magnitude parameters |
+| `suppress-first-pass` | boolean | `true` | Suppress first-pass output when two-pass is true |
+| `sb-kind` | string | (none) | Object type: `a` (asteroids) |
+| `sb-group` | string | (none) | Group: `neo`, etc. |
+| `req-elem` | boolean | `false` | Include osculating orbital elements |
+
+### 10.2 Response Structure
+
+```json
+{
+  "signature": { "version": "1.1", "source": "NASA/JPL Small-Body Identification API" },
+  "summary": {},
+  "observer": {
+    "obs_date": "string",
+    "location": "string",
+    "fov_center": "string",
+    "fov_offset": "string",
+    "frame": "J2000"
+  },
+  "n_first_pass": 0,
+  "n_second_pass": 0,
+  "fields_first": ["string"],
+  "fields_second": ["string"],
+  "data_first_pass": [[]],
+  "data_second_pass": [[]],
+  "elem_first_pass": [[]],
+  "elem_second_pass": [[]],
+  "sb_constraints": {}
+}
+```
+
+**Data columns (when `req-elem=false`):** Object name, Astrometric RA, Astrometric Dec,
+RA offset (arcsec), Dec offset (arcsec), total offset (arcsec), visual magnitude V,
+RA rate (deg/s), Dec rate (deg/s), RA error estimate (arcsec, first-pass only),
+Dec error estimate (arcsec, first-pass only).
+
+**Element columns (when `req-elem=true`):** Object name, H, G, e, q (AU), tp (JD),
+om (deg), w (deg), i (deg), epoch (JD).
+
+---
+
+## 11. SB Radar API
+
+**Endpoint:** `GET https://ssd-api.jpl.nasa.gov/sb_radar.api`
+
+Returns radar astrometry measurement data for small bodies.
+
+### 11.1 Request Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `spk` | integer | (none) | Select by SPK-ID |
+| `des` | string | (none) | Select by designation |
+| `kind` | string | (none) | Object type: `a`, `an`, `au`, `c`, `cn`, `cu`, `n`, `u` |
+| `bp` | string | (none) | Reference point: `P` (peak/center), `C` (center of mass) |
+| `type` | string | (none) | Measurement type: `R` (range/delay), `P` (Doppler) |
+| `observer` | boolean | `false` | Include observer field |
+| `notes` | boolean | `false` | Include notes field |
+| `ref` | boolean | `false` | Include reference field |
+| `fullname` | boolean | `false` | Include full object name |
+| `modified` | boolean | `false` | Include modification date |
+| `coords` | boolean | `false` | Include station geodetic coordinates |
+| `c-coords` | boolean | `false` | Use cylindrical station coordinates instead |
+
+### 11.2 Response Structure
+
+```json
+{
+  "signature": { "version": "string", "source": "string" },
+  "count": "string",
+  "fields": ["string"],
+  "data": [[]]
+}
+```
+
+**Standard fields:** `des`, `epoch`, `value`, `sigma`, `units` (us or Hz), `freq` (MHz),
+`rcvr`, `xmit`, `bp`
+
+**Optional fields:** `observer`, `notes`, `ref`, `fullname`, `modified`
+
+**Geodetic coordinates:** `longitude` (deg), `latitude` (deg), `altitude`, `alt_units`
+
+**Cylindrical coordinates:** `longitude` (deg), `d_xy` (10^-10 AU), `d_z` (10^-10 AU)
+
+---
+
+## 12. SB Observability API
+
+**Endpoint:** `GET https://ssd-api.jpl.nasa.gov/sbwobs.api`
+
+Determines which small bodies are optically observable from a specified observatory on a
+given night.
+
+### 12.1 Request Parameters
+
+#### Observer Location (one method required)
+
+Same location methods as SB Identification API (MPC code, geodetic, parallax).
+
+#### Observation Constraints
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `obs-time` | string | (required) | Observation date: `YYYY-MM-DD[_hh:mm:ss]` |
+| `obs-end` | string | (none) | End observation time |
+| `optical` | boolean | `true` | Require sun below horizon |
+| `elong-min` | float | (none) | Minimum solar elongation (deg, required if `optical=false`) |
+| `elong-max` | float | (none) | Maximum solar elongation (deg) |
+| `glat-min` | float | (none) | Minimum galactic latitude (deg) |
+| `glat-max` | float | (none) | Maximum galactic latitude (deg) |
+| `elev-min` | float | 30 | Minimum elevation above horizon (deg) |
+| `time-min` | integer | 0 | Minimum observable time (minutes) |
+| `vmag-min` | float | (none) | Minimum visual magnitude |
+| `vmag-max` | float | (none) | Maximum visual magnitude |
+| `mag-required` | boolean | `false` | Require magnitude data |
+| `helio-min` | float | (none) | Minimum heliocentric distance (AU) |
+| `helio-max` | float | (none) | Maximum heliocentric distance (AU) |
+| `dist-min` | float | (none) | Minimum topocentric distance (AU) |
+| `dist-max` | float | (none) | Maximum topocentric distance (AU) |
+
+#### Output Control
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `fmt-ra-dec` | boolean | `true` | Sexagesimal format (false = decimal degrees) |
+| `maxoutput` | integer | (none) | Max records |
+| `output-sort` | string | (none) | Sort field: `name`, `rise`, `trans`, `set`, `maxt`, `ra`, `dec`, `vmag`, `helio`, `topo`, `oes`, `oem`, `glat` |
+| `output-sort-r` | boolean | `false` | Descending sort |
+
+SBDB filter parameters (`sb-kind`, `sb-group`, `sb-class`, etc.) are also supported.
+
+### 12.2 Response Structure
+
+Contains night information (sunrise/sunset, twilight times, moon data) and observable
+object array. Each object record includes: designation, full name, rise/transit/set times (UT),
+max observable time, RA, Dec, visual magnitude, heliocentric range (AU), topocentric range (AU),
+sun angle (deg), moon angle (deg), galactic latitude (deg).
+
+---
+
+## 13. Data Fields Reference
+
+### Comprehensive Field Table
+
+| Field | Category | Type | Units | APIs |
+|-------|----------|------|-------|------|
+| `spkid` | Identity | string | | SBDB, Query |
+| `full_name` / `fullname` | Identity | string | | All |
+| `des` / `pdes` | Identity | string | | All |
+| `name` | Identity | string | | Query |
+| `prefix` | Identity | string | | SBDB, Query |
+| `kind` | Identity | string | | SBDB, Query, CAD |
+| `neo` | Identity | boolean/string | | SBDB, Query |
+| `pha` | Identity | boolean/string | | SBDB, Query |
+| `class` | Identity | string | | Query, CAD, MDesign |
+| `orbit_id` | Identity | string | | SBDB, Query, NHATS |
+| `e` | Orbital | float | (none) | SBDB, Query |
+| `a` | Orbital | float | AU | SBDB, Query |
+| `q` | Orbital | float | AU | SBDB, Query |
+| `i` | Orbital | float | deg | SBDB, Query |
+| `om` | Orbital | float | deg | SBDB, Query |
+| `w` | Orbital | float | deg | SBDB, Query |
+| `ma` | Orbital | float | deg | SBDB, Query |
+| `tp` | Orbital | float | JD (TDB) | SBDB, Query |
+| `n` | Orbital | float | deg/d | SBDB, Query |
+| `per` | Orbital | float | d | SBDB, Query |
+| `ad` | Orbital | float | AU | SBDB, Query |
+| `epoch` | Orbital | float | JD (TDB) | SBDB, Query |
+| `t_jup` | Derived | float | (none) | SBDB, Query |
+| `moid` | Derived | float | AU | SBDB, Query, Scout |
+| `moid_jup` | Derived | float | AU | SBDB, Query |
+| `moid_ld` | Derived | float | LD | Query |
+| `condition_code` | Quality | string | | SBDB, Query, NHATS, MDesign |
+| `data_arc` | Quality | float | d | SBDB, Query, Sentry |
+| `n_obs_used` | Quality | integer | | SBDB, Query |
+| `n_del_obs_used` | Quality | integer | | SBDB, Query |
+| `n_dop_obs_used` | Quality | integer | | SBDB, Query |
+| `rms` | Quality | float | | SBDB, Query |
+| `source` | Quality | string | | SBDB, Query |
+| `producer` | Quality | string | | SBDB, Query |
+| `soln_date` | Quality | string | | SBDB, Query |
+| `first_obs` | Quality | string | | SBDB, Query, Sentry |
+| `last_obs` | Quality | string | | SBDB, Query, Sentry |
+| `two_body` | Quality | string | | SBDB, Query |
+| `H` | Physical | float | mag | SBDB, Query, CAD, Sentry, Scout, NHATS, MDesign |
+| `G` | Physical | float | (none) | SBDB, Query |
+| `M1` | Physical | float | mag | Query (comets) |
+| `M2` | Physical | float | mag | Query (comets) |
+| `K1` | Physical | float | (none) | Query (comets) |
+| `K2` | Physical | float | (none) | Query (comets) |
+| `PC` | Physical | float | (none) | Query (comets) |
+| `diameter` | Physical | float | km | SBDB, Query, Sentry, NHATS |
+| `extent` | Physical | string | km | SBDB, Query |
+| `GM` | Physical | float | km^3/s^2 | SBDB, Query |
+| `density` | Physical | float | g/cm^3 | SBDB, Query |
+| `rot_per` | Physical | float | h | SBDB, Query |
+| `pole` | Physical | string | | SBDB, Query |
+| `albedo` | Physical | float | (none) | SBDB, Query |
+| `BV` | Physical | float | mag | SBDB, Query |
+| `UB` | Physical | float | mag | SBDB, Query |
+| `IR` | Physical | float | (none) | SBDB, Query |
+| `spec_T` | Physical | string | | SBDB, Query |
+| `spec_B` | Physical | string | | SBDB, Query |
+| `A1` | Non-grav | float | AU/d^2 | Query |
+| `A2` | Non-grav | float | AU/d^2 | Query |
+| `A3` | Non-grav | float | AU/d^2 | Query |
+| `DT` | Non-grav | float | d | Query |
+| `jd` | Close-approach | string | JD (TDB) | CAD |
+| `cd` | Close-approach | string | | CAD |
+| `dist` | Close-approach | string | AU | CAD, Sentry |
+| `dist_min` | Close-approach | string | AU | CAD |
+| `dist_max` | Close-approach | string | AU | CAD |
+| `v_rel` | Close-approach | string | km/s | CAD, MDesign |
+| `v_inf` | Close-approach | string | km/s | CAD, Sentry, Scout |
+| `t_sigma_f` | Close-approach | string | | CAD |
+| `body` | Close-approach | string | | CAD |
+| `ip` | Impact | string | (probability) | Sentry |
+| `ps` / `ps_cum` / `ps_max` | Impact | string | (log scale) | Sentry |
+| `ts` / `ts_max` | Impact | string | (0-10) | Sentry |
+| `n_imp` | Impact | integer | | Sentry |
+| `energy` | Impact | string | Mt TNT | Sentry, Fireball |
+| `sigma_lov` | Impact | string | | Sentry |
+| `sigma_vi` | Impact | string | | Sentry |
+| `width` | Impact | string | Earth radii | Sentry |
+| `stretch` | Impact | string | Earth radii/sigma | Sentry |
+
+### Important Type Notes for Rust Implementation
+
+1. **Nearly all numeric values are returned as JSON strings**, not JSON numbers. The Rust
+   deserializer must parse these: `"0.0123"` -> `f64`. Use a custom deserializer or
+   intermediate string type.
+
+2. **Boolean fields vary by API:** SBDB returns JSON booleans (`true`/`false`), Query returns
+   strings (`"Y"`/`"N"`), CAD uses boolean query parameters.
+
+3. **Nullable fields:** Many physical parameters and some close-approach fields may be `null`
+   or absent. Use `Option<T>` extensively.
+
+4. **The `data` arrays are positional:** Fields are identified by their position in the
+   array, matched against the `fields` array in the response. Build a field-index map at
+   parse time.
+
+5. **Date formats vary by API:**
+   - `YYYY-MM-DD` (common)
+   - `YYYY-MMM-DD` (3-letter month abbreviation)
+   - `YYYY-MM-DD hh:mm:ss` (fireball)
+   - `YYYY-MM-DD.DD` (Sentry VI dates, fractional day)
+   - Julian Date as string or number
+
+6. **Distance units:** AU by default. Some parameters accept `LD` suffix for lunar distances.
+   1 LD = 0.00257 AU approximately.
+
+---
+
+## 14. Example Requests
+
+### SBDB: Look up Apophis (99942)
+
+```
+GET https://ssd-api.jpl.nasa.gov/sbdb.api?sstr=Apophis&full-prec=true&phys-par=true&ca-data=true&vi-data=true
+```
+
+### SBDB Query: All PHAs with diameter > 1 km
+
+```
+GET https://ssd-api.jpl.nasa.gov/sbdb_query.api?fields=spkid,full_name,e,a,i,H,diameter&sb-group=pha&sb-cdata={"AND":["diameter|GT|1"]}&sort=-diameter
+```
+
+### SBDB Query: All numbered Amor-class asteroids
+
+```
+GET https://ssd-api.jpl.nasa.gov/sbdb_query.api?fields=spkid,full_name,a,e,q,i,H&sb-class=AMO&sb-ns=n&limit=50
+```
+
+### CAD: Earth close approaches within 0.05 AU in next year
+
+```
+GET https://ssd-api.jpl.nasa.gov/cad.api?date-min=now&date-max=%2B365&dist-max=0.05&body=Earth&sort=dist&fullname=true
+```
+
+### CAD: Apophis close approaches to all bodies
+
+```
+GET https://ssd-api.jpl.nasa.gov/cad.api?des=99942&body=ALL&date-min=2025-01-01&date-max=2040-01-01
+```
+
+### Fireball: All events in the last month
+
+```
+GET https://ssd-api.jpl.nasa.gov/fireball.api?date-min=2026-01-24&date-max=2026-02-24&req-loc=true&vel-comp=true
+```
+
+### Sentry: Objects with Palermo scale > -3
+
+```
+GET https://ssd-api.jpl.nasa.gov/sentry.api?ps-min=-3
+```
+
+### Sentry: Detailed data for Bennu
+
+```
+GET https://ssd-api.jpl.nasa.gov/sentry.api?des=101955
+```
+
+### Scout: All current NEOCP objects
+
+```
+GET https://ssd-api.jpl.nasa.gov/scout.api
+```
+
+### NHATS: Accessible asteroids with delta-v < 6 km/s
+
+```
+GET https://ssd-api.jpl.nasa.gov/nhats.api?dv=6&dur=360&stay=8
+```
+
+### Mission Design: Accessible targets for 2028 launch
+
+```
+GET https://ssd-api.jpl.nasa.gov/mdesign.api?crit=3&year=2028&lim=20
+```
+
+### Mission Design: Pre-computed missions to Bennu
+
+```
+GET https://ssd-api.jpl.nasa.gov/mdesign.api?des=101955
+```
+
+### SB Identification: Objects in a 1-degree FOV
+
+```
+GET https://ssd-api.jpl.nasa.gov/sb_ident.api?mpc-code=F51&obs-time=2026-03-01_10:00:00&fov-ra-center=12-30-00&fov-dec-center=25-00-00&fov-ra-hwidth=0.5&fov-dec-hwidth=0.5&two-pass=true
+```
+
+### SB Radar: All radar observations of Apophis
+
+```
+GET https://ssd-api.jpl.nasa.gov/sb_radar.api?des=99942&observer=true&fullname=true
+```
+
+---
+
+## 15. Rate Limits and Practical Concerns
+
+### No Authentication
+
+All APIs are free and require no API key, token, or registration.
+
+### Rate Limiting
+
+No published rate limits exist. JPL expects "reasonable use." In practice:
+
+- Avoid more than a few requests per second for sustained periods
+- Use pagination (`limit`/`limit-from`) for large result sets rather than requesting
+  everything at once
+- Cache responses where possible; orbital data changes infrequently (days to weeks)
+- The SBDB Query API can return very large JSON payloads for unfiltered queries
+
+### Pagination
+
+APIs supporting pagination use `limit` and `limit-from`:
+
+```
+# First 100 results
+?limit=100
+
+# Next 100 results
+?limit=100&limit-from=100
+
+# Results 200-299
+?limit=100&limit-from=200
+```
+
+The response includes a `total` or `count` field to know when to stop.
+
+### Null and Missing Data
+
+Many fields may be null or absent, especially for poorly-characterized objects:
+
+- Physical parameters (diameter, albedo, rotation period) are unknown for most objects
+- Spectral types are only available for a small fraction
+- Radar data exists for only ~1,000 objects
+- Comet-specific fields (M1, M2, K1, K2) are null for asteroids and vice versa
+
+### Data Freshness
+
+- Orbital elements are updated as new observations are processed (typically within days)
+- Sentry impact monitoring is updated continuously
+- Scout data is updated as new NEOCP submissions arrive
+- Close-approach data is recomputed with each orbit update
+- Database counts grow by approximately 2,000-3,000 objects per month
+
+### Response Size Considerations
+
+- SBDB Query with no `limit` on all objects: can be 100+ MB
+- CAD with broad date/distance ranges: can return 100,000+ records
+- Always use `limit` for initial exploration, then paginate
+- Consider streaming JSON parsing (e.g., `serde_json::StreamDeserializer`) for bulk queries
+
+### URL Encoding
+
+- Spaces in designations: use `%20` (e.g., `des=2015%20AB`)
+- Plus sign in date offsets: use `%2B` (e.g., `date-max=%2B60`)
+- JSON in `sb-cdata`: URL-encode the entire JSON string
+- Commas in multi-value parameters: typically not encoded
+
+### Error Handling
+
+All APIs return error information in the JSON response body, even for HTTP 200:
+
+```json
+{
+  "signature": { "version": "string", "source": "string" },
+  "message": "string describing the error",
+  "code": 400
+}
+```
+
+Or for object-not-found in some APIs:
+
+```json
+{
+  "error": "specified object was not found"
+}
+```
+
+Check for `error`, `message`, and `code` fields in every response.
+
+### Rust Implementation Notes
+
+1. **Use `reqwest` with query parameter builders** rather than string formatting URLs.
+   This handles URL encoding correctly.
+
+2. **Define enums for closed sets:** orbit classes, object kinds, body names, sort fields.
+
+3. **Use `#[serde(deserialize_with = ...)]`** for the string-to-number conversion pattern
+   that appears everywhere in these APIs.
+
+4. **Model the `fields`/`data` pattern** (CAD, Query, Fireball, Radar) with a generic
+   tabular response type that maps field names to array positions at parse time.
+
+5. **Use `Option<T>` aggressively.** Nearly every field can be null for some object.
+
+6. **Consider builder patterns** for the complex parameter sets (especially SBDB Query
+   filters and SB Identification FOV parameters).
+
+7. **Implement `From<&str>` / `FromStr`** for orbit class and object kind enums to
+   simplify parsing.
+
+8. **Time handling:** Use a JD/calendar date abstraction. Multiple date formats exist
+   across APIs; a unified internal representation (e.g., JD f64) with format-specific
+   parsing is cleanest.

--- a/docs/data-sources/spk-kernels.md
+++ b/docs/data-sources/spk-kernels.md
@@ -1,0 +1,1380 @@
+# JPL SPK (Spacecraft and Planet Kernel) Binary Files
+
+Implementation notes for building Rust SPK readers. This document covers the DAF
+container format, all SPK segment types, available kernel files, and the
+algorithms needed to evaluate ephemeris data.
+
+---
+
+## 1. Overview
+
+SPK files are NAIF SPICE binary ephemeris files that store position and velocity
+data for solar system bodies. They are the primary mechanism by which JPL
+distributes planetary, satellite, asteroid, and spacecraft trajectory data.
+
+- **Format**: Binary, stored inside a DAF (Double precision Array File) container
+- **Maintainer**: NAIF (Navigation and Ancillary Information Facility) at NASA's
+  Jet Propulsion Laboratory
+- **Users**: NASA, ESA, JAXA, and virtually all spaceflight organizations worldwide
+  use SPK files for mission planning, navigation, and scientific analysis
+- **File extension**: `.bsp` (Binary SPK)
+- **Reference toolkit**: NAIF SPICE toolkit (available in Fortran, C, MATLAB, Python via SpiceyPy)
+- **Python reference**: `skyfield` and `jplephem` packages read SPK files natively
+
+SPK files contain one or more **segments**, each providing ephemeris data for a
+specific body relative to a specific center body over a specific time range. A
+single file can contain segments for many bodies (e.g., `de440.bsp` contains
+segments for all planet barycenters, the Sun, the Moon, and the Earth).
+
+---
+
+## 2. DAF Container Format
+
+DAF is the general-purpose binary container used by NAIF for SPK, PCK (Planet
+Constants Kernel), and CK (C-matrix/pointing Kernel) files. Understanding DAF is
+a prerequisite for reading any SPK file.
+
+### 2.1 Overall File Structure
+
+A DAF file is organized as a sequence of **records**, each exactly **1024 bytes**
+long. Records are numbered starting from 1.
+
+```
+Record 1:             File Record (header)
+Records 2..FWARD-1:   Comment Area (ASCII text, optional)
+Record FWARD:         First Summary Record
+Record FWARD+1:       First Name Record
+...                   Additional Summary/Name record pairs
+Remaining records:    Element Records (coefficient data)
+```
+
+### 2.2 File Record (Record 1) - First 1024 Bytes
+
+The file record contains all metadata needed to parse the rest of the file.
+
+| Byte Offset | Size (bytes) | Field  | Description |
+|-------------|-------------|--------|-------------|
+| 0-7         | 8           | LOCIDW | File ID word, ASCII. `"DAF/SPK "` for SPK files, `"DAF/PCK "` for PCK files. Used to identify the file type. |
+| 8-11        | 4           | ND     | Number of double-precision components per summary. For SPK files, always **2** (start epoch, end epoch). |
+| 12-15       | 4           | NI     | Number of integer components per summary. For SPK files, always **6** (target, center, frame, data_type, start_addr, end_addr). |
+| 16-75       | 60          | LOCIFN | Internal filename, ASCII, right-padded with spaces. |
+| 76-79       | 4           | FWARD  | Record number of the first summary record (1-indexed). |
+| 80-83       | 4           | BWARD  | Record number of the last summary record (1-indexed). |
+| 84-87       | 4           | FREE   | First free double-precision address in the file (1-indexed). |
+| 88-95       | 8           | (unused) | Numeric format identifier string (e.g., `"LTL-IEEE"` or `"BIG-IEEE"`). |
+| 96-1023     | 928         | (unused) | Reserved/padding, typically zero-filled. |
+
+**ND and NI** determine the structure of every summary in the file. For SPK:
+- ND = 2 (two doubles: start epoch, end epoch)
+- NI = 6 (six integers: target, center, frame, data_type, start_i, end_i)
+
+**Endianness detection**: Read ND and NI as both little-endian and big-endian
+`u32`. Valid values are small (1-10). Whichever interpretation yields small
+positive values is the file's byte order. All subsequent multi-byte reads must
+use this byte order.
+
+```rust
+let nd_le = LittleEndian::read_u32(&header[8..12]);
+let ni_le = LittleEndian::read_u32(&header[12..16]);
+let nd_be = BigEndian::read_u32(&header[8..12]);
+let ni_be = BigEndian::read_u32(&header[12..16]);
+
+let endian = if nd_le > 0 && nd_le < 10 && ni_le > 0 && ni_le < 10 {
+    Endian::Little
+} else if nd_be > 0 && nd_be < 10 && ni_be > 0 && ni_be < 10 {
+    Endian::Big
+} else {
+    // Invalid file
+};
+```
+
+### 2.3 Comment Records (Records 2 through FWARD-1)
+
+If FWARD > 2, records 2 through FWARD-1 contain ASCII comment text. Comments are
+stored as raw bytes with NUL (`0x00`) as end-of-comment and `0x04` (EOT) as
+line separators (converted to `\n` when reading). Comments typically describe the
+file's provenance, creation parameters, and the bodies contained within.
+
+### 2.4 Summary Records
+
+Summary records form a **doubly-linked list**, starting at record number FWARD
+and ending at BWARD. Each summary record is paired with the immediately following
+**name record** (at record_number + 1).
+
+#### Summary Record Layout (1024 bytes)
+
+| Byte Offset | Size | Type | Field | Description |
+|-------------|------|------|-------|-------------|
+| 0-7         | 8    | f64  | NEXT  | Record number of next summary record (0 if last) |
+| 8-15        | 8    | f64  | PREV  | Record number of previous summary record (0 if first) |
+| 16-23       | 8    | f64  | NSUM  | Number of summaries in this record |
+| 24-...      | variable | mixed | Summaries | Packed summary entries |
+
+The maximum number of summaries per record is:
+
+```
+max_summaries = floor((1024 - 24) / summary_step)
+```
+
+where:
+
+```
+summary_length = ND + ceil(NI / 2)   // in double-words
+summary_step   = summary_length * 8  // in bytes
+```
+
+For SPK (ND=2, NI=6): `summary_length = 2 + 3 = 5`, `summary_step = 40 bytes`,
+`max_summaries = floor(1000 / 40) = 25`.
+
+#### Individual Summary Layout (40 bytes for SPK)
+
+Each summary contains ND doubles followed by NI integers. The integers are packed
+as pairs of `i32` values into 8-byte (double-word) slots.
+
+| Offset within summary | Size | Type | Field | Description |
+|-----------------------|------|------|-------|-------------|
+| 0-7                   | 8    | f64  | START_EPOCH | Start epoch in TDB seconds past J2000 |
+| 8-15                  | 8    | f64  | END_EPOCH   | End epoch in TDB seconds past J2000 |
+| 16-19                 | 4    | i32  | TARGET      | NAIF target body ID |
+| 20-23                 | 4    | i32  | CENTER      | NAIF center body ID |
+| 24-27                 | 4    | i32  | FRAME       | Reference frame ID |
+| 28-31                 | 4    | i32  | DATA_TYPE   | SPK segment type (2, 3, 5, 21, etc.) |
+| 32-35                 | 4    | i32  | START_ADDR  | Start address in element records (1-indexed, in double-words) |
+| 36-39                 | 4    | i32  | END_ADDR    | End address in element records (1-indexed, in double-words) |
+
+**Address convention**: START_ADDR and END_ADDR are 1-indexed addresses in units
+of double-precision words (8 bytes). To convert to a byte offset:
+`byte_offset = (address - 1) * 8`.
+
+#### Name Record Layout
+
+The name record immediately follows its summary record (at record_number + 1).
+It contains segment source labels packed at the same offsets as their
+corresponding summaries (each label occupies `summary_step` bytes, right-padded
+with spaces or NULs).
+
+### 2.5 Element Records
+
+All remaining records after the summary/name pairs contain the actual ephemeris
+data (Chebyshev coefficients, discrete states, difference arrays, etc.). Segments
+reference ranges within this data using the START_ADDR and END_ADDR fields from
+their summaries.
+
+To read a segment's data:
+
+```rust
+// addresses are 1-indexed double-word positions
+let data: Vec<f64> = daf.read_array(start_addr, end_addr)?;
+// data.len() == end_addr - start_addr + 1
+```
+
+The byte range in the file is:
+```
+start_byte = (start_addr - 1) * 8
+end_byte   = end_addr * 8    // exclusive
+```
+
+---
+
+## 3. SPK Segment Types - Complete Reference
+
+SPK defines over 20 segment types, each using a different mathematical
+representation. The DATA_TYPE field in each summary identifies the type.
+
+### Implementation Priority Summary
+
+| Priority | Types | Rationale |
+|----------|-------|-----------|
+| **Implemented** | 2, 3 | Planetary ephemerides, satellite kernels |
+| **Highest** | 21 | All modern Horizons small-body files |
+| **High** | 1 | Legacy small-body files (Type 21 predecessor) |
+| **Medium** | 5 | Osculating element propagation |
+| **Low** | 8, 9, 12, 13, 14 | Interpolation types, uncommon |
+| **Not needed** | 10, 15, 17, 18, 19, 20 | Domain-specific or very rare |
+
+---
+
+### Type 1: Modified Difference Arrays (MDA)
+
+**Status**: DEPRECATED in favor of Type 21, but still present in archived files.
+**Priority**: Should implement for backward compatibility with legacy data.
+
+**Used by**: Older JPL spacecraft trajectories, pre-2018 Horizons small-body
+outputs, archived mission SPK files.
+
+#### Mathematical Background
+
+Modified Difference Arrays use the Shampine-Gordon method for polynomial
+interpolation via divided differences. The method stores a reference state and a
+table of modified divided differences that can reconstruct a polynomial
+interpolation of the trajectory at any point within a record's time span.
+
+#### Segment Layout
+
+The segment data consists of a sequence of fixed-size records followed by an
+epoch directory.
+
+**Segment structure** (double-precision words):
+
+```
+[ Record_0 | Record_1 | ... | Record_{N-1} | Epoch_Dir | N ]
+```
+
+- The last word is `N`, the number of records (as f64, cast to integer).
+- Before `N` is the **epoch directory**: contains `floor((N-1) / 100)` epoch
+  values for fast searching when N > 100.
+
+**Each record** contains exactly **71 double-precision values** (MAXDIM = 15 for Type 1):
+
+| Word Index | Count | Field | Description |
+|------------|-------|-------|-------------|
+| 0          | 1     | TL    | Reference epoch (TDB seconds past J2000) |
+| 1-15       | 15    | G     | Stepsize function coefficients |
+| 16-18      | 3     | REFPOS | Reference position (X, Y, Z) in km |
+| 19-21      | 3     | REFVEL | Reference velocity (VX, VY, VZ) in km/s |
+| 22-36      | 15    | DT    | Modified difference array for X |
+| 37-51      | 15    | DT    | Modified difference array for Y |
+| 52-66      | 15    | DT    | Modified difference array for Z |
+| 67         | 1     | KQMAX1 | Maximum integration order + 1 |
+| 68-70      | 3     | KQ    | Integration order for each component |
+
+Total: **71 doubles per record** = 568 bytes.
+
+#### Evaluation Algorithm
+
+To compute position and velocity at epoch `t`:
+
+1. **Find the record**: Search epoch directory, then linear scan to find the
+   record whose reference epoch `TL` is nearest to `t`.
+
+2. **Compute normalized time**: `dt = t - TL`
+
+3. **Reconstruct position via difference table**: For each component (X, Y, Z):
+   ```
+   Initialize: tp = dt
+   pos = refpos[comp] + refvel[comp] * dt + dt * dt * kq_sum(...)
+   ```
+
+   The full reconstruction uses the Shampine-Gordon recurrence:
+   ```
+   fc[0] = 1.0
+   for i in 0..kq[comp]:
+       fc[i+1] = dt / g[i] * fc[i]
+
+   w[kq[comp]-1] = diff_table[comp][kq[comp]-1]
+   for j in (0..kq[comp]-1).rev():
+       w[j] = diff_table[comp][j] + fc[j+1] * w[j+1]
+
+   position[comp] = refpos[comp] + dt * (refvel[comp] + dt * w[0])
+   ```
+
+4. **Velocity via derivative**: Similar recurrence with derivative terms:
+   ```
+   velocity[comp] = refvel[comp] + dt * (2 * w[0] + dt * w'[0])
+   ```
+   where `w'` uses modified recurrence coefficients.
+
+**Reference implementation**: `spktype01` Python package by Shushi Uetsuki.
+
+---
+
+### Type 2: Chebyshev Polynomials (Position Only)
+
+**Status**: ALREADY IMPLEMENTED in starfield (`src/jplephem/spk.rs`).
+**Priority**: This is the single most important type.
+
+**Used by**: ALL JPL planetary ephemerides (DE421, DE430, DE440, DE441), bulk
+asteroid perturber kernels (sb441-n16.bsp, sb441-n373.bsp), numerically
+integrated satellite orbits, and many other high-precision ephemerides.
+
+#### Segment Layout
+
+Type 2 segments contain a sequence of fixed-length records, each covering a
+uniform time interval. Metadata is stored as the **last 4 words** of the segment.
+
+**Segment structure** (double-precision words):
+
+```
+[ Record_0 | Record_1 | ... | Record_{N-1} | INIT | INTLEN | RSIZE | N ]
+```
+
+**Segment metadata** (last 4 double-precision values):
+
+| Word (from end) | Field  | Description |
+|-----------------|--------|-------------|
+| N-4             | INIT   | Initial epoch of first record (TDB seconds past J2000) |
+| N-3             | INTLEN | Time length of each record interval (seconds) |
+| N-2             | RSIZE  | Record size in double-precision words |
+| N-1             | N      | Number of records |
+
+**Each record** (RSIZE double-precision values):
+
+| Word Offset | Count | Field | Description |
+|-------------|-------|-------|-------------|
+| 0           | 1     | MID   | Midpoint epoch of this interval (TDB seconds past J2000) |
+| 1           | 1     | RADIUS | Half-length of this interval (seconds). RADIUS = INTLEN / 2 |
+| 2           | D     | C_X   | Chebyshev coefficients for X position (degree 0 to D-1) |
+| 2+D         | D     | C_Y   | Chebyshev coefficients for Y position |
+| 2+2D        | D     | C_Z   | Chebyshev coefficients for Z position |
+
+where `D = (RSIZE - 2) / 3` is the number of coefficients per component
+(polynomial degree + 1).
+
+**Validation**: `N * RSIZE + 4 == total_segment_length`
+
+#### Evaluation Algorithm
+
+To compute position and velocity at epoch `t` (TDB seconds past J2000):
+
+**Step 1: Find the record index**
+```
+index = floor((t - INIT) / INTLEN)
+index = clamp(index, 0, N-1)
+```
+
+**Step 2: Read record data**
+```
+record_offset = index * RSIZE
+MID    = data[record_offset]
+RADIUS = data[record_offset + 1]
+C_X    = data[record_offset + 2 .. record_offset + 2 + D]
+C_Y    = data[record_offset + 2 + D .. record_offset + 2 + 2D]
+C_Z    = data[record_offset + 2 + 2D .. record_offset + 2 + 3D]
+```
+
+**Step 3: Normalize time to [-1, 1]**
+```
+tau = (t - MID) / RADIUS
+```
+The value `tau` must be in [-1, 1]. Clamp for floating-point edge cases.
+
+**Step 4: Evaluate position via Clenshaw recurrence**
+
+For each component (using coefficients `c[0..D]`):
+
+```
+b[D]   = 0
+b[D-1] = 0
+for k = D-1 down to 1:
+    b[k] = 2 * tau * b[k+1] - b[k+2] + c[k]
+position = c[0] + tau * b[1] - b[2]
+```
+
+This is numerically stable and costs O(D) operations.
+
+**Step 5: Compute velocity via Chebyshev derivative**
+
+The derivative of a Chebyshev expansion with respect to `tau` uses:
+
+```
+dT_n(tau)/dtau = n * U_{n-1}(tau)
+```
+
+where `U_n` is the Chebyshev polynomial of the second kind. Evaluate `U_n`
+via the recurrence:
+
+```
+U_0(x) = 1
+U_1(x) = 2x
+U_n(x) = 2x * U_{n-1}(x) - U_{n-2}(x)
+```
+
+Then the derivative of the expansion is:
+
+```
+df/dtau = sum_{n=1}^{D-1} c[n] * n * U_{n-1}(tau)
+```
+
+**Step 6: Rescale velocity to physical units**
+
+The derivative is with respect to normalized time `tau`. To get km/s:
+
+```
+velocity = (df/dtau) / RADIUS
+```
+
+Since RADIUS is in seconds and the coefficients are in km, this gives km/s.
+
+#### Rust Implementation Reference
+
+From `src/jplephem/spk.rs`:
+
+```rust
+let t = normalize_time(et, record_mid, record_radius)?;
+let poly_x = ChebyshevPolynomial::new(coeffs_x);
+let position_x = poly_x.evaluate(t);
+let velocity_x = rescale_derivative(poly_x.derivative(t), record_radius)?;
+```
+
+---
+
+### Type 3: Chebyshev Polynomials (Position + Velocity)
+
+**Status**: ALREADY IMPLEMENTED in starfield (`src/jplephem/spk.rs`).
+
+**Used by**: Satellite kernels with analytical orbit theories (jup365.bsp,
+sat441l.bsp, mar097.bsp, etc.). When velocity is independently computed (not
+derived from position polynomials), Type 3 provides both sets of coefficients.
+
+#### Segment Layout
+
+Identical structure to Type 2, but each record is twice as long because it
+contains separate Chebyshev coefficients for both position and velocity.
+
+**Segment metadata**: Same as Type 2 (INIT, INTLEN, RSIZE, N at end of segment).
+
+**Each record** (RSIZE double-precision values):
+
+| Word Offset | Count | Field | Description |
+|-------------|-------|-------|-------------|
+| 0           | 1     | MID   | Midpoint epoch |
+| 1           | 1     | RADIUS | Half-interval |
+| 2           | D     | C_X   | Position X coefficients |
+| 2+D         | D     | C_Y   | Position Y coefficients |
+| 2+2D        | D     | C_Z   | Position Z coefficients |
+| 2+3D        | D     | C_VX  | Velocity X coefficients |
+| 2+4D        | D     | C_VY  | Velocity Y coefficients |
+| 2+5D        | D     | C_VZ  | Velocity Z coefficients |
+
+where `D = (RSIZE - 2) / 6`.
+
+#### Evaluation Algorithm
+
+**Position**: Identical to Type 2 Clenshaw evaluation using the position
+coefficients `C_X`, `C_Y`, `C_Z`.
+
+**Velocity**: Apply Clenshaw evaluation **directly** to the velocity
+coefficients `C_VX`, `C_VY`, `C_VZ`, then rescale:
+
+```
+velocity = evaluate(C_V*, tau) / RADIUS
+```
+
+The velocity coefficients are Chebyshev expansions of `velocity * RADIUS`
+(i.e., velocity scaled by the half-interval), so dividing by RADIUS recovers
+the physical velocity in km/s.
+
+**Key difference from Type 2**: For Type 2, velocity is obtained by
+differentiating the position polynomials. For Type 3, velocity has its own
+independent polynomial expansion, which can be more accurate when the velocity
+is known independently (e.g., from an analytical theory).
+
+---
+
+### Type 5: Discrete States + Two-Body Propagation
+
+**Status**: Not yet implemented.
+**Priority**: Medium. Starfield already has Kepler propagation in `keplerlib`.
+
+**Used by**: Traditional asteroid/comet ephemerides from osculating elements,
+some older spacecraft trajectory files.
+
+#### Segment Layout
+
+Type 5 stores a sequence of discrete state vectors at specific epochs, plus the
+gravitational parameter (GM) of the central body.
+
+**Segment structure**:
+
+```
+[ State_0 | State_1 | ... | State_{N-1} | GM ]
+```
+
+Each state record is **6 double-precision values** (48 bytes):
+
+| Word Offset | Field | Description |
+|-------------|-------|-------------|
+| 0           | EPOCH | State epoch (TDB seconds past J2000) |
+| 1           | X     | Position X (km) |
+| 2           | Y     | Position Y (km) |
+| 3           | Z     | Position Z (km) |
+| 4           | VX    | Velocity X (km/s) |
+| 5           | VY    | Velocity Y (km/s) |
+| 6           | VZ    | Velocity Z (km/s) |
+
+Wait -- Type 5 actually stores **two-body discrete states**. The exact layout:
+
+**Segment structure**:
+
+```
+[ (epoch_0, state_0) | (epoch_1, state_1) | ... | Epochs | N | GM ]
+```
+
+- The last value is **GM** (gravitational parameter of central body, km^3/s^2)
+- The second-to-last value is **N** (number of states)
+- Before N: **epoch directory** (for fast lookup when N > 100)
+- Each state: 6 doubles (X, Y, Z, VX, VY, VZ) at a specific epoch
+
+#### Evaluation Algorithm
+
+To compute state at epoch `t`:
+
+1. **Find bracketing states**: Binary search the epoch list to find states at
+   times `t_i <= t <= t_{i+1}`.
+
+2. **Select nearest state**: Choose the state at `t_i` or `t_{i+1}` (whichever
+   is closer to `t`).
+
+3. **Two-body propagation**: From the selected state, propagate forward or
+   backward to `t` using Keplerian two-body mechanics:
+   - Convert state to orbital elements
+   - Propagate mean anomaly: `M = M_0 + n * dt` where `n = sqrt(GM / a^3)`
+   - Solve Kepler's equation: `M = E - e*sin(E)` (iteratively)
+   - Convert back to Cartesian state
+
+This provides a reasonable approximation for bodies on near-Keplerian orbits
+(asteroids, comets, distant moons).
+
+---
+
+### Type 8: Lagrange Interpolation (Equally Spaced)
+
+**Status**: Not implemented.
+**Priority**: Low -- uncommon in practice.
+
+**Used by**: Some mission-specific trajectory files where uniform sampling is
+natural.
+
+#### Segment Layout
+
+```
+[ State_0 | State_1 | ... | State_{N-1} | INIT | STEP | DEGREE+1 | N ]
+```
+
+Each state: 6 doubles (X, Y, Z, VX, VY, VZ) in km and km/s.
+
+**Metadata** (last 4 words):
+- INIT: epoch of first state
+- STEP: uniform time step between states (seconds)
+- DEGREE+1: window size (polynomial degree + 1); must be even
+- N: number of states
+
+#### Evaluation Algorithm
+
+1. Find the window of DEGREE+1 states centered around `t`
+2. Evaluate Lagrange interpolating polynomial through those states
+3. Evaluate derivative of Lagrange polynomial for velocity
+
+Lagrange polynomial at equally spaced nodes:
+```
+L_j(t) = prod_{k != j} (t - t_k) / (t_j - t_k)
+position(t) = sum_j state_j * L_j(t)
+```
+
+---
+
+### Type 9: Lagrange Interpolation (Unequally Spaced)
+
+**Status**: Not implemented.
+**Priority**: Low -- uncommon.
+
+**Used by**: Trajectory files with non-uniform time sampling.
+
+#### Segment Layout
+
+```
+[ State_0 | State_1 | ... | State_{N-1} | Epoch_0 | ... | Epoch_{N-1} | Epoch_Dir | DEGREE+1 | N ]
+```
+
+Each state: 6 doubles. Epochs are explicitly stored (non-uniform spacing).
+
+**Metadata** (last 2 words):
+- DEGREE+1: window size
+- N: number of states
+
+#### Evaluation
+
+Same Lagrange interpolation as Type 8, but at non-uniform knot times.
+
+---
+
+### Type 10: Space Command Two-Line Elements
+
+**Status**: Not implemented.
+**Priority**: Not needed -- completely different domain from planetary ephemerides.
+
+**Used by**: Earth-orbiting satellites using NORAD TLE sets.
+
+#### Structure
+
+Contains NORAD Two-Line Element sets:
+- Inclination, RAAN, eccentricity, argument of perigee, mean anomaly, mean motion
+- Plus associated drag terms (B* coefficient)
+
+#### Evaluation
+
+Requires the SGP4/SDP4 propagator, which is a fundamentally different algorithm
+from anything else in the SPK system. SGP4 models atmospheric drag, solar/lunar
+perturbations, and Earth oblateness effects specific to Earth-orbiting objects.
+
+---
+
+### Type 12: Hermite Interpolation (Equally Spaced)
+
+**Status**: Not implemented.
+**Priority**: Low.
+
+**Used by**: Some mission-specific trajectory files.
+
+#### Segment Layout
+
+```
+[ State_0 | State_1 | ... | State_{N-1} | INIT | STEP | DEGREE+1 | N ]
+```
+
+Each state: 6 doubles (position + velocity). Same metadata as Type 8.
+
+#### Evaluation
+
+Hermite interpolation uses both position **and** velocity values at each knot,
+producing a polynomial that matches the function value and first derivative at
+every knot point. This gives C^1 continuity (continuous first derivative) at
+record boundaries, unlike Lagrange (Type 8/9) which only guarantees C^0.
+
+For a window of DEGREE+1 states, Hermite interpolation constructs a polynomial
+of degree `2*(DEGREE+1) - 1` (twice the Lagrange degree) using divided
+differences on the doubled set of knots.
+
+---
+
+### Type 13: Hermite Interpolation (Unequally Spaced)
+
+**Status**: Not implemented.
+**Priority**: Low-medium.
+
+**Used by**: Some mission-specific trajectory files, ESA reconstructed orbits.
+
+#### Segment Layout
+
+```
+[ State_0 | ... | State_{N-1} | Epoch_0 | ... | Epoch_{N-1} | Epoch_Dir | DEGREE+1 | N ]
+```
+
+Same as Type 9 but with Hermite interpolation instead of Lagrange.
+
+#### Evaluation
+
+Same Hermite algorithm as Type 12, but with non-uniform knot spacing. The
+non-uniform spacing makes the divided difference computation slightly more
+involved but the algorithm is otherwise identical.
+
+---
+
+### Type 14: Chebyshev Polynomials (Unequally Spaced)
+
+**Status**: Not implemented.
+**Priority**: Low -- uncommon.
+
+**Used by**: Rare cases where different time intervals require different
+polynomial degrees or interval lengths.
+
+#### Segment Layout
+
+Unlike Types 2/3 which use fixed-length records at uniform intervals, Type 14
+allows each record to have a different length and cover a different time span.
+
+```
+[ Record_0 | Record_1 | ... | Record_{N-1} | Epochs | N ]
+```
+
+Each record has its own MID, RADIUS, and coefficient count. The epoch directory
+lists the start/end times of each record.
+
+#### Evaluation
+
+Same Clenshaw recurrence as Types 2/3, but with a binary search to find the
+correct record and variable polynomial degrees per record.
+
+---
+
+### Type 15: Precessing Conic Propagation
+
+**Status**: Not implemented.
+**Priority**: Low -- rarely used in practice.
+
+**Used by**: Very approximate satellite ephemerides where only the mean orbital
+elements and secular J2 perturbations matter.
+
+#### Segment Layout
+
+The entire segment is a single record containing:
+
+| Word | Field | Description |
+|------|-------|-------------|
+| 0    | EPOCH | Reference epoch (TDB seconds past J2000) |
+| 1-3  | TP    | Trajectory pole unit vector (perpendicular to orbital plane) |
+| 4-6  | PA    | Periapsis unit vector at epoch |
+| 7    | P     | Semi-latus rectum (km) |
+| 8    | ECC   | Eccentricity |
+| 9    | J2FLG | J2 processing flag (1 = apply J2 corrections) |
+| 10-12| PV    | Central body pole unit vector |
+| 13   | GM    | Central body gravitational parameter (km^3/s^2) |
+| 14   | J2    | Central body J2 coefficient |
+| 15   | RE    | Central body equatorial radius (km) |
+
+#### Evaluation
+
+1. Propagate mean anomaly from epoch: `M = M_0 + n * dt`
+2. Apply J2 secular perturbations if J2FLG = 1:
+   - Nodal regression: `dOmega/dt = -1.5 * n * J2 * (RE/a)^2 * cos(i) / (1-e^2)^2`
+   - Apsidal precession: `domega/dt = 0.75 * n * J2 * (RE/a)^2 * (5*cos^2(i) - 1) / (1-e^2)^2`
+3. Solve Kepler's equation for eccentric anomaly
+4. Convert to Cartesian position and velocity
+
+---
+
+### Type 17: Equinoctial Elements
+
+**Status**: Not implemented.
+**Priority**: Low.
+
+**Used by**: Some mean-element satellite ephemerides.
+
+#### Structure
+
+Stores equinoctial orbital elements and their time rates:
+- Semi-major axis `a`, mean longitude rate `dn/dt`
+- `h = e * sin(omega + Omega)`, `k = e * cos(omega + Omega)`
+- `p = tan(i/2) * sin(Omega)`, `q = tan(i/2) * cos(Omega)`
+- Mean longitude at epoch, plus rates for all elements
+- Precession rate of the node
+
+#### Evaluation
+
+Propagate elements linearly in time, convert equinoctial elements to Cartesian
+state. Equinoctial elements avoid singularities at zero eccentricity and zero
+inclination that affect classical Keplerian elements.
+
+---
+
+### Type 18: ESOC/DDID Hermite/Lagrange Interpolation
+
+**Status**: Not implemented.
+**Priority**: Not needed unless supporting ESA mission data.
+
+**Used by**: Mars Express, Rosetta, SMART-1, Venus Express, and other ESA missions.
+Designed by the European Space Operations Centre (ESOC).
+
+#### Structure
+
+Has two subtypes:
+- **Subtype S**: Hermite interpolation (uses position + velocity)
+- **Subtype T**: Lagrange interpolation (uses position only)
+
+A subtype flag in the segment distinguishes the two.
+
+#### Evaluation
+
+Similar to Types 12/13 (Hermite) or Types 8/9 (Lagrange) but with ESOC-specific
+record layout conventions.
+
+---
+
+### Type 19: ESOC/DDID Piecewise Interpolation
+
+**Status**: Not implemented.
+**Priority**: Not needed.
+
+An enhanced version of Type 18 that requires fewer segments by allowing
+variable-size "mini-segments" within a single SPK segment. Each mini-segment
+can use either Hermite or Lagrange interpolation independently.
+
+---
+
+### Type 20: Chebyshev Polynomials (Velocity Only)
+
+**Status**: Not implemented.
+**Priority**: Not needed unless supporting Russian ephemerides.
+
+**Used by**: Russian EPM (Ephemerides of Planets and the Moon) series only.
+This is the velocity-first counterpart to Type 2.
+
+#### Structure
+
+Same layout as Type 2, but coefficients represent **velocity** rather than
+position.
+
+#### Evaluation
+
+1. Evaluate Chebyshev expansion directly to get velocity
+2. **Integrate** the Chebyshev expansion analytically to get position:
+   ```
+   integral of T_n(x) = (T_{n+1}(x)/(2(n+1)) - T_{n-1}(x)/(2(n-1)))
+   ```
+   with appropriate treatment of the T_0 and T_1 terms.
+3. Add an integration constant (stored as the first velocity coefficient's
+   contribution to position)
+
+---
+
+### Type 21: Extended Modified Difference Arrays
+
+**Status**: Not implemented.
+**Priority**: HIGHEST for new implementation -- unlocks the entire Horizons
+small-body catalog.
+
+**Used by**: ALL modern Horizons-generated small-body SPK files (post-October
+2018), modern spacecraft trajectory reconstructions.
+
+This is the modern successor to Type 1. Since October 2018, JPL's Horizons
+system generates Type 21 exclusively for small-body SPK files, making this the
+essential type for anyone wanting to work with asteroid or comet ephemerides
+from Horizons.
+
+#### Key Difference from Type 1
+
+Type 1 uses a fixed MAXDIM of 15 (maximum number of difference table entries per
+component). Type 21 uses a **variable MAXDIM** that is stored per-segment,
+typically larger than 15. This allows higher-precision interpolation.
+
+#### Segment Layout
+
+**Segment structure**:
+
+```
+[ Record_0 | Record_1 | ... | Record_{N-1} | Epoch_Dir | N | DLSIZE ]
+```
+
+- The last word is **DLSIZE** (Difference Line Size = 4 * MAXDIM + 11),
+  giving the size of each record in double-precision words.
+- The second-to-last word is **N**, the number of records.
+- Before N: **epoch directory** with `floor((N-1) / 100)` values for fast
+  searching (only present when N > 100).
+
+To determine MAXDIM from DLSIZE:
+```
+MAXDIM = (DLSIZE - 11) / 4
+```
+
+**Each record** (DLSIZE double-precision values):
+
+| Word Index | Count | Field | Description |
+|------------|-------|-------|-------------|
+| 0          | 1     | TL    | Reference epoch (TDB seconds past J2000) |
+| 1..MAXDIM  | MAXDIM | G   | Stepsize function coefficients |
+| MAXDIM+1   | 1     | REFPOS_X | Reference X position (km) |
+| MAXDIM+2   | 1     | REFPOS_Y | Reference Y position (km) |
+| MAXDIM+3   | 1     | REFPOS_Z | Reference Z position (km) |
+| MAXDIM+4   | 1     | REFVEL_X | Reference X velocity (km/s) |
+| MAXDIM+5   | 1     | REFVEL_Y | Reference Y velocity (km/s) |
+| MAXDIM+6   | 1     | REFVEL_Z | Reference Z velocity (km/s) |
+| MAXDIM+7   | MAXDIM | DT_X | Modified difference array for X |
+| 2*MAXDIM+7 | MAXDIM | DT_Y | Modified difference array for Y |
+| 3*MAXDIM+7 | MAXDIM | DT_Z | Modified difference array for Z |
+| 4*MAXDIM+7 | 1     | KQMAX1 | Maximum integration order + 1 |
+| 4*MAXDIM+8 | 3     | KQ    | Integration orders for X, Y, Z |
+
+Total: **4*MAXDIM + 11 = DLSIZE** doubles per record.
+
+**Verification**: `record_count * DLSIZE + epoch_dir_count + 2 == segment_length`
+where `epoch_dir_count = max(0, floor((N-1) / 100))`.
+
+#### Evaluation Algorithm
+
+The evaluation algorithm is identical to Type 1 (Shampine-Gordon modified
+divided differences), just with variable MAXDIM. Here is the complete algorithm:
+
+**Step 1: Find the correct record**
+
+If N <= 100, do a linear scan. Otherwise, use the epoch directory for an
+initial bracket, then linear scan within that bracket.
+
+```
+// Epoch directory has floor((N-1)/100) entries
+// Entry i corresponds to record i*100
+// Binary search directory, then linear scan
+```
+
+Search for the record whose reference epoch `TL` is closest to `t` without
+exceeding it. Handle boundary conditions for the first and last records.
+
+**Step 2: Extract record fields**
+
+```rust
+let tl = record[0];
+let g = &record[1..1+maxdim];
+let refpos = [record[maxdim+1], record[maxdim+2], record[maxdim+3]];
+let refvel = [record[maxdim+4], record[maxdim+5], record[maxdim+6]];
+let dt = [
+    &record[maxdim+7 .. 2*maxdim+7],     // X differences
+    &record[2*maxdim+7 .. 3*maxdim+7],    // Y differences
+    &record[3*maxdim+7 .. 4*maxdim+7],    // Z differences
+];
+let kqmax1 = record[4*maxdim+7] as usize;
+let kq = [
+    record[4*maxdim+8] as usize,
+    record[4*maxdim+9] as usize,
+    record[4*maxdim+10] as usize,
+];
+```
+
+**Step 3: Compute position**
+
+```
+delta = t - tl
+
+// Build factorial-like coefficients from the stepsize function
+tp = delta
+fc[0] = 1.0
+for i in 0..kqmax1-1:
+    fc[i+1] = tp / g[i]
+    tp = delta + g[i]
+
+// For each component c = 0, 1, 2:
+//   Accumulate from highest order down
+w[kq[c]-1] = dt[c][kq[c]-1]
+for j = kq[c]-2 down to 0:
+    w[j] = dt[c][j] + fc[j+1] * w[j+1]
+
+position[c] = refpos[c] + delta * (refvel[c] + delta * w[0])
+```
+
+**Step 4: Compute velocity**
+
+```
+// Build derivative coefficients
+wc[0] = 0.0
+for i in 0..kqmax1-1:
+    wc[i+1] = fc[i+1] * (i+1) / (delta + g[i])  // derivative of fc
+
+// For each component c:
+//   Similar recurrence with wc mixed in
+dw[kq[c]-1] = dt[c][kq[c]-1] * wc[kq[c]-1]
+for j = kq[c]-2 down to 0:
+    dw[j] = dt[c][j] * wc[j] + fc[j+1] * dw[j+1] + wc[j+1] * w[j+1]
+    // (where w[j+1] values come from the position computation)
+
+velocity[c] = refvel[c] + delta * (2.0 * w[0] + delta * dw[0])
+```
+
+**Reference implementations**:
+- `spktype21` Python package (Shushi Uetsuki / MITSuMo group)
+- `jplephem` Python package (Brandon Rhodes) -- handles Types 1 and 21
+
+---
+
+## 4. Available Kernel Files from JPL
+
+### 4.1 Planetary Ephemerides
+
+These contain positions for the Sun, Moon, planet barycenters, and sometimes
+the Earth itself. All use Type 2 (Chebyshev position-only) segments.
+
+| File | Size | Type | Coverage | Bodies | Notes |
+|------|------|------|----------|--------|-------|
+| `de421.bsp` | ~17 MB | 2 | 1899-2053 | 10 Sun, Moon, planet barycenters 1-9, 199, 299, 399 | Good for modern applications, lightweight |
+| `de430.bsp` | ~115 MB | 2 | 1549-2650 | Same as de421 | Updated from de421, includes Pluto |
+| `de440.bsp` | ~115 MB | 2 | 1549-2650 | Same | Latest standard ephemeris (2021), improved inner planets |
+| `de440s.bsp` | ~32 MB | 2 | 1849-2150 | Same | Short-span version of de440 |
+| `de441.bsp` | ~3.1 GB | 2 | 13200 BC - AD 17191 | Same | Extended range, identical accuracy to de440 over modern era |
+
+**Recommended default**: `de440s.bsp` (32 MB, covers 1849-2150, sufficient for
+most applications). Use `de440.bsp` for historical work, `de441.bsp` only if
+you need deep-time coverage.
+
+**Download URL**: `https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/`
+
+### 4.2 Asteroid Perturber Kernels
+
+These are large Type 2 kernels containing Chebyshev-fit ephemerides for asteroids
+massive enough to gravitationally perturb other bodies. They are used alongside
+planetary ephemerides for high-precision work.
+
+| File | Size | Type | Coverage | Bodies | Notes |
+|------|------|------|----------|--------|-------|
+| `sb441-n16.bsp` | 616 MB | 2 | ~1800-2200 | 16 most massive asteroids | Ceres, Pallas, Vesta, Hygiea + 12 others |
+| `sb441-n373.bsp` | 14.1 GB | 2 | ~1800-2200 | 373 perturber asteroids | Full set used in DE441 integration |
+| `sb441-n373s.bsp` | 937 MB | 2 | Reduced span | 373 perturber asteroids | Shorter time coverage, same bodies |
+| `codes_300ast_20100725.bsp` | 59 MB | 2 | 1800-2200 | 300 asteroids | CODES/Baer mass model asteroids |
+
+**Download URL**: `https://ssd.jpl.nasa.gov/ftp/eph/small_bodies/asteroids_de441/`
+
+### 4.3 Satellite Kernels
+
+Natural satellite ephemerides, typically using Type 2 or Type 3 segments. These
+are large files because they contain many moons over long time spans.
+
+#### Jupiter System
+
+| File | Size | Type | Coverage | Bodies | Notes |
+|------|------|------|----------|--------|-------|
+| `jup365.bsp` | 1.03 GB | 2/3 | 1600-2200 | 13 moons | Galilean moons (Io, Europa, Ganymede, Callisto) + 9 inner/outer moons |
+| `jup347.bsp` | ~500 MB | 2/3 | 1600-2200 | 12 moons | Previous generation |
+| `jup387xl.bsp` | ~2.5 GB | 2/3 | Extended | 13+ moons | Extended version with additional small moons |
+
+#### Saturn System
+
+| File | Size | Type | Coverage | Bodies | Notes |
+|------|------|------|----------|--------|-------|
+| `sat441l.bsp` | 609 MB | 2/3 | 1749-2250 | 19 moons | Major moons: Mimas through Phoebe, plus smaller bodies |
+| `sat441xl.bsp` | ~1.5 GB | 2/3 | Extended | 19+ moons | Extended coverage version |
+| `sat456.bsp` | ~700 MB | 2/3 | 1749-2250 | 19+ moons | Updated satellite ephemeris |
+
+#### Mars System
+
+| File | Size | Type | Coverage | Bodies | Notes |
+|------|------|------|----------|--------|-------|
+| `mar099.bsp` | 1.10 GB | 2/3 | 1600-2600 | Phobos + Deimos | Long-span, high-precision satellite ephemeris |
+
+#### Uranus System
+
+| File | Size | Type | Coverage | Bodies | Notes |
+|------|------|------|----------|--------|-------|
+| `ura184.bsp` | 4.14 GB | 2/3 | 1600-2399 | Major moons | Miranda, Ariel, Umbriel, Titania, Oberon + others |
+| `ura111.30kyr.bsp` | 6.78 GB | 2/3 | 30,000 yr span | Major moons | Ultra-long coverage for dynamical studies |
+
+#### Neptune System
+
+| File | Size | Type | Coverage | Bodies | Notes |
+|------|------|------|----------|--------|-------|
+| `nep097.bsp` | 3.01 GB | 2/3 | 1600-2399 | Triton + others | Standard Neptune satellite ephemeris |
+| `nep104.bsp` | ~3 GB | 2/3 | 1600-2399 | Updated set | Updated from nep097 |
+| `Triton.nep097.30kyr.bsp` | 2.40 GB | 2/3 | 30,000 yr span | Triton only | Ultra-long Triton coverage |
+
+#### Pluto System
+
+| File | Size | Type | Coverage | Bodies | Notes |
+|------|------|------|----------|--------|-------|
+| `plu060.bsp` | 111 MB | 2/3 | ~1900-2100 | 5 moons | Charon, Nix, Hydra, Kerberos, Styx |
+
+**Download URL**: `https://ssd.jpl.nasa.gov/ftp/eph/satellites/bsp/`
+
+### 4.4 Notable Individual Small-Body Kernels
+
+These are typically Type 21 (modern) or Type 1 (legacy) segments generated by
+JPL's Horizons system for specific asteroids or comets.
+
+| Body | File | Size | Notes |
+|------|------|------|-------|
+| Apophis (99942) | Solutions 216-220 | 69-176 MB | Multiple trajectory solutions, extensively studied PHA |
+| Comet 67P/Churyumov-Gerasimenko | `sb-67p-k151-6.bsp` | 117 KB | Rosetta target |
+| Comet Siding Spring (C/2013 A1) | 8 kernel files | 1-37 MB | Mars close approach Oct 2014 |
+| Didymos/Dimorphos (65803) | `sb-65803-205.bsp` | 231 KB | DART mission target asteroid |
+| Dimorphos | `dimorphos_s542.bsp` | 48.8 MB | DART impact target moon |
+
+**Download URL**: `https://ssd.jpl.nasa.gov/ftp/eph/small_bodies/`
+
+### 4.5 Download URLs Summary
+
+| Category | URL |
+|----------|-----|
+| Planetary ephemerides | `https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/` |
+| Satellites | `https://ssd.jpl.nasa.gov/ftp/eph/satellites/bsp/` |
+| Asteroid perturbers | `https://ssd.jpl.nasa.gov/ftp/eph/small_bodies/asteroids_de441/` |
+| Individual small bodies | `https://ssd.jpl.nasa.gov/ftp/eph/small_bodies/` |
+| NAIF generic kernels | `https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/` |
+
+---
+
+## 5. Segment Addressing and Chain Resolution
+
+### 5.1 NAIF Body ID Convention
+
+Bodies are identified by integer IDs following NAIF conventions:
+
+| ID Range | Category | Examples |
+|----------|----------|---------|
+| 0 | Solar System Barycenter (SSB) | Origin of the ICRF |
+| 1-9 | Planet barycenters | 1=Mercury BC, 3=Earth-Moon BC, 5=Jupiter BC |
+| 10 | Sun | |
+| 1xx | Planet (xx=99) or satellites (xx=01,02,...) | 199=Mercury, 399=Earth, 301=Moon, 401=Phobos |
+| 2xxxxxx | Asteroids | 2000001=Ceres, 2000004=Vesta |
+| 1xxxxxxx | Comets | |
+
+### 5.2 Segment Graph
+
+Each SPK segment defines a directed edge in a body graph:
+```
+center_body ---> target_body
+```
+
+For example, `de440.bsp` contains these segments:
+
+```
+SSB (0) ---> Mercury Barycenter (1)
+SSB (0) ---> Venus Barycenter (2)
+SSB (0) ---> Earth-Moon Barycenter (3)
+SSB (0) ---> Mars Barycenter (4)
+SSB (0) ---> Jupiter Barycenter (5)
+SSB (0) ---> Saturn Barycenter (6)
+SSB (0) ---> Uranus Barycenter (7)
+SSB (0) ---> Neptune Barycenter (8)
+SSB (0) ---> Pluto Barycenter (9)
+SSB (0) ---> Sun (10)
+Earth-Moon Barycenter (3) ---> Moon (301)
+Earth-Moon Barycenter (3) ---> Earth (399)
+Mercury Barycenter (1) ---> Mercury (199)
+Venus Barycenter (2) ---> Venus (299)
+Mars Barycenter (4) ---> Mars (499)
+```
+
+### 5.3 Chain Resolution
+
+To compute the position of body A relative to the SSB, you must find a **chain**
+of segments from SSB to body A and sum their contributions.
+
+**Example**: Position of Mars (499) relative to SSB:
+
+```
+Chain: SSB(0) -> Mars Barycenter(4) -> Mars(499)
+Position = segment(0,4).compute(t) + segment(4,499).compute(t)
+```
+
+**Example**: Position of the Moon (301) relative to Earth (399):
+
+```
+Moon relative to SSB:  chain(0->3) + chain(3->301)
+Earth relative to SSB: chain(0->3) + chain(3->399)
+Moon relative to Earth: (chain_moon - chain_earth)
+                      = chain(3->301) - chain(3->399)
+```
+
+### 5.4 BFS Algorithm
+
+Starfield uses Breadth-First Search from SSB (ID=0) to build chains:
+
+```rust
+// Build adjacency list from segments
+let mut adj: HashMap<i32, Vec<(i32, i32)>> = HashMap::new();
+for seg in &spk.segments {
+    adj.entry(seg.center).or_default().push((seg.center, seg.target));
+}
+
+// BFS from SSB
+let mut queue = VecDeque::new();
+let mut parent: HashMap<i32, (i32, i32)> = HashMap::new();
+queue.push_back(0);
+parent.insert(0, (0, 0)); // sentinel
+
+while let Some(node) = queue.pop_front() {
+    if let Some(edges) = adj.get(&node) {
+        for &(center, target) in edges {
+            if !parent.contains_key(&target) {
+                parent.insert(target, (center, target));
+                queue.push_back(target);
+            }
+        }
+    }
+}
+
+// Reconstruct chain for target by walking parent pointers back to SSB
+```
+
+This precomputation runs once when opening a kernel. Subsequent lookups are O(1)
+hash map access plus O(chain_length) segment evaluations.
+
+---
+
+## 6. Time System
+
+### 6.1 TDB (Barycentric Dynamical Time)
+
+All epochs in SPK files are in **TDB seconds past J2000**.
+
+- **J2000 epoch**: 2000 January 1, 12:00:00.000 TDB = JD 2451545.0 TDB
+- **TDB**: The independent time argument for solar system dynamics, closely
+  tracks TT (Terrestrial Time) with periodic variations < 2 ms
+
+### 6.2 Conversions
+
+```
+TDB_seconds = (JD_TDB - 2451545.0) * 86400.0
+JD_TDB = 2451545.0 + TDB_seconds / 86400.0
+```
+
+For sub-microsecond precision, split the computation:
+```rust
+pub fn jd_to_seconds(jd: f64) -> f64 {
+    (jd - 2451545.0) * 86400.0
+}
+```
+
+The `compute_and_differentiate(tdb, tdb2)` interface in starfield accepts a
+split time where `tdb + tdb2` is the total TDB seconds. This preserves
+precision when working with large epoch values.
+
+### 6.3 TDB vs TT
+
+TDB differs from TT by periodic terms:
+
+```
+TDB - TT = 0.001657 * sin(628.3076 * T + 6.2401)
+          + 0.000022 * sin(575.3385 * T + 4.2970)
+          + ... (smaller terms)
+```
+
+where T is Julian centuries of TDB past J2000. The maximum difference is
+approximately 1.7 ms. For most applications (position accuracy > 1 km), TDB
+and TT can be used interchangeably. For sub-km precision, the correction
+matters.
+
+---
+
+## 7. Reference Frames
+
+### 7.1 Frame IDs in SPK Files
+
+The FRAME integer in each summary identifies the reference frame:
+
+| Frame ID | Name | Description |
+|----------|------|-------------|
+| 1 | J2000 | ICRF-aligned Earth mean equator and equinox of J2000. This is the standard frame for virtually all SPK files. |
+| 2 | B1950 | FK4 mean equator and equinox of B1950.0. Used by some legacy files. |
+| 17 | ECLIPJ2000 | Mean ecliptic and equinox of J2000. Rotated from J2000 by the obliquity of the ecliptic (~23.4 degrees). |
+
+**In practice**: Nearly all modern SPK files use frame 1 (J2000/ICRF). The J2000
+frame is aligned with the International Celestial Reference Frame to within
+the accuracy of the frame tie (~0.01 arcseconds).
+
+### 7.2 J2000 to ECLIPJ2000 Rotation
+
+The obliquity of the ecliptic at J2000:
+```
+epsilon = 23.439291111 degrees = 0.40909280422 radians
+```
+
+Rotation matrix (J2000 equatorial -> ECLIPJ2000 ecliptic):
+```
+R = [[1,          0,           0         ],
+     [0,  cos(eps),   sin(eps) ],
+     [0, -sin(eps),   cos(eps) ]]
+```
+
+---
+
+## 8. Units
+
+### 8.1 Internal SPK Units
+
+All SPK files store:
+- **Positions**: kilometers (km)
+- **Velocities**: kilometers per second (km/s) for most types
+  - Exception: some Type 2 velocity is derived as km/s from position differentiation
+  - Exception: Type 20 stores velocity coefficients in km/s directly
+
+### 8.2 Starfield API Units
+
+Starfield's high-level `SpiceKernel` API converts to astronomical units:
+
+```rust
+const AU_KM: f64 = 149_597_870.700;  // IAU 2012 exact definition
+const S_PER_DAY: f64 = 86400.0;
+
+// Position: km -> AU
+position_au = position_km / AU_KM;
+
+// Velocity: km/s -> AU/day
+velocity_au_day = velocity_km_s * S_PER_DAY / AU_KM;
+```
+
+The raw `Segment::compute_and_differentiate()` returns km and km/s.
+
+---
+
+## 9. Implementation Notes for Rust
+
+### 9.1 Binary Parsing
+
+- Use the `byteorder` crate for endian-aware reading (already used in starfield)
+- Use `memmap2` for memory-mapped I/O on large kernels (already used in starfield)
+- Records are always 1024 bytes; addresses are 1-indexed double-word positions
+- Byte offset from address: `(address - 1) * 8`
+
+### 9.2 Memory-Mapped I/O
+
+For large kernels (de441.bsp = 3.1 GB, sb441-n373.bsp = 14.1 GB), memory-mapped
+I/O is essential. The OS will page in data on demand. Starfield already implements
+this via `memmap2::Mmap`.
+
+```rust
+// Current starfield approach: mmap with file fallback
+if let Ok(mmap) = unsafe { MmapOptions::new().map(&file) } {
+    self.map = Some(mmap);
+}
+```
+
+### 9.3 Type 2/3 Implementation (Already Done)
+
+Fixed-size records with uniform time intervals make these straightforward:
+
+1. Read metadata (last 4 words of segment)
+2. Compute record index from time: `floor((t - INIT) / INTLEN)`
+3. Extract coefficients from `data[index * RSIZE .. (index+1) * RSIZE]`
+4. Clenshaw evaluation
+5. Derivative via Chebyshev second-kind polynomials
+
+See `src/jplephem/spk.rs` for the complete implementation.
+
+### 9.4 Type 21 Implementation (Next Priority)
+
+Key considerations:
+
+- **Variable record size**: Read DLSIZE from last word of segment, derive MAXDIM
+- **Epoch search**: For N > 100, use epoch directory for O(log N) initial bracket
+- **Stepsize function**: The `G` array encodes non-uniform integration steps
+- **Divided difference recurrence**: Careful with indexing -- the algorithm builds
+  coefficients from highest order down
+- **Velocity**: Requires tracking both `fc` and `wc` (derivative of `fc`)
+  coefficients simultaneously
+
+```rust
+struct Type21Record {
+    tl: f64,                    // Reference epoch
+    g: Vec<f64>,                // Stepsize function [MAXDIM]
+    refpos: [f64; 3],           // Reference position
+    refvel: [f64; 3],           // Reference velocity
+    dt: [Vec<f64>; 3],          // Difference tables [3][MAXDIM]
+    kqmax1: usize,              // Max integration order + 1
+    kq: [usize; 3],            // Integration orders per component
+}
+```
+
+### 9.5 Type 1 Implementation
+
+Identical to Type 21 but with fixed MAXDIM = 15, so record size is always
+`4 * 15 + 11 = 71` doubles. Can share the evaluation code with Type 21.
+
+### 9.6 Type 5 Implementation
+
+Requires:
+1. Binary search of epoch list
+2. Kepler equation solver (already exists in `keplerlib`)
+3. State vector <-> orbital elements conversion
+4. Two-body propagation from nearest state to target epoch
+
+### 9.7 Segment Caching
+
+Starfield caches decoded segment data in the `Segment::data` field (lazy
+initialization). This avoids re-parsing coefficient arrays on repeated queries
+to the same segment. For Type 21, consider caching the parsed records and
+epoch list similarly.
+
+### 9.8 Error Handling
+
+Follow the existing pattern using `JplephemError`:
+- `OutOfRangeError` when epoch is outside segment coverage
+- `UnsupportedDataType` for unimplemented segment types
+- `InvalidFormat` for corrupt or unexpected data layouts
+- `BodyNotFound` when no segment exists for a requested body pair
+
+### 9.9 Testing Strategy
+
+- **Unit tests**: Verify coefficient extraction and Clenshaw evaluation against
+  known values
+- **Python comparison tests**: Use the `pybridge` infrastructure to compare
+  Rust results against `skyfield`/`jplephem` for the same inputs
+- **Round-trip tests**: Evaluate at segment boundary times and verify continuity
+- **Edge cases**: First/last record, exact epoch boundaries, very short segments
+
+### 9.10 Reference Python Packages
+
+| Package | Types Supported | Notes |
+|---------|----------------|-------|
+| `jplephem` | 1, 2, 3, 21 | Brandon Rhodes, used by Skyfield |
+| `spktype01` | 1 | Shushi Uetsuki, standalone Type 1 reader |
+| `spktype21` | 21 | Shushi Uetsuki, standalone Type 21 reader |
+| `spiceypy` | All | Python wrapper around NAIF C toolkit |
+
+For algorithm details, `spktype21` and `jplephem` are the most readable
+reference implementations. The NAIF C toolkit (`cspice`) is authoritative but
+substantially harder to read.


### PR DESCRIPTION
## Summary
- Adds reference docs for DE ephemeris, Gaia, Hipparcos, HORIZONS API, SBDB API, and SPK kernels
- Migrated from the main starfield repo's `docs/data-sources/` directory

## Test plan
- [x] Files are valid markdown