### PR TITLE
Sharded excerpt writer + gaia-excerpt CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/horizons",
     "crates/sbdb",
     "crates/gaia",
+    "crates/gaia-tools",
     "crates/hipparcos",
     "crates/mpc",
     "crates/rubin",
@@ -31,3 +32,5 @@ regex = "1.10"
 rand = "0.8"
 indicatif = "0.17"
 arrow = "58"
+cdshealpix = "0.9.1"
+clap = { version = "4", features = ["derive"] }

--- a/crates/gaia-tools/Cargo.toml
+++ b/crates/gaia-tools/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "starfield-gaia-tools"
+version = "0.1.0"
+description = "Command-line tools for the starfield-gaia ecosystem (excerpt + sharding)"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[[bin]]
+name = "gaia-excerpt"
+path = "src/main.rs"
+
+[dependencies]
+starfield = { workspace = true }
+starfield-gaia = { version = "0.2.0", path = "../gaia", features = ["all-releases"] }
+clap = { workspace = true }
+indicatif = { workspace = true }
+nalgebra = { workspace = true }
+flate2 = { workspace = true }

--- a/crates/gaia-tools/src/cli.rs
+++ b/crates/gaia-tools/src/cli.rs
@@ -1,0 +1,135 @@
+//! `clap`-based CLI surface for `gaia-excerpt`.
+
+use clap::{Parser, ValueEnum};
+use starfield::{Result, StarfieldError};
+use std::path::PathBuf;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "gaia-excerpt",
+    version,
+    about = "Subset and shard Gaia catalog files"
+)]
+pub struct Cli {
+    /// Input `.csv` or `.csv.gz` files (one or more).
+    #[arg(long = "input", required = true, num_args = 1..)]
+    pub input: Vec<PathBuf>,
+
+    /// Output directory for shard files. Created if missing.
+    #[arg(long = "output-dir", short = 'o')]
+    pub output_dir: PathBuf,
+
+    /// Which Gaia data release the inputs come from.
+    #[arg(long = "release", value_enum)]
+    pub release: ReleaseChoice,
+
+    /// Sharding strategy.
+    #[arg(long = "shard-by", value_enum, default_value_t = Sharder::Hash)]
+    pub shard_by: Sharder,
+
+    /// Number of shard files to write into.
+    #[arg(long = "shards", default_value_t = 64)]
+    pub shards: u32,
+
+    /// HEALPix depth used by `--shard-by healpix` (0..=29).
+    #[arg(long = "healpix-level", default_value_t = 6)]
+    pub healpix_level: u8,
+
+    /// Discard rows with `phot_g_mean_mag` greater than this at read time.
+    #[arg(long = "mag-limit")]
+    pub mag_limit: Option<f64>,
+
+    /// Cone filter "RA,DEC,RADIUS_DEG" (degrees, ICRS). All combinable filters
+    /// are AND'd together with `--mag-limit` and `--id-range`.
+    #[arg(long = "cone", value_parser = parse_cone)]
+    pub cone: Option<Cone>,
+
+    /// Source-id range filter "LOW,HIGH" (inclusive both ends).
+    #[arg(long = "id-range", value_parser = parse_id_range)]
+    pub id_range: Option<(u64, u64)>,
+
+    /// After every input is processed, sort each shard file by `--sort-by`.
+    /// Sort is in-memory per shard (so each shard must fit in RAM).
+    #[arg(long = "sort", default_value_t = false)]
+    pub sort: bool,
+
+    /// Field to sort each shard by when `--sort` is set.
+    #[arg(long = "sort-by", value_enum, default_value_t = SortField::SourceId)]
+    pub sort_by: SortField,
+}
+
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReleaseChoice {
+    Dr1,
+    Dr2,
+    Dr3,
+}
+
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Sharder {
+    Hash,
+    IdRange,
+    Healpix,
+}
+
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SortField {
+    SourceId,
+    PhotGMeanMag,
+    Ra,
+    RandomIndex,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Cone {
+    pub ra_deg: f64,
+    pub dec_deg: f64,
+    pub radius_deg: f64,
+}
+
+fn parse_cone(s: &str) -> Result<Cone> {
+    let parts: Vec<&str> = s.split(',').collect();
+    if parts.len() != 3 {
+        return Err(StarfieldError::DataError(format!(
+            "--cone wants RA,DEC,RADIUS_DEG; got {:?}",
+            s
+        )));
+    }
+    let ra_deg = parts[0]
+        .parse::<f64>()
+        .map_err(|e| StarfieldError::DataError(format!("--cone ra: {}", e)))?;
+    let dec_deg = parts[1]
+        .parse::<f64>()
+        .map_err(|e| StarfieldError::DataError(format!("--cone dec: {}", e)))?;
+    let radius_deg = parts[2]
+        .parse::<f64>()
+        .map_err(|e| StarfieldError::DataError(format!("--cone radius: {}", e)))?;
+    Ok(Cone {
+        ra_deg,
+        dec_deg,
+        radius_deg,
+    })
+}
+
+fn parse_id_range(s: &str) -> Result<(u64, u64)> {
+    let parts: Vec<&str> = s.split(',').collect();
+    if parts.len() != 2 {
+        return Err(StarfieldError::DataError(format!(
+            "--id-range wants LOW,HIGH; got {:?}",
+            s
+        )));
+    }
+    let lo = parts[0]
+        .parse::<u64>()
+        .map_err(|e| StarfieldError::DataError(format!("--id-range low: {}", e)))?;
+    let hi = parts[1]
+        .parse::<u64>()
+        .map_err(|e| StarfieldError::DataError(format!("--id-range high: {}", e)))?;
+    if lo > hi {
+        return Err(StarfieldError::DataError(format!(
+            "--id-range low ({}) must be <= high ({})",
+            lo, hi
+        )));
+    }
+    Ok((lo, hi))
+}

--- a/crates/gaia-tools/src/main.rs
+++ b/crates/gaia-tools/src/main.rs
@@ -1,0 +1,185 @@
+//! `gaia-excerpt` — apply a predicate to one or more Gaia CSV(.gz) files and
+//! write the kept entries to sharded gzipped CSVs that round-trip through
+//! `Dr{1,2,3}Catalog::from_csv_file`.
+
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("gaia-excerpt: {}", e);
+        std::process::exit(1);
+    }
+}
+
+mod cli;
+mod sort_step;
+
+use cli::{Cli, ReleaseChoice, Sharder};
+use indicatif::{ProgressBar, ProgressStyle};
+use starfield::Result;
+use starfield_gaia::excerpt::{
+    excerpt_csv_file, ExcerptSummary, HashIdShard, HealpixShard, IdRangeShard,
+};
+use starfield_gaia::{Dr1, Dr2, Dr3, GaiaRelease, GaiaSource};
+use std::path::PathBuf;
+
+fn run() -> Result<()> {
+    use clap::Parser;
+    let args = Cli::parse();
+
+    let multi = indicatif::MultiProgress::new();
+    let file_pb = multi.add(ProgressBar::new(args.input.len() as u64));
+    file_pb.set_style(
+        ProgressStyle::with_template(
+            "[{elapsed_precise}] {bar:40.cyan/blue} {pos}/{len} input files ({eta})",
+        )
+        .unwrap(),
+    );
+
+    let kept_pb = multi.add(ProgressBar::new_spinner());
+    kept_pb.set_style(
+        ProgressStyle::with_template("  kept: {pos} stars across {msg} shards").unwrap(),
+    );
+
+    let mut totals = Totals::default();
+    for input in &args.input {
+        match args.release {
+            ReleaseChoice::Dr1 => run_one::<Dr1>(input, &args, &mut totals, &kept_pb)?,
+            ReleaseChoice::Dr2 => run_one::<Dr2>(input, &args, &mut totals, &kept_pb)?,
+            ReleaseChoice::Dr3 => run_one::<Dr3>(input, &args, &mut totals, &kept_pb)?,
+        }
+        file_pb.inc(1);
+    }
+    file_pb.finish_with_message("done");
+    kept_pb.finish_and_clear();
+
+    println!(
+        "read {} stars across {} files; kept {} ({:.2}%); wrote {} shard files",
+        totals.input_rows,
+        args.input.len(),
+        totals.kept_rows,
+        if totals.input_rows == 0 {
+            0.0
+        } else {
+            100.0 * totals.kept_rows as f64 / totals.input_rows as f64
+        },
+        totals.distinct_shard_files.len(),
+    );
+
+    if args.sort {
+        eprintln!(
+            "\nsorting {} shard files by {:?} ...",
+            totals.distinct_shard_files.len(),
+            args.sort_by
+        );
+        let sort_pb = ProgressBar::new(totals.distinct_shard_files.len() as u64);
+        sort_pb.set_style(
+            ProgressStyle::with_template(
+                "[{elapsed_precise}] {bar:40.green/blue} {pos}/{len} sorted ({eta})",
+            )
+            .unwrap(),
+        );
+        for path in &totals.distinct_shard_files {
+            match args.release {
+                ReleaseChoice::Dr1 => sort_step::sort_shard::<Dr1>(path, args.sort_by)?,
+                ReleaseChoice::Dr2 => sort_step::sort_shard::<Dr2>(path, args.sort_by)?,
+                ReleaseChoice::Dr3 => sort_step::sort_shard::<Dr3>(path, args.sort_by)?,
+            }
+            sort_pb.inc(1);
+        }
+        sort_pb.finish_with_message("sorted");
+    }
+
+    Ok(())
+}
+
+#[derive(Default)]
+struct Totals {
+    input_rows: usize,
+    kept_rows: u64,
+    distinct_shard_files: Vec<PathBuf>,
+}
+
+fn run_one<R>(input: &PathBuf, args: &Cli, totals: &mut Totals, kept_pb: &ProgressBar) -> Result<()>
+where
+    R: GaiaRelease,
+{
+    let predicate = build_predicate::<R::Entry>(args)?;
+    let summary = match args.shard_by {
+        Sharder::Hash => excerpt_csv_file::<R, _, _>(
+            input,
+            args.mag_limit.unwrap_or(f64::INFINITY),
+            &args.output_dir,
+            HashIdShard {
+                num_shards: args.shards,
+            },
+            predicate,
+        )?,
+        Sharder::IdRange => excerpt_csv_file::<R, _, _>(
+            input,
+            args.mag_limit.unwrap_or(f64::INFINITY),
+            &args.output_dir,
+            IdRangeShard {
+                num_shards: args.shards,
+            },
+            predicate,
+        )?,
+        Sharder::Healpix => excerpt_csv_file::<R, _, _>(
+            input,
+            args.mag_limit.unwrap_or(f64::INFINITY),
+            &args.output_dir,
+            HealpixShard {
+                num_shards: args.shards,
+                level: args.healpix_level,
+            },
+            predicate,
+        )?,
+    };
+    accumulate(totals, summary, kept_pb);
+    Ok(())
+}
+
+fn accumulate(totals: &mut Totals, s: ExcerptSummary, kept_pb: &ProgressBar) {
+    totals.input_rows += s.input_rows;
+    totals.kept_rows += s.kept_rows;
+    for p in s.written_paths() {
+        if !totals.distinct_shard_files.iter().any(|x| x == p) {
+            totals.distinct_shard_files.push(p.clone());
+        }
+    }
+    kept_pb.set_position(totals.kept_rows);
+    kept_pb.set_message(totals.distinct_shard_files.len().to_string());
+}
+
+type BoxedPredicate<E> = Box<dyn FnMut(&E) -> bool + Send>;
+
+/// Compose mag/cone/id-range filters into a single closure. Cone filtering
+/// is done with great-circle distance via core unit vectors.
+fn build_predicate<E: GaiaSource + 'static>(args: &Cli) -> Result<BoxedPredicate<E>> {
+    let cone = args.cone;
+    let id_range = args.id_range;
+    let cone_threshold = cone.as_ref().map(|c| (c.radius_deg.to_radians()).cos());
+    let cone_center = cone.as_ref().map(|c| {
+        let ra_rad = c.ra_deg.to_radians();
+        let dec_rad = c.dec_deg.to_radians();
+        nalgebra::Vector3::new(
+            dec_rad.cos() * ra_rad.cos(),
+            dec_rad.cos() * ra_rad.sin(),
+            dec_rad.sin(),
+        )
+    });
+
+    Ok(Box::new(move |e: &E| {
+        let c = e.core();
+        if let Some((lo, hi)) = id_range {
+            if c.source_id < lo || c.source_id > hi {
+                return false;
+            }
+        }
+        if let (Some(center), Some(threshold)) = (cone_center.as_ref(), cone_threshold) {
+            let v = c.unit_vector();
+            if v.dot(center) < threshold {
+                return false;
+            }
+        }
+        true
+    }))
+}

