### PR TITLE
Update Fink URLs to current ztf.fink-portal.org hostnames

### DIFF
--- a/crates/rubin/src/fink.rs
+++ b/crates/rubin/src/fink.rs
@@ -1,13 +1,13 @@
 //! Fink alert broker client.
 //!
-//! [Fink](https://fink-portal.org) is a French-led broker built on Apache
+//! [Fink](https://ztf.fink-portal.org) is a French-led broker built on Apache
 //! Spark with strong ML classification pipelines. It offers both a REST API
 //! and Kafka streaming.
 //!
 //! **Authentication:** None required for REST API queries.
 //! Kafka streaming requires credentials obtained by registration.
 //!
-//! **Documentation:** <https://fink-broker.readthedocs.io>
+//! **Documentation:** <https://fink-broker.org>
 
 use serde::Deserialize;
 use serde_json::Value;
@@ -15,13 +15,13 @@ use starfield::{Result, StarfieldError};
 use starfield_datasource_utils::{build_http_client, check_response_status};
 
 /// REST API base URL (ZTF data).
-pub const API_BASE_URL: &str = "https://api.fink-portal.org";
+pub const API_BASE_URL: &str = "https://api.ztf.fink-portal.org";
 
 /// REST API base URL for LSST data.
 pub const LSST_API_BASE_URL: &str = "https://api.lsst.fink-portal.org";
 
 /// Web portal URL.
-pub const PORTAL_URL: &str = "https://fink-portal.org";
+pub const PORTAL_URL: &str = "https://ztf.fink-portal.org";
 
 /// Client for the Fink broker REST API.
 pub struct FinkClient {
@@ -173,8 +173,8 @@ mod tests {
     #[test]
     fn test_api_url_matches_docs() {
         assert!(
-            API_BASE_URL.contains("fink-portal.org"),
-            "API_BASE_URL should point to fink-portal.org"
+            API_BASE_URL.contains("ztf.fink-portal.org"),
+            "API_BASE_URL should point to the current ztf.fink-portal.org host"
         );
     }
 }

--- a/crates/rubin/src/lib.rs
+++ b/crates/rubin/src/lib.rs
@@ -12,7 +12,7 @@
 //! |--------|------|--------|
 //! | [ALeRCE](https://alerce.online) | None | Public REST API |
 //! | [ANTARES](https://antares.noirlab.edu) | None (search) | Public REST API |
-//! | [Fink](https://fink-portal.org) | None | Public REST API |
+//! | [Fink](https://ztf.fink-portal.org) | None | Public REST API |
 //! | [Lasair](https://lasair-ztf.lsst.ac.uk) | API token | Requires registration |
 //! | [Pitt-Google](https://pitt-broker.readthedocs.io) | GCP credentials | Google Cloud native |
 //! | [AMPEL](https://ampel.zeuthen.desy.de) | Bearer token | GitHub org membership |


### PR DESCRIPTION
## Summary

- Fink migrated their ZTF endpoints from `fink-portal.org` / `api.fink-portal.org` → `ztf.fink-portal.org` / `api.ztf.fink-portal.org` per [astrolabsoftware/ztf.fink-portal.org#799](https://github.com/astrolabsoftware/ztf.fink-portal.org/issues/799). The old hosts still resolve but serve expired TLS certs.
- `crates/rubin/src/fink.rs` updated: `API_BASE_URL`, `PORTAL_URL`, and module/docs URLs point at the current hosts. `LSST_API_BASE_URL` left alone — `api.lsst.fink-portal.org` is still healthy.
- Docs URL changed from dead `fink-broker.readthedocs.io` (404) to `fink-broker.org` (live).

After this lands there are no expected TLS warnings in the broker URL check — the TLS-tolerance logic added in #23 stays as defensive infra for future cases.

## Test plan

- [x] `cargo test -p starfield-rubin` — unit tests green
- [x] `cargo test -p starfield-rubin --test url_verification -- --ignored` — all 7 brokers reachable, zero TLS warnings
- [x] Each of the 5 `FinkClient` REST routes (`/api/v1/{classes,latests,objects,conesearch,sso}`) returns 200 on the new host
- [x] `cargo fmt --check`, `cargo clippy -p starfield-rubin --all-targets` clean
- [ ] CI green

Closes #24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)