--- a/crates/gaia-tools/src/sort_step.rs
+++ b/crates/gaia-tools/src/sort_step.rs
@@ -1,0 +1,64 @@
+//! Optional post-processing step: sort each shard file by a chosen field.
+//!
+//! Reads the shard back through the release's `Dr{N}Catalog::from_csv_file`
+//! path (so the data is parsed into typed entries with the same projection
+//! the loader uses), sorts by the requested field, and rewrites the file
+//! atomically via a tempfile + rename. In-memory per shard.
+
+use crate::cli::SortField;
+use flate2::{write::GzEncoder, Compression};
+use starfield::{Result, StarfieldError};
+use starfield_gaia::common::reader::CsvSourceReader;
+use starfield_gaia::{GaiaRelease, GaiaSource};
+use std::cmp::Ordering;
+use std::fs::{self, File};
+use std::io::{BufWriter, Write};
+use std::path::Path;
+
+pub fn sort_shard<R: GaiaRelease>(path: &Path, by: SortField) -> Result<()> {
+    // Read every entry from the shard (no mag filtering — keep everything).
+    let reader = CsvSourceReader::<R>::open(path, f64::INFINITY)?;
+    let mut entries: Vec<R::Entry> = Vec::new();
+    for e in reader {
+        entries.push(e?);
+    }
+
+    entries.sort_by(|a, b| compare(a, b, by));
+
+    // Write back to a sibling tmp file, then rename over.
+    let tmp_path = path.with_extension("csv.gz.sorting");
+    {
+        let file = File::create(&tmp_path).map_err(StarfieldError::IoError)?;
+        let gz = GzEncoder::new(file, Compression::default());
+        let mut buf = BufWriter::new(gz);
+        writeln!(buf, "{}", R::csv_header()).map_err(StarfieldError::IoError)?;
+        for e in &entries {
+            writeln!(buf, "{}", R::format_csv_row(e)).map_err(StarfieldError::IoError)?;
+        }
+        let gz = buf
+            .into_inner()
+            .map_err(|e: std::io::IntoInnerError<_>| StarfieldError::IoError(e.into_error()))?;
+        gz.finish().map_err(StarfieldError::IoError)?;
+    }
+    fs::rename(&tmp_path, path).map_err(StarfieldError::IoError)?;
+    Ok(())
+}
+
+fn compare<E: GaiaSource>(a: &E, b: &E, by: SortField) -> Ordering {
+    let ca = a.core();
+    let cb = b.core();
+    match by {
+        SortField::SourceId => ca.source_id.cmp(&cb.source_id),
+        SortField::PhotGMeanMag => ca
+            .phot_g_mean_mag
+            .partial_cmp(&cb.phot_g_mean_mag)
+            .unwrap_or(Ordering::Equal),
+        SortField::Ra => ca.ra.partial_cmp(&cb.ra).unwrap_or(Ordering::Equal),
+        SortField::RandomIndex => match (ca.random_index, cb.random_index) {
+            (Some(x), Some(y)) => x.cmp(&y),
+            (Some(_), None) => Ordering::Less,
+            (None, Some(_)) => Ordering::Greater,
+            (None, None) => Ordering::Equal,
+        },
+    }
+}

--- a/crates/gaia/Cargo.toml
+++ b/crates/gaia/Cargo.toml
@@ -26,4 +26,5 @@ regex = { workspace = true }
 rand = { workspace = true }
 nalgebra = { workspace = true }
 arrow = { workspace = true }
+cdshealpix = { workspace = true }
 starfield-datasource-utils = { version = "0.1.0", path = "../datasource-utils" }

--- a/crates/gaia/src/common/format.rs
+++ b/crates/gaia/src/common/format.rs
@@ -1,0 +1,35 @@
+//! Tiny formatting helpers used by per-release `format_csv_row` implementations.
+//!
+//! All helpers stringify in a way that round-trips through Rust's standard
+//! `FromStr` impls (and therefore through the arrow CSV reader's typed parsers).
+//! `Option::None` always becomes the empty string.
+
+use crate::common::core::VarFlag;
+use std::fmt::Display;
+
+#[inline]
+pub fn fopt<T: Display>(v: Option<T>) -> String {
+    match v {
+        Some(x) => x.to_string(),
+        None => String::new(),
+    }
+}
+
+#[inline]
+pub fn fopt_bool(v: Option<bool>) -> &'static str {
+    match v {
+        Some(true) => "true",
+        Some(false) => "false",
+        None => "",
+    }
+}
+
+#[inline]
+pub fn fvar(v: VarFlag) -> &'static str {
+    v.as_str()
+}
+
+#[inline]
+pub fn fopt_str(v: Option<&str>) -> &str {
+    v.unwrap_or("")
+}

--- a/crates/gaia/src/common/mod.rs
+++ b/crates/gaia/src/common/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod catalog;
 pub mod core;
+pub mod format;
 pub mod parse;
 pub mod reader;
 pub mod traits;

--- a/crates/gaia/src/common/reader.rs
+++ b/crates/gaia/src/common/reader.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 
 use arrow::csv::reader::Format;
 use arrow::csv::ReaderBuilder;
+use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 use flate2::read::GzDecoder;
 
@@ -61,8 +62,27 @@ impl<R: GaiaRelease> CsvSourceReader<R> {
         let header = read_csv_header(&mut buf)?;
         let csv_columns: Vec<&str> = header.trim_end().split(',').collect();
 
-        let schema = R::arrow_schema();
-        let projection: Vec<usize> = schema
+        // Arrow CSV's projection requires the schema to describe *every* column
+        // in the source file. We build a full-width schema by overlaying our
+        // typed schema (per-release `arrow_schema`) onto the CSV header order;
+        // unknown columns get DataType::Utf8 and are projected out.
+        let typed = R::arrow_schema();
+        let mut typed_by_name: std::collections::HashMap<&str, &Field> = Default::default();
+        for f in typed.fields() {
+            typed_by_name.insert(f.name().as_str(), f);
+        }
+        let full_fields: Vec<Field> = csv_columns
+            .iter()
+            .map(|name| match typed_by_name.get(name) {
+                Some(f) => Field::new(*name, f.data_type().clone(), f.is_nullable()),
+                None => Field::new(*name, DataType::Utf8, true),
+            })
+            .collect();
+        let full_schema = Arc::new(Schema::new(full_fields));
+
+        // Projection picks the columns we actually want (in our schema's order
+        // so `build_entry` can index batches by `ColIdx`).
+        let projection: Vec<usize> = typed
             .fields()
             .iter()
             .map(|f| {
@@ -81,7 +101,7 @@ impl<R: GaiaRelease> CsvSourceReader<R> {
             .collect::<Result<_>>()?;
 
         let format = Format::default().with_header(false);
-        let reader = ReaderBuilder::new(Arc::clone(&schema))
+        let reader = ReaderBuilder::new(full_schema)
             .with_format(format)
             .with_batch_size(BATCH_SIZE)
             .with_projection(projection)

--- a/crates/gaia/src/common/traits.rs
+++ b/crates/gaia/src/common/traits.rs
@@ -68,4 +68,19 @@ pub trait GaiaRelease: 'static {
     /// Build one entry from row `row` of `batch`. Columns are in the order declared
     /// by [`arrow_schema`].
     fn build_entry(batch: &RecordBatch, row: usize) -> Result<Self::Entry>;
+
+    /// Format an entry as one CSV row matching the column layout in [`arrow_schema`].
+    /// Floats use Rust's default `Display` (full round-trip precision); `Option::None`
+    /// becomes the empty string. Output is parseable by [`from_csv_file`](crate::common::catalog::GaiaCatalogBase::from_csv_file).
+    fn format_csv_row(entry: &Self::Entry) -> String;
+
+    /// Comma-joined header line listing every column in [`arrow_schema`] order.
+    fn csv_header() -> String {
+        Self::arrow_schema()
+            .fields()
+            .iter()
+            .map(|f| f.name().clone())
+            .collect::<Vec<_>>()
+            .join(",")
+    }
 }

--- a/crates/gaia/src/dr1/schema.rs
+++ b/crates/gaia/src/dr1/schema.rs
@@ -7,6 +7,7 @@ use arrow::record_batch::RecordBatch;
 use starfield::Result;
 
 use crate::common::core::{GaiaCore, VarFlag};
+use crate::common::format::*;
 use crate::common::parse::*;
 use crate::common::traits::{GaiaRelease, Release};
 use crate::dr1::entry::{AstrometricExtra, Dr1Entry, ScanDirection};
@@ -99,6 +100,64 @@ impl GaiaRelease for Dr1 {
             scan_direction,
             tgas: None,
         })
+    }
+
+    fn format_csv_row(e: &Self::Entry) -> String {
+        let c = &e.core;
+        let ax = &e.astrometric_extra;
+        let sd = &e.scan_direction;
+        // Order MUST match COLUMNS below.
+        [
+            c.source_id.to_string(),
+            c.solution_id.to_string(),
+            c.ref_epoch.to_string(),
+            fopt(c.random_index),
+            c.ra.to_string(),
+            c.ra_error.to_string(),
+            c.dec.to_string(),
+            c.dec_error.to_string(),
+            fopt(c.ra_dec_corr),
+            fopt(c.parallax),
+            fopt(c.parallax_error),
+            fopt(c.pmra),
+            fopt(c.pmra_error),
+            fopt(c.pmdec),
+            fopt(c.pmdec_error),
+            c.l.to_string(),
+            c.b.to_string(),
+            c.ecl_lon.to_string(),
+            c.ecl_lat.to_string(),
+            c.phot_g_mean_mag.to_string(),
+            fopt(c.phot_g_mean_flux),
+            fopt(c.phot_g_mean_flux_error),
+            fopt(c.phot_g_n_obs),
+            fvar(c.phot_variable_flag).to_string(),
+            fopt(c.astrometric_n_obs_al),
+            fopt(c.astrometric_excess_noise),
+            fopt(c.astrometric_excess_noise_sig),
+            fopt_bool(c.astrometric_primary_flag).to_string(),
+            fopt_bool(c.duplicated_source).to_string(),
+            fopt(c.matched_observations),
+            fopt(ax.astrometric_n_obs_ac),
+            fopt(ax.astrometric_n_good_obs_al),
+            fopt(ax.astrometric_n_good_obs_ac),
+            fopt(ax.astrometric_n_bad_obs_al),
+            fopt(ax.astrometric_n_bad_obs_ac),
+            fopt(ax.astrometric_delta_q),
+            fopt(ax.astrometric_relegation_factor),
+            fopt(ax.astrometric_weight_al),
+            fopt(ax.astrometric_weight_ac),
+            fopt(ax.astrometric_priors_used),
+            fopt(sd.strength_k1),
+            fopt(sd.strength_k2),
+            fopt(sd.strength_k3),
+            fopt(sd.strength_k4),
+            fopt(sd.mean_k1),
+            fopt(sd.mean_k2),
+            fopt(sd.mean_k3),
+            fopt(sd.mean_k4),
+        ]
+        .join(",")
     }
 }
 

--- a/crates/gaia/src/dr2/schema.rs
+++ b/crates/gaia/src/dr2/schema.rs
@@ -7,6 +7,7 @@ use arrow::record_batch::RecordBatch;
 use starfield::Result;
 
 use crate::common::core::{GaiaCore, VarFlag};
+use crate::common::format::*;
 use crate::common::parse::*;
 use crate::common::traits::{GaiaRelease, Release};
 use crate::dr2::entry::{AstroParams, AstrometricExtra, BpRpPhotometry, Dr2Entry, RadialVelocity};
@@ -165,6 +166,101 @@ impl GaiaRelease for Dr2 {
             radial_velocity,
             astrophysical,
         })
+    }
+
+    fn format_csv_row(e: &Self::Entry) -> String {
+        let c = &e.core;
+        let ax = &e.astrometric_extra;
+        let bp = e.bp_rp.as_ref();
+        let rv = e.radial_velocity.as_ref();
+        let ap = e.astrophysical.as_ref();
+        // Order MUST match COLUMNS below.
+        [
+            c.source_id.to_string(),
+            c.solution_id.to_string(),
+            fopt_str(e.designation.as_deref()).to_string(),
+            c.ref_epoch.to_string(),
+            fopt(c.random_index),
+            c.ra.to_string(),
+            c.ra_error.to_string(),
+            c.dec.to_string(),
+            c.dec_error.to_string(),
+            fopt(c.ra_dec_corr),
+            fopt(c.parallax),
+            fopt(c.parallax_error),
+            fopt(e.parallax_over_error),
+            fopt(c.pmra),
+            fopt(c.pmra_error),
+            fopt(c.pmdec),
+            fopt(c.pmdec_error),
+            c.l.to_string(),
+            c.b.to_string(),
+            c.ecl_lon.to_string(),
+            c.ecl_lat.to_string(),
+            c.phot_g_mean_mag.to_string(),
+            fopt(c.phot_g_mean_flux),
+            fopt(c.phot_g_mean_flux_error),
+            fopt(c.phot_g_n_obs),
+            fvar(c.phot_variable_flag).to_string(),
+            fopt(c.astrometric_n_obs_al),
+            fopt(c.astrometric_excess_noise),
+            fopt(c.astrometric_excess_noise_sig),
+            fopt_bool(c.astrometric_primary_flag).to_string(),
+            fopt_bool(c.duplicated_source).to_string(),
+            fopt(c.matched_observations),
+            fopt(ax.astrometric_n_good_obs_al),
+            fopt(ax.astrometric_n_bad_obs_al),
+            fopt(ax.astrometric_gof_al),
+            fopt(ax.astrometric_chi2_al),
+            fopt(ax.astrometric_params_solved),
+            fopt(ax.astrometric_weight_al),
+            fopt(ax.astrometric_pseudo_colour),
+            fopt(ax.astrometric_pseudo_colour_error),
+            fopt(ax.mean_varpi_factor_al),
+            fopt(ax.astrometric_matched_observations),
+            fopt(ax.visibility_periods_used),
+            fopt(ax.astrometric_sigma5d_max),
+            fopt(ax.frame_rotator_object_type),
+            fopt(bp.and_then(|b| b.phot_bp_n_obs)),
+            fopt(bp.and_then(|b| b.phot_bp_mean_flux)),
+            fopt(bp.and_then(|b| b.phot_bp_mean_flux_error)),
+            fopt(bp.and_then(|b| b.phot_bp_mean_flux_over_error)),
+            fopt(bp.and_then(|b| b.phot_bp_mean_mag)),
+            fopt(bp.and_then(|b| b.phot_rp_n_obs)),
+            fopt(bp.and_then(|b| b.phot_rp_mean_flux)),
+            fopt(bp.and_then(|b| b.phot_rp_mean_flux_error)),
+            fopt(bp.and_then(|b| b.phot_rp_mean_flux_over_error)),
+            fopt(bp.and_then(|b| b.phot_rp_mean_mag)),
+            fopt(bp.and_then(|b| b.phot_bp_rp_excess_factor)),
+            fopt(bp.and_then(|b| b.phot_proc_mode)),
+            fopt(bp.and_then(|b| b.bp_rp)),
+            fopt(bp.and_then(|b| b.bp_g)),
+            fopt(bp.and_then(|b| b.g_rp)),
+            fopt(rv.and_then(|r| r.radial_velocity)),
+            fopt(rv.and_then(|r| r.radial_velocity_error)),
+            fopt(rv.and_then(|r| r.rv_nb_transits)),
+            fopt(rv.and_then(|r| r.rv_template_teff)),
+            fopt(rv.and_then(|r| r.rv_template_logg)),
+            fopt(rv.and_then(|r| r.rv_template_fe_h)),
+            fopt(ap.and_then(|a| a.priam_flags)),
+            fopt(ap.and_then(|a| a.teff_val)),
+            fopt(ap.and_then(|a| a.teff_percentile_lower)),
+            fopt(ap.and_then(|a| a.teff_percentile_upper)),
+            fopt(ap.and_then(|a| a.a_g_val)),
+            fopt(ap.and_then(|a| a.a_g_percentile_lower)),
+            fopt(ap.and_then(|a| a.a_g_percentile_upper)),
+            fopt(ap.and_then(|a| a.e_bp_min_rp_val)),
+            fopt(ap.and_then(|a| a.e_bp_min_rp_percentile_lower)),
+            fopt(ap.and_then(|a| a.e_bp_min_rp_percentile_upper)),
+            fopt(ap.and_then(|a| a.flame_flags)),
+            fopt(ap.and_then(|a| a.radius_val)),
+            fopt(ap.and_then(|a| a.radius_percentile_lower)),
+            fopt(ap.and_then(|a| a.radius_percentile_upper)),
+            fopt(ap.and_then(|a| a.lum_val)),
+            fopt(ap.and_then(|a| a.lum_percentile_lower)),
+            fopt(ap.and_then(|a| a.lum_percentile_upper)),
+        ]
+        .join(",")
     }
 }
 

--- a/crates/gaia/src/dr3/schema.rs
+++ b/crates/gaia/src/dr3/schema.rs
@@ -7,6 +7,7 @@ use arrow::record_batch::RecordBatch;
 use starfield::Result;
 
 use crate::common::core::{GaiaCore, VarFlag};
+use crate::common::format::*;
 use crate::common::parse::*;
 use crate::common::traits::{GaiaRelease, Release};
 use crate::dr3::entry::{
@@ -187,6 +188,118 @@ impl GaiaRelease for Dr3 {
             data_links,
             classifications,
         })
+    }
+
+    fn format_csv_row(e: &Self::Entry) -> String {
+        let c = &e.core;
+        let ax = &e.astrometric_extra;
+        let ip = &e.ipd;
+        let bp = e.bp_rp.as_ref();
+        let rv = e.radial_velocity.as_ref();
+        let gsp = e.gspphot.as_ref();
+        let dl = &e.data_links;
+        let cl = &e.classifications;
+        // Order MUST match COLUMNS below.
+        [
+            c.source_id.to_string(),
+            c.solution_id.to_string(),
+            c.ref_epoch.to_string(),
+            fopt(c.random_index),
+            fopt_str(e.designation.as_deref()).to_string(),
+            c.ra.to_string(),
+            c.ra_error.to_string(),
+            c.dec.to_string(),
+            c.dec_error.to_string(),
+            fopt(c.ra_dec_corr),
+            fopt(c.parallax),
+            fopt(c.parallax_error),
+            fopt(e.parallax_over_error),
+            fopt(e.pm),
+            fopt(c.pmra),
+            fopt(c.pmra_error),
+            fopt(c.pmdec),
+            fopt(c.pmdec_error),
+            c.l.to_string(),
+            c.b.to_string(),
+            c.ecl_lon.to_string(),
+            c.ecl_lat.to_string(),
+            c.phot_g_mean_mag.to_string(),
+            fopt(c.phot_g_mean_flux),
+            fopt(c.phot_g_mean_flux_error),
+            fopt(c.phot_g_n_obs),
+            fvar(c.phot_variable_flag).to_string(),
+            fopt(c.astrometric_n_obs_al),
+            fopt(c.astrometric_excess_noise),
+            fopt(c.astrometric_excess_noise_sig),
+            fopt_bool(c.astrometric_primary_flag).to_string(),
+            fopt_bool(c.duplicated_source).to_string(),
+            fopt(c.matched_observations),
+            fopt(ax.astrometric_n_good_obs_al),
+            fopt(ax.astrometric_n_bad_obs_al),
+            fopt(ax.astrometric_gof_al),
+            fopt(ax.astrometric_chi2_al),
+            fopt(ax.astrometric_params_solved),
+            fopt(ax.visibility_periods_used),
+            fopt(ax.astrometric_sigma5d_max),
+            fopt(ax.nu_eff_used_in_astrometry),
+            fopt(ax.pseudocolour),
+            fopt(ax.pseudocolour_error),
+            fopt(ip.ruwe),
+            fopt(ip.ipd_gof_harmonic_amplitude),
+            fopt(ip.ipd_gof_harmonic_phase),
+            fopt(ip.ipd_frac_multi_peak),
+            fopt(ip.ipd_frac_odd_win),
+            fopt(bp.and_then(|b| b.phot_bp_mean_mag)),
+            fopt(bp.and_then(|b| b.phot_bp_mean_flux)),
+            fopt(bp.and_then(|b| b.phot_bp_mean_flux_error)),
+            fopt(bp.and_then(|b| b.phot_bp_n_obs)),
+            fopt(bp.and_then(|b| b.phot_rp_mean_mag)),
+            fopt(bp.and_then(|b| b.phot_rp_mean_flux)),
+            fopt(bp.and_then(|b| b.phot_rp_mean_flux_error)),
+            fopt(bp.and_then(|b| b.phot_rp_n_obs)),
+            fopt(bp.and_then(|b| b.bp_rp)),
+            fopt(bp.and_then(|b| b.bp_g)),
+            fopt(bp.and_then(|b| b.g_rp)),
+            fopt(bp.and_then(|b| b.phot_bp_rp_excess_factor)),
+            fopt(bp.and_then(|b| b.phot_proc_mode)),
+            fopt(rv.and_then(|r| r.radial_velocity)),
+            fopt(rv.and_then(|r| r.radial_velocity_error)),
+            fopt(rv.and_then(|r| r.rv_method_used)),
+            fopt(rv.and_then(|r| r.rv_nb_transits)),
+            fopt(rv.and_then(|r| r.rv_expected_sig_to_noise)),
+            fopt(rv.and_then(|r| r.rv_amplitude_robust)),
+            fopt(rv.and_then(|r| r.rv_template_teff)),
+            fopt(rv.and_then(|r| r.rv_template_logg)),
+            fopt(rv.and_then(|r| r.rv_template_fe_h)),
+            fopt(rv.and_then(|r| r.rv_atm_param_origin)),
+            fopt(gsp.and_then(|g| g.teff_gspphot)),
+            fopt(gsp.and_then(|g| g.teff_gspphot_lower)),
+            fopt(gsp.and_then(|g| g.teff_gspphot_upper)),
+            fopt(gsp.and_then(|g| g.logg_gspphot)),
+            fopt(gsp.and_then(|g| g.mh_gspphot)),
+            fopt(gsp.and_then(|g| g.distance_gspphot)),
+            fopt(gsp.and_then(|g| g.distance_gspphot_lower)),
+            fopt(gsp.and_then(|g| g.distance_gspphot_upper)),
+            fopt(gsp.and_then(|g| g.azero_gspphot)),
+            fopt(gsp.and_then(|g| g.ag_gspphot)),
+            fopt(gsp.and_then(|g| g.ebpminrp_gspphot)),
+            fopt_str(gsp.and_then(|g| g.libname_gspphot.as_deref())).to_string(),
+            fopt_bool(dl.has_xp_continuous).to_string(),
+            fopt_bool(dl.has_xp_sampled).to_string(),
+            fopt_bool(dl.has_rvs).to_string(),
+            fopt_bool(dl.has_epoch_photometry).to_string(),
+            fopt_bool(dl.has_epoch_rv).to_string(),
+            fopt_bool(dl.has_mcmc_gspphot).to_string(),
+            fopt_bool(dl.has_mcmc_msc).to_string(),
+            fopt_bool(cl.in_qso_candidates).to_string(),
+            fopt_bool(cl.in_galaxy_candidates).to_string(),
+            fopt_bool(cl.in_andromeda_survey).to_string(),
+            fopt(cl.non_single_star),
+            fopt(cl.classprob_dsc_combmod_quasar),
+            fopt(cl.classprob_dsc_combmod_galaxy),
+            fopt(cl.classprob_dsc_combmod_star),
+        ]
+        .join(",")
     }
 }
 

--- a/crates/gaia/src/excerpt.rs
+++ b/crates/gaia/src/excerpt.rs
@@ -1,0 +1,291 @@
+//! Sharded, incremental excerpt writer.
+//!
+//! Reads any Gaia CSV(.gz) catalog, applies a caller-supplied predicate, and
+//! writes the kept entries to one of N shard files chosen by a [`ShardKey`]. Each
+//! shard is written as gzipped CSV in the source release's own column layout, so
+//! the output round-trips back through `Dr{1,2,3}Catalog::from_csv_file`.
+//!
+//! Per-shard files are opened lazily (only when first written to) so excerpts
+//! that touch only a few shards don't litter the output directory with empty
+//! files.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use starfield_gaia::excerpt::{excerpt_csv_file, HashIdShard};
+//! use starfield_gaia::Dr3;
+//!
+//! let summary = excerpt_csv_file::<Dr3, _, _>(
+//!     "GaiaSource_000000-003111.csv.gz",
+//!     20.0,
+//!     "out/",
+//!     HashIdShard { num_shards: 32 },
+//!     |entry| entry.core.phot_g_mean_mag < 16.0,
+//! )?;
+//! println!("kept {} of {} stars across {} shards",
+//!          summary.kept_rows, summary.input_rows, summary.shard_files.len());
+//! # Ok::<(), starfield::StarfieldError>(())
+//! ```
+
+use std::fs::{self, File};
+use std::io::{BufWriter, Write};
+use std::marker::PhantomData;
+use std::path::{Path, PathBuf};
+
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use starfield::{Result, StarfieldError};
+
+use crate::common::reader::CsvSourceReader;
+use crate::common::traits::{GaiaRelease, GaiaSource};
+
+// =====================================================================================
+// Sharding trait + built-in embodiments
+// =====================================================================================
+
+/// Maps an entry to a shard index in `0..num_shards()`.
+///
+/// Built-in embodiments cover the common cases (hash-of-id, id-range banding,
+/// HEALPix cell). Implement this trait directly to shard by anything else
+/// (brightness, date, custom hash, etc.).
+pub trait ShardKey<E> {
+    /// Number of shards. Returned values from [`shard_of`](Self::shard_of) must lie in `0..num_shards()`.
+    fn num_shards(&self) -> u32;
+
+    /// The shard index for one entry. Must be `< num_shards()`.
+    fn shard_of(&self, entry: &E) -> u32;
+}
+
+/// Shard by `hash(source_id) % num_shards`. Roughly even distribution; loses
+/// any spatial / brightness locality. Use when you want shards of similar
+/// size for parallel processing.
+#[derive(Debug, Clone, Copy)]
+pub struct HashIdShard {
+    pub num_shards: u32,
+}
+
+impl<E: GaiaSource> ShardKey<E> for HashIdShard {
+    fn num_shards(&self) -> u32 {
+        self.num_shards
+    }
+    fn shard_of(&self, entry: &E) -> u32 {
+        // SplitMix64 (see `mix_id`) is deterministic across runs, so the same
+        // source_id always lands in the same shard — important for incremental
+        // / resumable workflows. `std::hash`-based hashers are randomized per
+        // process and would make this non-reproducible.
+        let mixed = mix_id(entry.core().source_id);
+        (mixed % self.num_shards as u64) as u32
+    }
+}
+
+/// SplitMix64 — deterministic, very fast, good distribution. Used to break the
+/// HEALPix-12 bit alignment in Gaia source_ids before bucketing.
+fn mix_id(x: u64) -> u64 {
+    let mut z = x.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^ (z >> 31)
+}
+
+/// Shard by source_id range — divide the `u64` ID space into `num_shards`
+/// equal-width buckets. For DR2/DR3 source_ids encode HEALPix-12 in the high
+/// bits, so this gives spatial locality "for free" (nearby pixels in adjacent
+/// shards). For DR1 the encoding differs and locality is weaker.
+#[derive(Debug, Clone, Copy)]
+pub struct IdRangeShard {
+    pub num_shards: u32,
+}
+
+impl<E: GaiaSource> ShardKey<E> for IdRangeShard {
+    fn num_shards(&self) -> u32 {
+        self.num_shards
+    }
+    fn shard_of(&self, entry: &E) -> u32 {
+        let id = entry.core().source_id;
+        let bucket_size = (u64::MAX / self.num_shards as u64).saturating_add(1);
+        ((id / bucket_size) as u32).min(self.num_shards - 1)
+    }
+}
+
+/// Shard by HEALPix cell at the given depth, modulo `num_shards`. Computes
+/// the pixel from the entry's RA/Dec via [`cdshealpix::nested::hash`], so it
+/// works identically across DR1/DR2/DR3.
+#[derive(Debug, Clone, Copy)]
+pub struct HealpixShard {
+    pub num_shards: u32,
+    /// HEALPix depth (0..=29). Higher = finer pixels. Default 6 (49,152 pixels).
+    pub level: u8,
+}
+
+impl<E: GaiaSource> ShardKey<E> for HealpixShard {
+    fn num_shards(&self) -> u32 {
+        self.num_shards
+    }
+    fn shard_of(&self, entry: &E) -> u32 {
+        let c = entry.core();
+        let pixel = cdshealpix::nested::hash(self.level, c.ra.to_radians(), c.dec.to_radians());
+        (pixel % self.num_shards as u64) as u32
+    }
+}
+
+// =====================================================================================
+// Sharded gzipped CSV writer
+// =====================================================================================
+
+/// Streaming sharded CSV.gz writer. Files are opened lazily — a shard that
+/// receives no entries leaves no file behind.
+pub struct ShardedCsvWriter<R: GaiaRelease, S: ShardKey<R::Entry>> {
+    output_dir: PathBuf,
+    shard_key: S,
+    writers: Vec<Option<BufWriter<GzEncoder<File>>>>,
+    counts: Vec<u64>,
+    paths: Vec<Option<PathBuf>>,
+    width: usize,
+    _marker: PhantomData<R>,
+}
+
+impl<R: GaiaRelease, S: ShardKey<R::Entry>> ShardedCsvWriter<R, S> {
+    /// Create a new writer rooted at `output_dir`. Creates the directory if missing.
+    pub fn new(output_dir: impl AsRef<Path>, shard_key: S) -> Result<Self> {
+        let output_dir = output_dir.as_ref().to_path_buf();
+        fs::create_dir_all(&output_dir).map_err(StarfieldError::IoError)?;
+        let n = shard_key.num_shards();
+        if n == 0 {
+            return Err(StarfieldError::DataError(
+                "ShardedCsvWriter: num_shards must be > 0".into(),
+            ));
+        }
+        let width = digits_for(n);
+        let mut writers = Vec::with_capacity(n as usize);
+        let mut paths = Vec::with_capacity(n as usize);
+        for _ in 0..n {
+            writers.push(None);
+            paths.push(None);
+        }
+        Ok(Self {
+            output_dir,
+            shard_key,
+            writers,
+            counts: vec![0; n as usize],
+            paths,
+            width,
+            _marker: PhantomData,
+        })
+    }
+
+    /// Write one entry to its shard file, opening the file (and writing the CSV
+    /// header) the first time that shard is touched.
+    pub fn write(&mut self, entry: &R::Entry) -> Result<()> {
+        let shard = self.shard_key.shard_of(entry);
+        if shard >= self.writers.len() as u32 {
+            return Err(StarfieldError::DataError(format!(
+                "ShardKey returned {} for num_shards={}",
+                shard,
+                self.writers.len()
+            )));
+        }
+        let idx = shard as usize;
+
+        if self.writers[idx].is_none() {
+            let filename = format!("shard_{:0width$}.csv.gz", shard, width = self.width);
+            let path = self.output_dir.join(&filename);
+            let file = File::create(&path).map_err(StarfieldError::IoError)?;
+            let gz = GzEncoder::new(file, Compression::default());
+            let mut buf = BufWriter::new(gz);
+            writeln!(buf, "{}", R::csv_header()).map_err(StarfieldError::IoError)?;
+            self.writers[idx] = Some(buf);
+            self.paths[idx] = Some(path);
+        }
+
+        let row = R::format_csv_row(entry);
+        let writer = self.writers[idx].as_mut().unwrap();
+        writeln!(writer, "{}", row).map_err(StarfieldError::IoError)?;
+        self.counts[idx] += 1;
+        Ok(())
+    }
+
+    /// Finalize: flush every open shard file and return a summary.
+    pub fn finish(mut self) -> Result<ExcerptSummary> {
+        for w in self.writers.iter_mut() {
+            if let Some(buf) = w.take() {
+                let gz = buf
+                    .into_inner()
+                    .map_err(|e| StarfieldError::IoError(e.into_error()))?;
+                gz.finish().map_err(StarfieldError::IoError)?;
+            }
+        }
+        Ok(ExcerptSummary {
+            input_rows: 0, // populated by `excerpt_csv_file`
+            kept_rows: self.counts.iter().sum(),
+            per_shard_counts: self.counts,
+            shard_files: self.paths,
+        })
+    }
+}
+
+fn digits_for(n: u32) -> usize {
+    // Number of digits needed to represent `n - 1`, with a minimum of 4 so file
+    // listings sort sensibly even for small shard counts.
+    let max_idx = n.saturating_sub(1);
+    let nd = if max_idx == 0 {
+        1
+    } else {
+        (max_idx as f64).log10().floor() as usize + 1
+    };
+    nd.max(4)
+}
+
+// =====================================================================================
+// Summary + convenience function
+// =====================================================================================
+
+/// What the excerpt run produced. `shard_files[i]` is `Some(path)` iff shard `i`
+/// received at least one entry.
+#[derive(Debug, Clone)]
+pub struct ExcerptSummary {
+    pub input_rows: usize,
+    pub kept_rows: u64,
+    pub per_shard_counts: Vec<u64>,
+    pub shard_files: Vec<Option<PathBuf>>,
+}
+
+impl ExcerptSummary {
+    /// Paths of every shard file that was actually written (Some entries only).
+    pub fn written_paths(&self) -> impl Iterator<Item = &PathBuf> {
+        self.shard_files.iter().flatten()
+    }
+}
+
+/// Read a single CSV(.gz) file, apply `predicate` to each row's typed entry,
+/// and stream the kept entries into shard files in `output_dir`.
+///
+/// `mag_limit` is applied at read time as a fast pre-filter on `phot_g_mean_mag`;
+/// rows fainter than the limit never materialize. `predicate` runs after the
+/// mag-limit pass and gets full access to the typed entry (including any nested
+/// sub-structs your release exposes).
+pub fn excerpt_csv_file<R, S, F>(
+    input_path: impl AsRef<Path>,
+    mag_limit: f64,
+    output_dir: impl AsRef<Path>,
+    sharder: S,
+    mut predicate: F,
+) -> Result<ExcerptSummary>
+where
+    R: GaiaRelease,
+    S: ShardKey<R::Entry>,
+    F: FnMut(&R::Entry) -> bool,
+{
+    let mut writer = ShardedCsvWriter::<R, S>::new(output_dir, sharder)?;
+    let mut input_rows = 0usize;
+    let reader = CsvSourceReader::<R>::open(input_path, mag_limit)?;
+    for entry in reader {
+        let entry = entry?;
+        input_rows += 1;
+        if predicate(&entry) {
+            writer.write(&entry)?;
+        }
+    }
+    let mut summary = writer.finish()?;
+    summary.input_rows = input_rows;
+    Ok(summary)
+}

--- a/crates/gaia/src/lib.rs
+++ b/crates/gaia/src/lib.rs
@@ -28,6 +28,7 @@
 
 pub mod common;
 pub mod download;
+pub mod excerpt;
 
 #[cfg(feature = "dr1")]
 pub mod dr1;

--- a/crates/gaia/tests/dr3_excerpt.rs
+++ b/crates/gaia/tests/dr3_excerpt.rs
@@ -1,0 +1,189 @@
+//! End-to-end excerpt test: write a synthetic DR3 fixture with known rows,
+//! shard via every built-in `ShardKey`, and verify (a) every kept row lands
+//! in some shard, (b) shard membership respects the rule, (c) shard files
+//! round-trip back through `Dr3Catalog::from_csv_file`.
+#![cfg(feature = "dr3")]
+
+use std::collections::HashMap;
+use std::io::Write;
+
+use starfield::catalogs::StarCatalog;
+use starfield_gaia::excerpt::{
+    excerpt_csv_file, HashIdShard, HealpixShard, IdRangeShard, ShardKey,
+};
+use starfield_gaia::{Dr3, Dr3Catalog};
+
+const HEADER: &str = "source_id,solution_id,ref_epoch,random_index,designation,ra,ra_error,dec,dec_error,ra_dec_corr,parallax,parallax_error,parallax_over_error,pm,pmra,pmra_error,pmdec,pmdec_error,l,b,ecl_lon,ecl_lat,phot_g_mean_mag,phot_g_mean_flux,phot_g_mean_flux_error,phot_g_n_obs,phot_variable_flag,astrometric_n_obs_al,astrometric_excess_noise,astrometric_excess_noise_sig,astrometric_primary_flag,duplicated_source,matched_observations,astrometric_n_good_obs_al,astrometric_n_bad_obs_al,astrometric_gof_al,astrometric_chi2_al,astrometric_params_solved,visibility_periods_used,astrometric_sigma5d_max,nu_eff_used_in_astrometry,pseudocolour,pseudocolour_error,ruwe,ipd_gof_harmonic_amplitude,ipd_gof_harmonic_phase,ipd_frac_multi_peak,ipd_frac_odd_win,phot_bp_mean_mag,phot_bp_mean_flux,phot_bp_mean_flux_error,phot_bp_n_obs,phot_rp_mean_mag,phot_rp_mean_flux,phot_rp_mean_flux_error,phot_rp_n_obs,bp_rp,bp_g,g_rp,phot_bp_rp_excess_factor,phot_proc_mode,radial_velocity,radial_velocity_error,rv_method_used,rv_nb_transits,rv_expected_sig_to_noise,rv_amplitude_robust,rv_template_teff,rv_template_logg,rv_template_fe_h,rv_atm_param_origin,teff_gspphot,teff_gspphot_lower,teff_gspphot_upper,logg_gspphot,mh_gspphot,distance_gspphot,distance_gspphot_lower,distance_gspphot_upper,azero_gspphot,ag_gspphot,ebpminrp_gspphot,libname_gspphot,has_xp_continuous,has_xp_sampled,has_rvs,has_epoch_photometry,has_epoch_rv,has_mcmc_gspphot,has_mcmc_msc,in_qso_candidates,in_galaxy_candidates,in_andromeda_survey,non_single_star,classprob_dsc_combmod_quasar,classprob_dsc_combmod_galaxy,classprob_dsc_combmod_star";
+
+fn row_from(overrides: &HashMap<&str, &str>) -> String {
+    HEADER
+        .split(',')
+        .map(|c| overrides.get(c).copied().unwrap_or(""))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+/// Build a fixture with N synthetic rows whose source_ids cover a wide range
+/// and whose ra/dec are scattered across the sphere.
+fn write_n_row_fixture(n: usize) -> tempfile::NamedTempFile {
+    let mut f = tempfile::Builder::new().suffix(".csv").tempfile().unwrap();
+    writeln!(f, "{}", HEADER).unwrap();
+    for i in 0..n {
+        let id = (i as u64).wrapping_mul(0x123_4567_89AB_CDEF);
+        let mag = 4.0 + (i as f64) * 0.05;
+        let ra = (i as f64 * 7.13) % 360.0;
+        let dec = -85.0 + (i as f64 * 1.91) % 170.0;
+        let row = row_from(&HashMap::from([
+            ("source_id", id.to_string().as_str()),
+            ("solution_id", "1635721458409799680"),
+            ("ref_epoch", "2016.0"),
+            ("ra", ra.to_string().as_str()),
+            ("ra_error", "0.04"),
+            ("dec", dec.to_string().as_str()),
+            ("dec_error", "0.04"),
+            ("l", "0.0"),
+            ("b", "0.0"),
+            ("ecl_lon", "0.0"),
+            ("ecl_lat", "0.0"),
+            ("phot_g_mean_mag", mag.to_string().as_str()),
+            ("phot_variable_flag", "NOT_AVAILABLE"),
+        ]));
+        writeln!(f, "{}", row).unwrap();
+    }
+    f.flush().unwrap();
+    f
+}
+
+#[test]
+fn excerpt_round_trip_with_hash_shard() {
+    let fixture = write_n_row_fixture(200);
+    let out = tempfile::tempdir().unwrap();
+    let summary = excerpt_csv_file::<Dr3, _, _>(
+        fixture.path(),
+        f64::INFINITY,
+        out.path(),
+        HashIdShard { num_shards: 8 },
+        |_| true,
+    )
+    .expect("excerpt");
+
+    assert_eq!(summary.input_rows, 200);
+    assert_eq!(summary.kept_rows, 200);
+    assert_eq!(summary.per_shard_counts.iter().sum::<u64>(), 200);
+
+    // Reload every shard and verify every original source_id is present.
+    let mut all_ids = Vec::new();
+    for path in summary.written_paths() {
+        let cat = Dr3Catalog::from_csv_file(path, f64::INFINITY).expect("reload shard");
+        for s in cat.stars() {
+            all_ids.push(s.core.source_id);
+        }
+    }
+    all_ids.sort();
+    let mut expected: Vec<u64> = (0..200u64)
+        .map(|i| i.wrapping_mul(0x123_4567_89AB_CDEF))
+        .collect();
+    expected.sort();
+    assert_eq!(all_ids, expected, "round-trip lost or duplicated rows");
+}
+
+#[test]
+fn excerpt_predicate_filters_rows() {
+    let fixture = write_n_row_fixture(100);
+    let out = tempfile::tempdir().unwrap();
+    let summary = excerpt_csv_file::<Dr3, _, _>(
+        fixture.path(),
+        f64::INFINITY,
+        out.path(),
+        HashIdShard { num_shards: 4 },
+        |e| e.core.phot_g_mean_mag < 5.0, // mag < 5 → first 20 rows (4.0..4.95)
+    )
+    .expect("excerpt");
+    assert_eq!(summary.kept_rows, 20);
+}
+
+#[test]
+fn id_range_shard_buckets_monotonically() {
+    let s = IdRangeShard { num_shards: 4 };
+    // Construct fake entries by parsing them via from_csv_file with single rows.
+    // Simpler: test the shard arithmetic directly.
+    use starfield_gaia::common::core::GaiaCore;
+    use starfield_gaia::dr3::Dr3Entry;
+    let make = |id: u64| Dr3Entry {
+        core: GaiaCore {
+            source_id: id,
+            solution_id: 0,
+            ref_epoch: 2016.0,
+            random_index: None,
+            ra: 0.0,
+            ra_error: 0.0,
+            dec: 0.0,
+            dec_error: 0.0,
+            ra_dec_corr: None,
+            parallax: None,
+            parallax_error: None,
+            pmra: None,
+            pmra_error: None,
+            pmdec: None,
+            pmdec_error: None,
+            l: 0.0,
+            b: 0.0,
+            ecl_lon: 0.0,
+            ecl_lat: 0.0,
+            phot_g_mean_mag: 0.0,
+            phot_g_mean_flux: None,
+            phot_g_mean_flux_error: None,
+            phot_g_n_obs: None,
+            phot_variable_flag: Default::default(),
+            astrometric_n_obs_al: None,
+            astrometric_excess_noise: None,
+            astrometric_excess_noise_sig: None,
+            astrometric_primary_flag: None,
+            duplicated_source: None,
+            matched_observations: None,
+        },
+        designation: None,
+        pm: None,
+        parallax_over_error: None,
+        astrometric_extra: Default::default(),
+        ipd: Default::default(),
+        bp_rp: None,
+        radial_velocity: None,
+        gspphot: None,
+        data_links: Default::default(),
+        classifications: Default::default(),
+    };
+
+    assert_eq!(
+        <IdRangeShard as ShardKey<Dr3Entry>>::shard_of(&s, &make(0)),
+        0
+    );
+    assert_eq!(
+        <IdRangeShard as ShardKey<Dr3Entry>>::shard_of(&s, &make(u64::MAX)),
+        3
+    );
+    assert_eq!(
+        <IdRangeShard as ShardKey<Dr3Entry>>::shard_of(&s, &make(u64::MAX / 2)),
+        1
+    );
+    let prev = <IdRangeShard as ShardKey<Dr3Entry>>::shard_of(&s, &make(0));
+    let next = <IdRangeShard as ShardKey<Dr3Entry>>::shard_of(&s, &make(u64::MAX / 4 + 1));
+    assert!(next >= prev, "id-range buckets should be non-decreasing");
+}
+
+#[test]
+fn healpix_shard_returns_in_range() {
+    let s = HealpixShard {
+        num_shards: 32,
+        level: 6,
+    };
+    let fixture = write_n_row_fixture(50);
+    let out = tempfile::tempdir().unwrap();
+    let summary =
+        excerpt_csv_file::<Dr3, _, _>(fixture.path(), f64::INFINITY, out.path(), s, |_| true)
+            .unwrap();
+    assert_eq!(summary.kept_rows, 50);
+    // Every shard count must be in 0..num_shards; sum equals kept.
+    assert_eq!(summary.per_shard_counts.len(), 32);
+    assert_eq!(summary.per_shard_counts.iter().sum::<u64>(), 50);
+}


### PR DESCRIPTION
## Summary

Adds the ability to subset a Gaia catalog by an arbitrary predicate and write the kept entries to N shard files chosen by a pluggable `ShardKey`. Output is gzipped CSV in the source release's column layout, so excerpts round-trip back through `Dr{1,2,3}Catalog::from_csv_file`.

## Library (`starfield-gaia`)

- **`ShardKey<E>` trait** — `record → 0..num_shards()`. Implement directly to shard by anything (brightness, date, custom hash, etc.).
- **Built-in embodiments**:
  - `HashIdShard { num_shards }` — deterministic SplitMix64 of `source_id`. Even distribution; loses spatial locality.
  - `IdRangeShard { num_shards }` — equal-width `u64` buckets. Gives spatial locality on DR2/DR3 (their source_ids encode HEALPix-12 in the high bits).
  - `HealpixShard { num_shards, level }` — `cdshealpix::nested::hash` on RA/Dec, modulo `num_shards`. Works identically across releases.
- **`ShardedCsvWriter<R, S>`** — incremental, lazy per-shard file open, gzip output. A shard that receives no entries leaves no file.
- **`excerpt_csv_file::<R, S, F>(input, mag_limit, output_dir, sharder, predicate)`** — convenience that ties read + filter + shard-write into one streaming call. Returns `ExcerptSummary { input_rows, kept_rows, per_shard_counts, shard_files }`.
- **`format_csv_row` + `csv_header`** added to `GaiaRelease`. Per-release formatters in `dr{1,2,3}/schema.rs` walk the existing `COLUMNS` table.

### Reader fix

Arrow-csv's `with_projection` requires the schema describe **every** CSV column, not just the projected subset. Our previous code only passed the typed columns we wanted — worked on synthetic fixtures, broke on real Gaia files (57/94/152 columns vs our ~48/82/95). Reader now overlays the typed schema onto the actual CSV header and fills unknown columns with `Utf8` before projecting. Caught by smoke-testing on real DR1 cache.

## Binary (new crate `starfield-gaia-tools`)

`gaia-excerpt` CLI:

```
gaia-excerpt --input file1.csv.gz file2.csv.gz \
             --release dr1 --output-dir out/ \
             --shard-by healpix --healpix-level 5 --shards 16 \
             --mag-limit 12 --cone 83.6,-5.4,2.0 \
             --sort --sort-by source-id
```

- `--shard-by {hash,id-range,healpix}` `--shards N` `--healpix-level L`
- Combinable filters: `--mag-limit F`, `--cone RA,DEC,RADIUS_DEG`, `--id-range LO,HI` (AND'd)
- `--sort` post-processes each shard (in-memory, atomic via tempfile + rename)
- `--sort-by {source-id, phot-g-mean-mag, ra, random-index}` (GaiaCore-only fields so it works across releases)
- Indicatif progress bars for input files, kept stars, and sort phase

## Test plan

- [x] 4 new tests in `crates/gaia/tests/dr3_excerpt.rs`:
  - `excerpt_round_trip_with_hash_shard` — 200 synthetic rows → 8 shards → reload via `Dr3Catalog::from_csv_file` → all 200 source_ids present
  - `excerpt_predicate_filters_rows` — confirms predicate actually filters
  - `id_range_shard_buckets_monotonically` — bucket math sanity
  - `healpix_shard_returns_in_range` — every shard index < num_shards
- [x] All existing gaia tests still pass (`cargo test -p starfield-gaia --features all-releases` — 12 tests)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p starfield-gaia -p starfield-gaia-tools --all-features --all-targets` clean
- [x] Smoke test on real DR1 cache: 5,323 stars across 2 input files → 16 HEALPix shards, sorted by source_id, in 2.85s; first 3 source_ids in shard 0000 are monotonically ascending
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)