### PR TITLE
gaia-excerpt: atomic per-file via cache-raw + eviction; share writer across run

### DIFF
--- a/IN_PROGRESS_dr3_mag20_excerpt.md
+++ b/IN_PROGRESS_dr3_mag20_excerpt.md
@@ -1,0 +1,115 @@
+# IN-PROGRESS: DR3 mag-20 excerpt build
+
+> **This file is temporary.** Delete it from `main` once the DR3 mag-20 excerpt
+> has finished and we've moved on. It exists so a future Claude Code session
+> (or you, returning to this after a break) can pick up where we left off
+> without re-deriving context.
+
+## What's running
+
+A `gaia-excerpt` invocation is streaming all 3,386 DR3 `gaia_source` files
+(~750 GB compressed) through the new `--cache-raw --clean-after-excerpt`
+atomic-per-file pipeline, magnitude-cut to G < 20, sharded into 128 HEALPix-5
+files.
+
+```
+command:    gaia-excerpt \
+              --from-release dr3 --cache-raw --clean-after-excerpt \
+              --output-dir ~/.cache/starfield/gaia-excerpts/dr3-mag20/ \
+              --shard-by healpix --healpix-level 5 --shards 128 \
+              --mag-limit 20
+
+binary:     ~/repos/starfield-datasources/target/release/gaia-excerpt
+            (built from this branch)
+
+output:     ~/.cache/starfield/gaia-excerpts/dr3-mag20/shard_NNNN.csv.gz × 128
+log:        ~/.cache/starfield/gaia-excerpts/dr3-mag20.log
+raw cache:  ~/.cache/starfield/gaia/dr3/   (transient; ~250 MB / 1–2 files in flight)
+
+ETA:        ~25–30 hours from launch (network-bound on ESA's CDN)
+```
+
+To find the live PID: `pgrep -af gaia-excerpt | grep -v pgrep`.
+
+## Why this approach (and what failed first)
+
+Two earlier full-catalog attempts failed for distinct reasons:
+
+1. **Pure streaming** (`--from-release dr3` with no `--cache-raw`): mid-stream
+   HTTP body errors during the streamed gz decode caused unrecoverable row
+   loss. ~18 files × ~150k rows lost in run 2. Streaming has no MD5
+   verification and no resume; the only safe per-file retry is
+   "give up if any rows already committed", which is exactly the data-loss
+   case we wanted to avoid.
+
+2. **Per-file `ShardedCsvWriter`**: the convenience function `excerpt_csv_file`
+   constructed a fresh writer on every input. The writer's first-touch on a
+   shard called `File::create()`, which **truncates**. After ~10 hours the
+   total disk size was *shrinking* because each new input was overwriting
+   prior shards. Final state was useless — at most one input file's worth of
+   data per shard.
+
+The current approach uses **download-then-extract-then-evict**, with **one
+writer that lives across the whole run**:
+
+- `Downloader::download_file` writes to `.tmp` + atomic rename + MD5 verify;
+  partial / interrupted downloads re-fetch cleanly on the next attempt.
+- `excerpt_csv_file_into` parses the local file into the shared writer.
+  Local I/O can't fail mid-stream the way HTTP can.
+- `--clean-after-excerpt` deletes the cached raw file immediately after a
+  successful extract, so disk for raw stays bounded.
+- The shared `ShardedCsvWriter` is created once per run; per-file shard files
+  are opened lazily on first touch and never re-truncated.
+
+## How to check on it
+
+```sh
+# alive?
+pgrep -af gaia-excerpt | grep -v pgrep
+ps -p $PID -o pid,etime,rss,stat,%cpu
+
+# output
+ls ~/.cache/starfield/gaia-excerpts/dr3-mag20/ | wc -l   # should be 128
+du -sh ~/.cache/starfield/gaia-excerpts/dr3-mag20/
+
+# raw cache (should hover at 1–2 files)
+ls ~/.cache/starfield/gaia/dr3/*.csv.gz 2>/dev/null | wc -l
+du -sh ~/.cache/starfield/gaia/dr3/
+
+# trouble in the log
+grep -cE 'attempt [0-9]+/5 failed' ~/.cache/starfield/gaia-excerpts/dr3-mag20.log
+grep -E 'giving up' ~/.cache/starfield/gaia-excerpts/dr3-mag20.log
+tail -20 ~/.cache/starfield/gaia-excerpts/dr3-mag20.log
+```
+
+## Expected end state on success
+
+- `~/.cache/starfield/gaia-excerpts/dr3-mag20/` contains 128 shard files,
+  total ~120–180 GB (mag-20 cut of DR3's ~1.5B sources; per-shard size
+  varies 600 MB – 1.7 GB based on HEALPix density across the sky).
+- `~/.cache/starfield/gaia/dr3/` is empty.
+- Log's final stdout line: `read N stars; kept M (Z%); wrote 128 shard files`.
+- No `giving up` lines in the log. Some `attempt 1/5 failed ... retrying` is
+  normal and harmless.
+
+## If it died
+
+1. `tail -50 ~/.cache/starfield/gaia-excerpts/dr3-mag20.log` for the last error.
+2. The cached raw file for whatever was in flight is still in
+   `~/.cache/starfield/gaia/dr3/`. Re-running the same command will pick up
+   from there: `download_file` skips files already cached, eviction only
+   happens on extract success.
+3. If specific files in the log keep saying "giving up", their names are
+   listed in the trailing summary. Re-run the same command and they'll be
+   retried (they may succeed when ESA's CDN is healthier).
+4. Worst case: `rm -rf ~/.cache/starfield/gaia-excerpts/dr3-mag20/` and re-run
+   from scratch. ~25–30 hours.
+
+## Next tasks queued behind this
+
+1. Delete this file as part of the PR that closes out the DR3 build.
+2. Hipparcos supplement-builder binary (`gaia-tools`): generate per-release
+   supplement CSVs that get baked into the `starfield-gaia` crate so
+   `Dr{N}Catalog::insert_missing_sources()` can fix Gaia's bright-end
+   incompleteness without runtime cross-matching. Design discussed in chat;
+   not yet started.

--- a/crates/gaia-tools/src/cli.rs
+++ b/crates/gaia-tools/src/cli.rs
@@ -95,15 +95,9 @@ pub enum ReleaseChoice {
     Dr3,
 }
 
-impl ReleaseChoice {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            ReleaseChoice::Dr1 => "DR1",
-            ReleaseChoice::Dr2 => "DR2",
-            ReleaseChoice::Dr3 => "DR3",
-        }
-    }
-}
+// (release-label conversion lives in main.rs as `release_label::<R>` so it
+// dispatches off the typed `R::RELEASE` rather than the CLI-side enum.)
+
 
 #[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Sharder {

--- a/crates/gaia-tools/src/cli.rs
+++ b/crates/gaia-tools/src/cli.rs
@@ -98,7 +98,6 @@ pub enum ReleaseChoice {
 // (release-label conversion lives in main.rs as `release_label::<R>` so it
 // dispatches off the typed `R::RELEASE` rather than the CLI-side enum.)
 
-
 #[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Sharder {
     Hash,

--- a/crates/gaia-tools/src/cli.rs
+++ b/crates/gaia-tools/src/cli.rs
@@ -34,8 +34,12 @@ pub struct Cli {
     #[arg(long = "cache-raw", default_value_t = false)]
     pub cache_raw: bool,
 
-    /// Delete each `--input` file from disk after successful processing. Local
-    /// paths only; no-op on streamed CDN sources.
+    /// Delete each input file from disk once it has been successfully
+    /// extracted. Applies to both `--input` local paths AND `--from-release
+    /// --cache-raw` CDN-cached files (which makes that mode "stage to disk,
+    /// extract, evict" — bounded steady-state disk for the raw bytes).
+    /// No-op for `--from-release` without `--cache-raw` (streaming mode
+    /// never stages anything to disk in the first place).
     #[arg(long = "clean-after-excerpt", default_value_t = false)]
     pub clean_after_excerpt: bool,
 

--- a/crates/gaia-tools/src/cli.rs
+++ b/crates/gaia-tools/src/cli.rs
@@ -34,6 +34,13 @@ pub struct Cli {
     #[arg(long = "cache-raw", default_value_t = false)]
     pub cache_raw: bool,
 
+    /// Concurrent CDN download workers used in `--cache-raw` mode. Workers
+    /// download in parallel into the per-release cache; the extract+commit
+    /// phase is single-threaded and consumes results as they arrive.
+    /// Streaming mode (`--cache-raw` not set) ignores this and runs serially.
+    #[arg(long = "download-workers", default_value_t = 10)]
+    pub download_workers: u32,
+
     /// Delete each input file from disk once it has been successfully
     /// extracted. Applies to both `--input` local paths AND `--from-release
     /// --cache-raw` CDN-cached files (which makes that mode "stage to disk,

--- a/crates/gaia-tools/src/main.rs
+++ b/crates/gaia-tools/src/main.rs
@@ -26,6 +26,10 @@ use starfield_gaia::excerpt::{
     ShardKey, ShardedCsvWriter,
 };
 use starfield_gaia::{Dr1, Dr2, Dr3, GaiaRelease, GaiaSource};
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::mpsc::sync_channel;
+use std::sync::Arc;
 
 const MAX_CONNECT_RETRIES: u32 = 4; // total 5 attempts
 
@@ -108,8 +112,9 @@ fn run_release<R: GaiaRelease>(args: &Cli) -> Result<()> {
         // CDN mode: enumerate, then per-file streamed-or-cached with retry.
         let names = Downloader::<R>::list_remote()?;
         let total_files = args.max_files.unwrap_or(names.len()).min(names.len());
+        let parallel = args.cache_raw && args.download_workers > 1;
         eprintln!(
-            "fetching {} of {} {} files from CDN ({})",
+            "fetching {} of {} {} files from CDN ({}{})",
             total_files,
             names.len(),
             release_label::<R>(),
@@ -118,7 +123,31 @@ fn run_release<R: GaiaRelease>(args: &Cli) -> Result<()> {
             } else {
                 "streaming, no raw on disk"
             },
+            if parallel {
+                format!(", {} download workers", args.download_workers)
+            } else {
+                String::new()
+            },
         );
+
+        // Pre-filter: skip already-processed files, optionally evicting any
+        // stale raw cache entries left over from a prior run.
+        let mut work: Vec<String> = Vec::with_capacity(total_files);
+        let mut skipped_resume = 0usize;
+        for name in names.iter().take(total_files) {
+            if already_processed.contains(name) {
+                if args.cache_raw && args.clean_after_excerpt {
+                    let path = Downloader::<R>::cache_dir().join(name);
+                    if path.exists() {
+                        let _ = std::fs::remove_file(&path);
+                    }
+                }
+                skipped_resume += 1;
+            } else {
+                work.push(name.clone());
+            }
+        }
+
         let file_pb = multi.add(ProgressBar::new(total_files as u64));
         file_pb.set_style(
             ProgressStyle::with_template(
@@ -126,46 +155,49 @@ fn run_release<R: GaiaRelease>(args: &Cli) -> Result<()> {
             )
             .unwrap(),
         );
+        file_pb.set_position(skipped_resume as u64);
 
-        for (idx, name) in names.iter().take(total_files).enumerate() {
-            if already_processed.contains(name) {
-                // Resume case: this file was committed in a prior run. If the
-                // raw is still hanging around in the cache, evict it now.
-                if args.cache_raw && args.clean_after_excerpt {
-                    let path = Downloader::<R>::cache_dir().join(name);
-                    if path.exists() {
-                        let _ = std::fs::remove_file(&path);
-                    }
-                }
-                file_pb.inc(1);
-                continue;
-            }
-            match retry_one_file::<R>(
-                idx,
-                total_files,
-                name,
+        if parallel {
+            run_parallel_cdn::<R>(
+                &work,
                 args,
                 mag_limit,
                 &mut writer,
                 &mut predicate,
-            ) {
-                FileOutcome::Ok(rows) => {
-                    input_rows_total += rows;
+                &file_pb,
+                &kept_pb,
+                &mut input_rows_total,
+                &mut skipped_failures,
+            )?;
+        } else {
+            for (idx, name) in work.iter().enumerate() {
+                match retry_one_file::<R>(
+                    idx,
+                    work.len(),
+                    name,
+                    args,
+                    mag_limit,
+                    &mut writer,
+                    &mut predicate,
+                ) {
+                    FileOutcome::Ok(rows) => {
+                        input_rows_total += rows;
+                    }
+                    FileOutcome::GivingUp { attempts, err } => {
+                        eprintln!(
+                            "[{}/{}] {}: giving up after {} attempts ({})",
+                            idx + 1,
+                            work.len(),
+                            name,
+                            attempts,
+                            err
+                        );
+                        skipped_failures.push((name.clone(), err));
+                    }
                 }
-                FileOutcome::GivingUp { attempts, err } => {
-                    eprintln!(
-                        "[{}/{}] {}: giving up after {} attempts ({})",
-                        idx + 1,
-                        total_files,
-                        name,
-                        attempts,
-                        err
-                    );
-                    skipped_failures.push((name.clone(), err));
-                }
+                kept_pb.set_position(writer.kept_so_far());
+                file_pb.inc(1);
             }
-            kept_pb.set_position(writer.kept_so_far());
-            file_pb.inc(1);
         }
         file_pb.finish_with_message("done");
 
@@ -319,6 +351,123 @@ where
         }
     }
     FileOutcome::Ok(0)
+}
+
+/// Result of a single CDN download attempt, sent from worker threads to the
+/// extract thread. The raw bytes are already on disk at `path` when `res` is
+/// `Ok`; on `Err`, the file was never produced (or a partial tmp was cleaned
+/// up by `download_to_file`'s atomic-rename guarantee).
+struct DownloadOutcome {
+    name: String,
+    res: std::result::Result<PathBuf, String>,
+}
+
+/// Spawn a download worker pool and drain results into the single-threaded
+/// extract phase. Workers retry their own download up to `MAX_CONNECT_RETRIES`
+/// before reporting failure. The bounded channel limits how many staged raw
+/// files sit on disk at once: `download_workers` files × ~5 MB/file ≈ tens
+/// of MB at peak.
+#[allow(clippy::too_many_arguments)]
+fn run_parallel_cdn<R: GaiaRelease>(
+    work: &[String],
+    args: &Cli,
+    mag_limit: f64,
+    writer: &mut ShardedCsvWriter<R, Box<dyn ShardKey<R::Entry>>>,
+    predicate: &mut BoxedPredicate<R::Entry>,
+    file_pb: &ProgressBar,
+    kept_pb: &ProgressBar,
+    input_rows_total: &mut usize,
+    skipped_failures: &mut Vec<(String, String)>,
+) -> Result<()> {
+    let workers = args.download_workers.max(1) as usize;
+    let names: Arc<Vec<String>> = Arc::new(work.to_vec());
+    let next = Arc::new(AtomicUsize::new(0));
+    let (tx, rx) = sync_channel::<DownloadOutcome>(workers);
+
+    let mut handles = Vec::with_capacity(workers);
+    for _ in 0..workers {
+        let names = Arc::clone(&names);
+        let next = Arc::clone(&next);
+        let tx = tx.clone();
+        handles.push(std::thread::spawn(move || loop {
+            let i = next.fetch_add(1, Ordering::SeqCst);
+            if i >= names.len() {
+                break;
+            }
+            let name = names[i].clone();
+            let res = retry_download::<R>(&name);
+            if tx.send(DownloadOutcome { name, res }).is_err() {
+                break;
+            }
+        }));
+    }
+    drop(tx);
+
+    while let Ok(item) = rx.recv() {
+        match item.res {
+            Ok(path) => {
+                let extract =
+                    excerpt_csv_file_into::<R, _, _>(&path, mag_limit, writer, &mut *predicate);
+                match extract {
+                    Ok(rows) => {
+                        *input_rows_total += rows;
+                        if args.clean_after_excerpt {
+                            if let Err(e) = std::fs::remove_file(&path) {
+                                eprintln!(
+                                    "{}: warn: extract ok but failed to evict {}: {}",
+                                    item.name,
+                                    path.display(),
+                                    e
+                                );
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        let err_str = e.to_string();
+                        eprintln!("{}: extract failed: {}", item.name, err_str);
+                        skipped_failures.push((item.name, err_str));
+                    }
+                }
+            }
+            Err(e) => {
+                skipped_failures.push((item.name, e));
+            }
+        }
+        kept_pb.set_position(writer.kept_so_far());
+        file_pb.inc(1);
+    }
+
+    for h in handles {
+        let _ = h.join();
+    }
+    Ok(())
+}
+
+/// Download one file with bounded retries, returning a stringified error on
+/// final failure (so it can cross thread boundaries without `Send` worries).
+fn retry_download<R: GaiaRelease>(name: &str) -> std::result::Result<PathBuf, String> {
+    for attempt in 0..=MAX_CONNECT_RETRIES {
+        match Downloader::<R>::download_file(name) {
+            Ok(p) => return Ok(p),
+            Err(e) => {
+                let s = e.to_string();
+                if attempt == MAX_CONNECT_RETRIES {
+                    return Err(format!("after {} attempts: {}", MAX_CONNECT_RETRIES + 1, s));
+                }
+                let wait = 1u64 << attempt; // 1, 2, 4, 8 seconds
+                eprintln!(
+                    "{}: download attempt {}/{} failed ({}); retrying in {}s",
+                    name,
+                    attempt + 1,
+                    MAX_CONNECT_RETRIES + 1,
+                    s,
+                    wait,
+                );
+                std::thread::sleep(std::time::Duration::from_secs(wait));
+            }
+        }
+    }
+    unreachable!("retry_download loop should have returned by now")
 }
 
 type BoxedPredicate<E> = Box<dyn FnMut(&E) -> bool + Send>;

--- a/crates/gaia-tools/src/main.rs
+++ b/crates/gaia-tools/src/main.rs
@@ -1,6 +1,11 @@
 //! `gaia-excerpt` — apply a predicate to one or more Gaia CSV(.gz) files
 //! (local paths or streamed from ESA's CDN) and write the kept entries to
 //! sharded gzipped CSVs that round-trip through `Dr{1,2,3}Catalog::from_csv_file`.
+//!
+//! Crash-safe and resumable: on each invocation, the writer reads the
+//! `.gaia-excerpt-manifest.json` in the output directory and skips any input
+//! files already committed. Re-running the exact same command after a crash
+//! (or sibling-OOM, or reboot) picks up cleanly.
 
 fn main() {
     if let Err(e) = run() {
@@ -30,10 +35,7 @@ fn run() -> Result<()> {
     args.validate()?;
     let release = args.effective_release()?;
 
-    // Dispatch on release exactly once so the writer can live across every
-    // input file in the run. (Previously the per-file `excerpt_csv_file`
-    // convenience constructed a fresh writer each time, which `File::create`-
-    // truncated every shard it touched and silently lost data.)
+    // Dispatch on release once so the writer is monomorphized.
     match release {
         ReleaseChoice::Dr1 => run_release::<Dr1>(&args),
         ReleaseChoice::Dr2 => run_release::<Dr2>(&args),
@@ -45,17 +47,31 @@ fn run_release<R: GaiaRelease>(args: &Cli) -> Result<()> {
     let mag_limit = args.mag_limit.unwrap_or(f64::INFINITY);
 
     let sharder = make_sharder::<R::Entry>(args);
-    let mut writer =
-        ShardedCsvWriter::<R, Box<dyn ShardKey<R::Entry>>>::new(&args.output_dir, sharder)?;
+    let mut writer = ShardedCsvWriter::<R, Box<dyn ShardKey<R::Entry>>>::new_or_resume(
+        &args.output_dir,
+        sharder,
+        mag_limit,
+    )?;
     let mut predicate = build_predicate::<R::Entry>(args)?;
+
+    let already_processed = writer.processed_files().clone();
+    if !already_processed.is_empty() {
+        eprintln!(
+            "resume: manifest at {} lists {} already-processed files; skipping those",
+            writer.manifest_path().display(),
+            already_processed.len()
+        );
+    }
 
     let multi = indicatif::MultiProgress::new();
     let kept_pb = multi.add(ProgressBar::new_spinner());
     kept_pb.set_style(
         ProgressStyle::with_template("  kept: {pos} stars (across all shards)").unwrap(),
     );
+    kept_pb.set_position(writer.kept_so_far());
 
     let mut input_rows_total: usize = 0;
+    let mut skipped_failures: Vec<(String, String)> = Vec::new();
 
     if !args.input.is_empty() {
         let file_pb = multi.add(ProgressBar::new(args.input.len() as u64));
@@ -66,6 +82,18 @@ fn run_release<R: GaiaRelease>(args: &Cli) -> Result<()> {
             .unwrap(),
         );
         for input in &args.input {
+            let name = input
+                .file_name()
+                .and_then(|s| s.to_str())
+                .unwrap_or("input")
+                .to_string();
+            if already_processed.contains(&name) {
+                if args.clean_after_excerpt {
+                    let _ = std::fs::remove_file(input);
+                }
+                file_pb.inc(1);
+                continue;
+            }
             let rows =
                 excerpt_csv_file_into::<R, _, _>(input, mag_limit, &mut writer, &mut predicate)?;
             input_rows_total += rows;
@@ -98,11 +126,21 @@ fn run_release<R: GaiaRelease>(args: &Cli) -> Result<()> {
             )
             .unwrap(),
         );
-        let mut skipped: Vec<(String, String)> = Vec::new();
-        let mut partial: Vec<String> = Vec::new();
 
         for (idx, name) in names.iter().take(total_files).enumerate() {
-            let outcome = retry_one_file::<R>(
+            if already_processed.contains(name) {
+                // Resume case: this file was committed in a prior run. If the
+                // raw is still hanging around in the cache, evict it now.
+                if args.cache_raw && args.clean_after_excerpt {
+                    let path = Downloader::<R>::cache_dir().join(name);
+                    if path.exists() {
+                        let _ = std::fs::remove_file(&path);
+                    }
+                }
+                file_pb.inc(1);
+                continue;
+            }
+            match retry_one_file::<R>(
                 idx,
                 total_files,
                 name,
@@ -110,32 +148,20 @@ fn run_release<R: GaiaRelease>(args: &Cli) -> Result<()> {
                 mag_limit,
                 &mut writer,
                 &mut predicate,
-                &mut input_rows_total,
-            );
-            match outcome {
-                FileOutcome::Ok => {}
-                FileOutcome::PartialMidStream { rows_written, err } => {
-                    eprintln!(
-                        "[{}/{}] {}: mid-stream failure after {} rows kept ({}); \
-                         continuing with partial data from this file",
-                        idx + 1,
-                        total_files,
-                        name,
-                        rows_written,
-                        err
-                    );
-                    partial.push(name.clone());
+            ) {
+                FileOutcome::Ok(rows) => {
+                    input_rows_total += rows;
                 }
                 FileOutcome::GivingUp { attempts, err } => {
                     eprintln!(
-                        "[{}/{}] {}: giving up after {} connect attempts ({})",
+                        "[{}/{}] {}: giving up after {} attempts ({})",
                         idx + 1,
                         total_files,
                         name,
                         attempts,
                         err
                     );
-                    skipped.push((name.clone(), err));
+                    skipped_failures.push((name.clone(), err));
                 }
             }
             kept_pb.set_position(writer.kept_so_far());
@@ -143,21 +169,12 @@ fn run_release<R: GaiaRelease>(args: &Cli) -> Result<()> {
         }
         file_pb.finish_with_message("done");
 
-        if !partial.is_empty() {
+        if !skipped_failures.is_empty() {
             eprintln!(
-                "\n{} files had mid-stream failures (some rows may be missing from shards):",
-                partial.len()
+                "\n{} files exhausted retries — re-run the same command to retry them:",
+                skipped_failures.len()
             );
-            for p in &partial {
-                eprintln!("  - {}", p);
-            }
-        }
-        if !skipped.is_empty() {
-            eprintln!(
-                "\n{} files never completed a single successful connect:",
-                skipped.len()
-            );
-            for (p, err) in &skipped {
+            for (p, err) in &skipped_failures {
                 eprintln!("  - {}  ({})", p, err);
             }
         }
@@ -167,14 +184,9 @@ fn run_release<R: GaiaRelease>(args: &Cli) -> Result<()> {
     let summary = writer.finish()?;
     let written: Vec<_> = summary.written_paths().cloned().collect();
     println!(
-        "read {} stars; kept {} ({:.2}%); wrote {} shard files",
+        "read {} stars (this run); kept total {} across {} shard files",
         input_rows_total,
         summary.kept_rows,
-        if input_rows_total == 0 {
-            0.0
-        } else {
-            100.0 * summary.kept_rows as f64 / input_rows_total as f64
-        },
         written.len(),
     );
 
@@ -224,17 +236,15 @@ fn make_sharder<E: GaiaSource + 'static>(args: &Cli) -> Box<dyn ShardKey<E>> {
     }
 }
 
-/// Outcome of one (retried) CDN file. `Ok` = file fully processed. `PartialMidStream`
-/// = the HTTP body errored mid-read after some rows had already been written to
-/// shards; we don't retry (would duplicate those rows) and move on. `GivingUp` =
-/// failed before a single row was kept and exhausted retries.
+/// Outcome of one retried CDN file. With the new buffered-commit writer there's
+/// no longer a "mid-stream partial commit" case — failures during read leave
+/// the writer's in-memory pending buffer dirty, but commit_file is never
+/// reached, so the manifest and shards are unchanged. Retries are always safe.
 enum FileOutcome {
-    Ok,
-    PartialMidStream { rows_written: u64, err: String },
+    Ok(usize),
     GivingUp { attempts: u32, err: String },
 }
 
-#[allow(clippy::too_many_arguments)]
 fn retry_one_file<R>(
     idx: usize,
     total: usize,
@@ -243,22 +253,17 @@ fn retry_one_file<R>(
     mag_limit: f64,
     writer: &mut ShardedCsvWriter<R, Box<dyn ShardKey<R::Entry>>>,
     predicate: &mut BoxedPredicate<R::Entry>,
-    input_rows_total: &mut usize,
 ) -> FileOutcome
 where
     R: GaiaRelease,
 {
     for attempt in 0..=MAX_CONNECT_RETRIES {
-        let kept_before = writer.kept_so_far();
         let res: Result<usize> = if args.cache_raw {
             match Downloader::<R>::download_file(name) {
                 Ok(path) => {
                     let extract =
                         excerpt_csv_file_into::<R, _, _>(&path, mag_limit, writer, &mut *predicate);
-                    // On successful extract, optionally evict the cached raw
-                    // file so disk usage stays bounded (one file in flight).
-                    // Failure to delete is a warning, not an error — the
-                    // rows are already committed to shards.
+                    // Evict cached raw only after a successful extract+commit.
                     if extract.is_ok() && args.clean_after_excerpt {
                         if let Err(e) = std::fs::remove_file(&path) {
                             eprintln!(
@@ -282,25 +287,16 @@ where
                     true,
                     mag_limit,
                     writer,
+                    name,
                     &mut *predicate,
                 ),
                 Err(e) => Err(e),
             }
         };
         match res {
-            Ok(rows) => {
-                *input_rows_total += rows;
-                return FileOutcome::Ok;
-            }
+            Ok(rows) => return FileOutcome::Ok(rows),
             Err(e) => {
                 let err_str = e.to_string();
-                let rows_written = writer.kept_so_far().saturating_sub(kept_before);
-                if rows_written > 0 {
-                    return FileOutcome::PartialMidStream {
-                        rows_written,
-                        err: err_str,
-                    };
-                }
                 if attempt == MAX_CONNECT_RETRIES {
                     return FileOutcome::GivingUp {
                         attempts: attempt + 1,
@@ -322,7 +318,7 @@ where
             }
         }
     }
-    FileOutcome::Ok
+    FileOutcome::Ok(0)
 }
 
 type BoxedPredicate<E> = Box<dyn FnMut(&E) -> bool + Send>;

--- a/crates/gaia-tools/src/main.rs
+++ b/crates/gaia-tools/src/main.rs
@@ -17,10 +17,12 @@ use indicatif::{ProgressBar, ProgressStyle};
 use starfield::{Result, StarfieldError};
 use starfield_gaia::download::Downloader;
 use starfield_gaia::excerpt::{
-    excerpt_csv_file, excerpt_csv_reader, ExcerptSummary, HashIdShard, HealpixShard, IdRangeShard,
+    excerpt_csv_file_into, excerpt_csv_reader_into, HashIdShard, HealpixShard, IdRangeShard,
+    ShardKey, ShardedCsvWriter,
 };
 use starfield_gaia::{Dr1, Dr2, Dr3, GaiaRelease, GaiaSource};
-use std::path::{Path, PathBuf};
+
+const MAX_CONNECT_RETRIES: u32 = 4; // total 5 attempts
 
 fn run() -> Result<()> {
     use clap::Parser;
@@ -28,13 +30,32 @@ fn run() -> Result<()> {
     args.validate()?;
     let release = args.effective_release()?;
 
+    // Dispatch on release exactly once so the writer can live across every
+    // input file in the run. (Previously the per-file `excerpt_csv_file`
+    // convenience constructed a fresh writer each time, which `File::create`-
+    // truncated every shard it touched and silently lost data.)
+    match release {
+        ReleaseChoice::Dr1 => run_release::<Dr1>(&args),
+        ReleaseChoice::Dr2 => run_release::<Dr2>(&args),
+        ReleaseChoice::Dr3 => run_release::<Dr3>(&args),
+    }
+}
+
+fn run_release<R: GaiaRelease>(args: &Cli) -> Result<()> {
+    let mag_limit = args.mag_limit.unwrap_or(f64::INFINITY);
+
+    let sharder = make_sharder::<R::Entry>(args);
+    let mut writer =
+        ShardedCsvWriter::<R, Box<dyn ShardKey<R::Entry>>>::new(&args.output_dir, sharder)?;
+    let mut predicate = build_predicate::<R::Entry>(args)?;
+
     let multi = indicatif::MultiProgress::new();
     let kept_pb = multi.add(ProgressBar::new_spinner());
     kept_pb.set_style(
-        ProgressStyle::with_template("  kept: {pos} stars across {msg} shards").unwrap(),
+        ProgressStyle::with_template("  kept: {pos} stars (across all shards)").unwrap(),
     );
 
-    let mut totals = Totals::default();
+    let mut input_rows_total: usize = 0;
 
     if !args.input.is_empty() {
         let file_pb = multi.add(ProgressBar::new(args.input.len() as u64));
@@ -45,30 +66,25 @@ fn run() -> Result<()> {
             .unwrap(),
         );
         for input in &args.input {
-            match release {
-                ReleaseChoice::Dr1 => run_local::<Dr1>(input, &args, &mut totals, &kept_pb)?,
-                ReleaseChoice::Dr2 => run_local::<Dr2>(input, &args, &mut totals, &kept_pb)?,
-                ReleaseChoice::Dr3 => run_local::<Dr3>(input, &args, &mut totals, &kept_pb)?,
-            }
+            let rows =
+                excerpt_csv_file_into::<R, _, _>(input, mag_limit, &mut writer, &mut predicate)?;
+            input_rows_total += rows;
             if args.clean_after_excerpt {
                 std::fs::remove_file(input).map_err(StarfieldError::IoError)?;
             }
+            kept_pb.set_position(writer.kept_so_far());
             file_pb.inc(1);
         }
         file_pb.finish_with_message("done");
     } else {
-        // CDN mode: enumerate, then per-file stream-or-cache.
-        let names = match release {
-            ReleaseChoice::Dr1 => Downloader::<Dr1>::list_remote()?,
-            ReleaseChoice::Dr2 => Downloader::<Dr2>::list_remote()?,
-            ReleaseChoice::Dr3 => Downloader::<Dr3>::list_remote()?,
-        };
+        // CDN mode: enumerate, then per-file streamed-or-cached with retry.
+        let names = Downloader::<R>::list_remote()?;
         let total_files = args.max_files.unwrap_or(names.len()).min(names.len());
         eprintln!(
             "fetching {} of {} {} files from CDN ({})",
             total_files,
             names.len(),
-            release.as_str(),
+            release_label::<R>(),
             if args.cache_raw {
                 "writing raw to cache"
             } else {
@@ -82,55 +98,101 @@ fn run() -> Result<()> {
             )
             .unwrap(),
         );
-        for name in names.iter().take(total_files) {
-            match release {
-                ReleaseChoice::Dr1 => run_cdn::<Dr1>(name, &args, &mut totals, &kept_pb)?,
-                ReleaseChoice::Dr2 => run_cdn::<Dr2>(name, &args, &mut totals, &kept_pb)?,
-                ReleaseChoice::Dr3 => run_cdn::<Dr3>(name, &args, &mut totals, &kept_pb)?,
+        let mut skipped: Vec<(String, String)> = Vec::new();
+        let mut partial: Vec<String> = Vec::new();
+
+        for (idx, name) in names.iter().take(total_files).enumerate() {
+            let outcome = retry_one_file::<R>(
+                idx,
+                total_files,
+                name,
+                args,
+                mag_limit,
+                &mut writer,
+                &mut predicate,
+                &mut input_rows_total,
+            );
+            match outcome {
+                FileOutcome::Ok => {}
+                FileOutcome::PartialMidStream { rows_written, err } => {
+                    eprintln!(
+                        "[{}/{}] {}: mid-stream failure after {} rows kept ({}); \
+                         continuing with partial data from this file",
+                        idx + 1,
+                        total_files,
+                        name,
+                        rows_written,
+                        err
+                    );
+                    partial.push(name.clone());
+                }
+                FileOutcome::GivingUp { attempts, err } => {
+                    eprintln!(
+                        "[{}/{}] {}: giving up after {} connect attempts ({})",
+                        idx + 1,
+                        total_files,
+                        name,
+                        attempts,
+                        err
+                    );
+                    skipped.push((name.clone(), err));
+                }
             }
+            kept_pb.set_position(writer.kept_so_far());
             file_pb.inc(1);
         }
         file_pb.finish_with_message("done");
+
+        if !partial.is_empty() {
+            eprintln!(
+                "\n{} files had mid-stream failures (some rows may be missing from shards):",
+                partial.len()
+            );
+            for p in &partial {
+                eprintln!("  - {}", p);
+            }
+        }
+        if !skipped.is_empty() {
+            eprintln!(
+                "\n{} files never completed a single successful connect:",
+                skipped.len()
+            );
+            for (p, err) in &skipped {
+                eprintln!("  - {}  ({})", p, err);
+            }
+        }
     }
     kept_pb.finish_and_clear();
 
-    let inputs_processed = if args.input.is_empty() {
-        args.max_files.unwrap_or(0)
-    } else {
-        args.input.len()
-    };
+    let summary = writer.finish()?;
+    let written: Vec<_> = summary.written_paths().cloned().collect();
     println!(
-        "read {} stars across {} files; kept {} ({:.2}%); wrote {} shard files",
-        totals.input_rows,
-        inputs_processed,
-        totals.kept_rows,
-        if totals.input_rows == 0 {
+        "read {} stars; kept {} ({:.2}%); wrote {} shard files",
+        input_rows_total,
+        summary.kept_rows,
+        if input_rows_total == 0 {
             0.0
         } else {
-            100.0 * totals.kept_rows as f64 / totals.input_rows as f64
+            100.0 * summary.kept_rows as f64 / input_rows_total as f64
         },
-        totals.distinct_shard_files.len(),
+        written.len(),
     );
 
     if args.sort {
         eprintln!(
             "\nsorting {} shard files by {:?} ...",
-            totals.distinct_shard_files.len(),
+            written.len(),
             args.sort_by
         );
-        let sort_pb = ProgressBar::new(totals.distinct_shard_files.len() as u64);
+        let sort_pb = ProgressBar::new(written.len() as u64);
         sort_pb.set_style(
             ProgressStyle::with_template(
                 "[{elapsed_precise}] {bar:40.green/blue} {pos}/{len} sorted ({eta})",
             )
             .unwrap(),
         );
-        for path in &totals.distinct_shard_files {
-            match release {
-                ReleaseChoice::Dr1 => sort_step::sort_shard::<Dr1>(path, args.sort_by)?,
-                ReleaseChoice::Dr2 => sort_step::sort_shard::<Dr2>(path, args.sort_by)?,
-                ReleaseChoice::Dr3 => sort_step::sort_shard::<Dr3>(path, args.sort_by)?,
-            }
+        for path in &written {
+            sort_step::sort_shard::<R>(path, args.sort_by)?;
             sort_pb.inc(1);
         }
         sort_pb.finish_with_message("sorted");
@@ -139,144 +201,128 @@ fn run() -> Result<()> {
     Ok(())
 }
 
-#[derive(Default)]
-struct Totals {
-    input_rows: usize,
-    kept_rows: u64,
-    distinct_shard_files: Vec<PathBuf>,
+fn release_label<R: GaiaRelease>() -> &'static str {
+    match R::RELEASE {
+        starfield_gaia::Release::Dr1 => "DR1",
+        starfield_gaia::Release::Dr2 => "DR2",
+        starfield_gaia::Release::Dr3 => "DR3",
+    }
 }
 
-fn run_local<R>(input: &Path, args: &Cli, totals: &mut Totals, kept_pb: &ProgressBar) -> Result<()>
+fn make_sharder<E: GaiaSource + 'static>(args: &Cli) -> Box<dyn ShardKey<E>> {
+    match args.shard_by {
+        Sharder::Hash => Box::new(HashIdShard {
+            num_shards: args.shards,
+        }),
+        Sharder::IdRange => Box::new(IdRangeShard {
+            num_shards: args.shards,
+        }),
+        Sharder::Healpix => Box::new(HealpixShard {
+            num_shards: args.shards,
+            level: args.healpix_level,
+        }),
+    }
+}
+
+/// Outcome of one (retried) CDN file. `Ok` = file fully processed. `PartialMidStream`
+/// = the HTTP body errored mid-read after some rows had already been written to
+/// shards; we don't retry (would duplicate those rows) and move on. `GivingUp` =
+/// failed before a single row was kept and exhausted retries.
+enum FileOutcome {
+    Ok,
+    PartialMidStream { rows_written: u64, err: String },
+    GivingUp { attempts: u32, err: String },
+}
+
+#[allow(clippy::too_many_arguments)]
+fn retry_one_file<R>(
+    idx: usize,
+    total: usize,
+    name: &str,
+    args: &Cli,
+    mag_limit: f64,
+    writer: &mut ShardedCsvWriter<R, Box<dyn ShardKey<R::Entry>>>,
+    predicate: &mut BoxedPredicate<R::Entry>,
+    input_rows_total: &mut usize,
+) -> FileOutcome
 where
     R: GaiaRelease,
 {
-    let predicate = build_predicate::<R::Entry>(args)?;
-    let summary = match args.shard_by {
-        Sharder::Hash => excerpt_csv_file::<R, _, _>(
-            input,
-            args.mag_limit.unwrap_or(f64::INFINITY),
-            &args.output_dir,
-            HashIdShard {
-                num_shards: args.shards,
-            },
-            predicate,
-        )?,
-        Sharder::IdRange => excerpt_csv_file::<R, _, _>(
-            input,
-            args.mag_limit.unwrap_or(f64::INFINITY),
-            &args.output_dir,
-            IdRangeShard {
-                num_shards: args.shards,
-            },
-            predicate,
-        )?,
-        Sharder::Healpix => excerpt_csv_file::<R, _, _>(
-            input,
-            args.mag_limit.unwrap_or(f64::INFINITY),
-            &args.output_dir,
-            HealpixShard {
-                num_shards: args.shards,
-                level: args.healpix_level,
-            },
-            predicate,
-        )?,
-    };
-    accumulate(totals, summary, kept_pb);
-    Ok(())
-}
-
-fn run_cdn<R>(filename: &str, args: &Cli, totals: &mut Totals, kept_pb: &ProgressBar) -> Result<()>
-where
-    R: GaiaRelease,
-{
-    let predicate = build_predicate::<R::Entry>(args)?;
-
-    // Pick the byte source: cached or streamed.
-    let summary = if args.cache_raw {
-        let path = Downloader::<R>::download_file(filename)?;
-        match args.shard_by {
-            Sharder::Hash => excerpt_csv_file::<R, _, _>(
-                &path,
-                args.mag_limit.unwrap_or(f64::INFINITY),
-                &args.output_dir,
-                HashIdShard {
-                    num_shards: args.shards,
-                },
-                predicate,
-            )?,
-            Sharder::IdRange => excerpt_csv_file::<R, _, _>(
-                &path,
-                args.mag_limit.unwrap_or(f64::INFINITY),
-                &args.output_dir,
-                IdRangeShard {
-                    num_shards: args.shards,
-                },
-                predicate,
-            )?,
-            Sharder::Healpix => excerpt_csv_file::<R, _, _>(
-                &path,
-                args.mag_limit.unwrap_or(f64::INFINITY),
-                &args.output_dir,
-                HealpixShard {
-                    num_shards: args.shards,
-                    level: args.healpix_level,
-                },
-                predicate,
-            )?,
-        }
-    } else {
-        let stream = Downloader::<R>::stream_file(filename)?;
-        // Filenames come from the index regex which targets `*.csv.gz` only,
-        // so is_gz is always true for CDN-sourced files.
-        let is_gz = filename.ends_with(".gz");
-        match args.shard_by {
-            Sharder::Hash => excerpt_csv_reader::<R, _, _>(
-                stream,
-                is_gz,
-                args.mag_limit.unwrap_or(f64::INFINITY),
-                &args.output_dir,
-                HashIdShard {
-                    num_shards: args.shards,
-                },
-                predicate,
-            )?,
-            Sharder::IdRange => excerpt_csv_reader::<R, _, _>(
-                stream,
-                is_gz,
-                args.mag_limit.unwrap_or(f64::INFINITY),
-                &args.output_dir,
-                IdRangeShard {
-                    num_shards: args.shards,
-                },
-                predicate,
-            )?,
-            Sharder::Healpix => excerpt_csv_reader::<R, _, _>(
-                stream,
-                is_gz,
-                args.mag_limit.unwrap_or(f64::INFINITY),
-                &args.output_dir,
-                HealpixShard {
-                    num_shards: args.shards,
-                    level: args.healpix_level,
-                },
-                predicate,
-            )?,
-        }
-    };
-    accumulate(totals, summary, kept_pb);
-    Ok(())
-}
-
-fn accumulate(totals: &mut Totals, s: ExcerptSummary, kept_pb: &ProgressBar) {
-    totals.input_rows += s.input_rows;
-    totals.kept_rows += s.kept_rows;
-    for p in s.written_paths() {
-        if !totals.distinct_shard_files.iter().any(|x| x == p) {
-            totals.distinct_shard_files.push(p.clone());
+    for attempt in 0..=MAX_CONNECT_RETRIES {
+        let kept_before = writer.kept_so_far();
+        let res: Result<usize> = if args.cache_raw {
+            match Downloader::<R>::download_file(name) {
+                Ok(path) => {
+                    let extract =
+                        excerpt_csv_file_into::<R, _, _>(&path, mag_limit, writer, &mut *predicate);
+                    // On successful extract, optionally evict the cached raw
+                    // file so disk usage stays bounded (one file in flight).
+                    // Failure to delete is a warning, not an error — the
+                    // rows are already committed to shards.
+                    if extract.is_ok() && args.clean_after_excerpt {
+                        if let Err(e) = std::fs::remove_file(&path) {
+                            eprintln!(
+                                "[{}/{}] {}: warn: extract ok but failed to evict {}: {}",
+                                idx + 1,
+                                total,
+                                name,
+                                path.display(),
+                                e
+                            );
+                        }
+                    }
+                    extract
+                }
+                Err(e) => Err(e),
+            }
+        } else {
+            match Downloader::<R>::stream_file(name) {
+                Ok(stream) => excerpt_csv_reader_into::<R, _, _>(
+                    stream,
+                    true,
+                    mag_limit,
+                    writer,
+                    &mut *predicate,
+                ),
+                Err(e) => Err(e),
+            }
+        };
+        match res {
+            Ok(rows) => {
+                *input_rows_total += rows;
+                return FileOutcome::Ok;
+            }
+            Err(e) => {
+                let err_str = e.to_string();
+                let rows_written = writer.kept_so_far().saturating_sub(kept_before);
+                if rows_written > 0 {
+                    return FileOutcome::PartialMidStream {
+                        rows_written,
+                        err: err_str,
+                    };
+                }
+                if attempt == MAX_CONNECT_RETRIES {
+                    return FileOutcome::GivingUp {
+                        attempts: attempt + 1,
+                        err: err_str,
+                    };
+                }
+                let wait = 1u64 << attempt; // 1, 2, 4, 8, 16 seconds
+                eprintln!(
+                    "[{}/{}] {}: attempt {}/{} failed ({}); retrying in {}s",
+                    idx + 1,
+                    total,
+                    name,
+                    attempt + 1,
+                    MAX_CONNECT_RETRIES + 1,
+                    err_str,
+                    wait,
+                );
+                std::thread::sleep(std::time::Duration::from_secs(wait));
+            }
         }
     }
-    kept_pb.set_position(totals.kept_rows);
-    kept_pb.set_message(totals.distinct_shard_files.len().to_string());
+    FileOutcome::Ok
 }
 
 type BoxedPredicate<E> = Box<dyn FnMut(&E) -> bool + Send>;

--- a/crates/gaia/Cargo.toml
+++ b/crates/gaia/Cargo.toml
@@ -19,6 +19,7 @@ tempfile = "3"
 [dependencies]
 starfield = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 flate2 = { workspace = true }
 md5 = { workspace = true }

--- a/crates/gaia/src/common/reader.rs
+++ b/crates/gaia/src/common/reader.rs
@@ -15,7 +15,7 @@ use arrow::csv::reader::Format;
 use arrow::csv::ReaderBuilder;
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
-use flate2::read::GzDecoder;
+use flate2::read::MultiGzDecoder;
 
 use crate::common::traits::GaiaRelease;
 use starfield::{Result, StarfieldError};
@@ -62,8 +62,12 @@ impl<R: GaiaRelease> CsvSourceReader<R> {
     /// Set `is_gz` true for gzipped streams (this wraps in `flate2::GzDecoder`).
     /// `mag_limit` is applied per-row at the same point as in [`open`](Self::open).
     pub fn from_reader(reader: Box<dyn Read>, is_gz: bool, mag_limit: f64) -> Result<Self> {
+        // MultiGzDecoder reads concatenated gzip streams as one logical stream.
+        // The excerpt writer emits one gz stream per input file appended into
+        // the same shard file, so resumable shard files can have many streams
+        // back-to-back.
         let raw: Box<dyn Read> = if is_gz {
-            Box::new(BufReader::new(GzDecoder::new(BufReader::new(reader))))
+            Box::new(BufReader::new(MultiGzDecoder::new(BufReader::new(reader))))
         } else {
             Box::new(BufReader::new(reader))
         };

--- a/crates/gaia/src/excerpt.rs
+++ b/crates/gaia/src/excerpt.rs
@@ -56,6 +56,17 @@ pub trait ShardKey<E> {
     fn shard_of(&self, entry: &E) -> u32;
 }
 
+/// Forwarding impl so callers can hold a `Box<dyn ShardKey<E>>` and pass it
+/// where a `S: ShardKey<E>` is required (e.g. into [`ShardedCsvWriter::new`]).
+impl<E, S: ?Sized + ShardKey<E>> ShardKey<E> for Box<S> {
+    fn num_shards(&self) -> u32 {
+        (**self).num_shards()
+    }
+    fn shard_of(&self, entry: &E) -> u32 {
+        (**self).shard_of(entry)
+    }
+}
+
 /// Shard by `hash(source_id) % num_shards`. Roughly even distribution; loses
 /// any spatial / brightness locality. Use when you want shards of similar
 /// size for parallel processing.
@@ -204,6 +215,13 @@ impl<R: GaiaRelease, S: ShardKey<R::Entry>> ShardedCsvWriter<R, S> {
         Ok(())
     }
 
+    /// Total rows written so far across every shard. Useful for progress
+    /// reporting and for the CLI's "did this attempt commit anything?" check
+    /// when deciding whether a transient HTTP failure is safe to retry.
+    pub fn kept_so_far(&self) -> u64 {
+        self.counts.iter().sum()
+    }
+
     /// Finalize: flush every open shard file and return a summary.
     pub fn finish(mut self) -> Result<ExcerptSummary> {
         for w in self.writers.iter_mut() {
@@ -308,7 +326,12 @@ where
     Ok(summary)
 }
 
-fn drive<R, S, F>(
+/// Stream `reader` through `predicate` into an existing `writer`. Returns the
+/// number of input rows seen (post-mag-limit, pre-predicate). Use this when you
+/// have multiple input files that should write into a single shared output set
+/// — calling [`excerpt_csv_file`] once per input file would `File::create`-truncate
+/// every shard each time, losing all but the last input's data per shard.
+pub fn drive<R, S, F>(
     reader: CsvSourceReader<R>,
     writer: &mut ShardedCsvWriter<R, S>,
     mut predicate: F,
@@ -327,4 +350,40 @@ where
         }
     }
     Ok(input_rows)
+}
+
+/// `excerpt_csv_file` variant that uses an *existing* writer (so multi-file
+/// runs can stream into one shared shard set). Returns the number of input
+/// rows seen.
+pub fn excerpt_csv_file_into<R, S, F>(
+    input_path: impl AsRef<Path>,
+    mag_limit: f64,
+    writer: &mut ShardedCsvWriter<R, S>,
+    predicate: F,
+) -> Result<usize>
+where
+    R: GaiaRelease,
+    S: ShardKey<R::Entry>,
+    F: FnMut(&R::Entry) -> bool,
+{
+    let reader = CsvSourceReader::<R>::open(input_path, mag_limit)?;
+    drive(reader, writer, predicate)
+}
+
+/// `excerpt_csv_reader` variant that uses an *existing* writer. Same multi-file
+/// rationale as [`excerpt_csv_file_into`].
+pub fn excerpt_csv_reader_into<R, S, F>(
+    reader: Box<dyn std::io::Read>,
+    is_gz: bool,
+    mag_limit: f64,
+    writer: &mut ShardedCsvWriter<R, S>,
+    predicate: F,
+) -> Result<usize>
+where
+    R: GaiaRelease,
+    S: ShardKey<R::Entry>,
+    F: FnMut(&R::Entry) -> bool,
+{
+    let reader = CsvSourceReader::<R>::from_reader(reader, is_gz, mag_limit)?;
+    drive(reader, writer, predicate)
 }

--- a/crates/gaia/src/excerpt.rs
+++ b/crates/gaia/src/excerpt.rs
@@ -1,43 +1,69 @@
-//! Sharded, incremental excerpt writer.
+//! Sharded, resumable, crash-safe excerpt writer.
 //!
 //! Reads any Gaia CSV(.gz) catalog, applies a caller-supplied predicate, and
-//! writes the kept entries to one of N shard files chosen by a [`ShardKey`]. Each
-//! shard is written as gzipped CSV in the source release's own column layout, so
-//! the output round-trips back through `Dr{1,2,3}Catalog::from_csv_file`.
+//! writes the kept entries to one of N shard files chosen by a [`ShardKey`].
+//! Each shard is a **multi-stream gzip** of the source release's CSV layout
+//! (header line at file creation, then one fresh gz stream per input file
+//! appended afterward). This means:
 //!
-//! Per-shard files are opened lazily (only when first written to) so excerpts
-//! that touch only a few shards don't litter the output directory with empty
-//! files.
+//! - **Round-trip** through `Dr{1,2,3}Catalog::from_csv_file` works because
+//!   the reader uses `MultiGzDecoder` and treats the header line as a
+//!   one-time CSV header.
+//! - **Crash safety** is built in: each input file's contribution is buffered
+//!   in memory until [`ShardedCsvWriter::commit_file`] flushes everything,
+//!   fsyncs, and atomically updates the on-disk manifest. Mid-extract crashes
+//!   never leave partial rows in shards.
+//! - **Resume** is automatic: [`ShardedCsvWriter::new_or_resume`] reads the
+//!   manifest, truncates each shard to its last-committed byte length (cheap
+//!   safety net in case fsync was incomplete), and reports which input files
+//!   have already been processed so the caller can skip them.
 //!
-//! # Example
+//! # Example (multi-file, resumable)
 //!
 //! ```no_run
-//! use starfield_gaia::excerpt::{excerpt_csv_file, HashIdShard};
+//! use starfield_gaia::excerpt::{ShardedCsvWriter, HealpixShard, excerpt_csv_file_into};
 //! use starfield_gaia::Dr3;
 //!
-//! let summary = excerpt_csv_file::<Dr3, _, _>(
-//!     "GaiaSource_000000-003111.csv.gz",
-//!     20.0,
-//!     "out/",
-//!     HashIdShard { num_shards: 32 },
-//!     |entry| entry.core.phot_g_mean_mag < 16.0,
+//! let mut writer = ShardedCsvWriter::<Dr3, _>::new_or_resume(
+//!     "out/", HealpixShard { num_shards: 128, level: 5 }, 20.0,
 //! )?;
-//! println!("kept {} of {} stars across {} shards",
-//!          summary.kept_rows, summary.input_rows, summary.shard_files.len());
+//! let already = writer.processed_files().clone();
+//! for path in std::fs::read_dir("inputs/")? {
+//!     let path = path?.path();
+//!     let name = path.file_name().unwrap().to_string_lossy().into_owned();
+//!     if already.contains(&name) { continue; }
+//!     excerpt_csv_file_into::<Dr3, _, _>(&path, 20.0, &mut writer, |_| true)?;
+//! }
+//! let summary = writer.finish()?;
 //! # Ok::<(), starfield::StarfieldError>(())
 //! ```
 
-use std::fs::{self, File};
+use std::collections::BTreeSet;
+use std::fs::{self, File, OpenOptions};
 use std::io::{BufWriter, Write};
 use std::marker::PhantomData;
 use std::path::{Path, PathBuf};
 
 use flate2::write::GzEncoder;
 use flate2::Compression;
+use serde::{Deserialize, Serialize};
 use starfield::{Result, StarfieldError};
 
 use crate::common::reader::CsvSourceReader;
 use crate::common::traits::{GaiaRelease, GaiaSource};
+
+const MANIFEST_FILE: &str = ".gaia-excerpt-manifest.json";
+const MANIFEST_VERSION: u32 = 1;
+
+/// JSON has no representation for `INFINITY` / `NaN`; encode "no magnitude
+/// limit" as `None` and finite limits as `Some(value)`.
+fn encode_mag_limit(m: f64) -> Option<f64> {
+    if m.is_finite() {
+        Some(m)
+    } else {
+        None
+    }
+}
 
 // =====================================================================================
 // Sharding trait + built-in embodiments
@@ -47,17 +73,33 @@ use crate::common::traits::{GaiaRelease, GaiaSource};
 ///
 /// Built-in embodiments cover the common cases (hash-of-id, id-range banding,
 /// HEALPix cell). Implement this trait directly to shard by anything else
-/// (brightness, date, custom hash, etc.).
+/// (brightness, date, custom hash, etc.). User-defined sharders should
+/// override [`describe`](Self::describe) so the manifest can validate that
+/// a resume run is using the same partitioning function.
 pub trait ShardKey<E> {
-    /// Number of shards. Returned values from [`shard_of`](Self::shard_of) must lie in `0..num_shards()`.
     fn num_shards(&self) -> u32;
-
-    /// The shard index for one entry. Must be `< num_shards()`.
     fn shard_of(&self, entry: &E) -> u32;
+    /// A serializable summary stored in the manifest. On resume, the new run's
+    /// description must equal the recorded one or the writer refuses to attach.
+    /// Default returns `kind="custom"` with no sub-config — fine for ad-hoc
+    /// closures, but means resume can't distinguish two different "custom"
+    /// sharders. Override for production use.
+    fn describe(&self) -> ShardKeyDescription {
+        ShardKeyDescription {
+            kind: "custom".into(),
+            num_shards: self.num_shards(),
+            healpix_level: None,
+        }
+    }
 }
 
-/// Forwarding impl so callers can hold a `Box<dyn ShardKey<E>>` and pass it
-/// where a `S: ShardKey<E>` is required (e.g. into [`ShardedCsvWriter::new`]).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ShardKeyDescription {
+    pub kind: String,
+    pub num_shards: u32,
+    pub healpix_level: Option<u8>,
+}
+
 impl<E, S: ?Sized + ShardKey<E>> ShardKey<E> for Box<S> {
     fn num_shards(&self) -> u32 {
         (**self).num_shards()
@@ -65,11 +107,11 @@ impl<E, S: ?Sized + ShardKey<E>> ShardKey<E> for Box<S> {
     fn shard_of(&self, entry: &E) -> u32 {
         (**self).shard_of(entry)
     }
+    fn describe(&self) -> ShardKeyDescription {
+        (**self).describe()
+    }
 }
 
-/// Shard by `hash(source_id) % num_shards`. Roughly even distribution; loses
-/// any spatial / brightness locality. Use when you want shards of similar
-/// size for parallel processing.
 #[derive(Debug, Clone, Copy)]
 pub struct HashIdShard {
     pub num_shards: u32,
@@ -80,17 +122,18 @@ impl<E: GaiaSource> ShardKey<E> for HashIdShard {
         self.num_shards
     }
     fn shard_of(&self, entry: &E) -> u32 {
-        // SplitMix64 (see `mix_id`) is deterministic across runs, so the same
-        // source_id always lands in the same shard — important for incremental
-        // / resumable workflows. `std::hash`-based hashers are randomized per
-        // process and would make this non-reproducible.
         let mixed = mix_id(entry.core().source_id);
         (mixed % self.num_shards as u64) as u32
     }
+    fn describe(&self) -> ShardKeyDescription {
+        ShardKeyDescription {
+            kind: "hash".into(),
+            num_shards: self.num_shards,
+            healpix_level: None,
+        }
+    }
 }
 
-/// SplitMix64 — deterministic, very fast, good distribution. Used to break the
-/// HEALPix-12 bit alignment in Gaia source_ids before bucketing.
 fn mix_id(x: u64) -> u64 {
     let mut z = x.wrapping_add(0x9E37_79B9_7F4A_7C15);
     z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
@@ -98,10 +141,6 @@ fn mix_id(x: u64) -> u64 {
     z ^ (z >> 31)
 }
 
-/// Shard by source_id range — divide the `u64` ID space into `num_shards`
-/// equal-width buckets. For DR2/DR3 source_ids encode HEALPix-12 in the high
-/// bits, so this gives spatial locality "for free" (nearby pixels in adjacent
-/// shards). For DR1 the encoding differs and locality is weaker.
 #[derive(Debug, Clone, Copy)]
 pub struct IdRangeShard {
     pub num_shards: u32,
@@ -116,15 +155,18 @@ impl<E: GaiaSource> ShardKey<E> for IdRangeShard {
         let bucket_size = (u64::MAX / self.num_shards as u64).saturating_add(1);
         ((id / bucket_size) as u32).min(self.num_shards - 1)
     }
+    fn describe(&self) -> ShardKeyDescription {
+        ShardKeyDescription {
+            kind: "id-range".into(),
+            num_shards: self.num_shards,
+            healpix_level: None,
+        }
+    }
 }
 
-/// Shard by HEALPix cell at the given depth, modulo `num_shards`. Computes
-/// the pixel from the entry's RA/Dec via [`cdshealpix::nested::hash`], so it
-/// works identically across DR1/DR2/DR3.
 #[derive(Debug, Clone, Copy)]
 pub struct HealpixShard {
     pub num_shards: u32,
-    /// HEALPix depth (0..=29). Higher = finer pixels. Default 6 (49,152 pixels).
     pub level: u8,
 }
 
@@ -137,27 +179,160 @@ impl<E: GaiaSource> ShardKey<E> for HealpixShard {
         let pixel = cdshealpix::nested::hash(self.level, c.ra.to_radians(), c.dec.to_radians());
         (pixel % self.num_shards as u64) as u32
     }
+    fn describe(&self) -> ShardKeyDescription {
+        ShardKeyDescription {
+            kind: "healpix".into(),
+            num_shards: self.num_shards,
+            healpix_level: Some(self.level),
+        }
+    }
 }
 
 // =====================================================================================
-// Sharded gzipped CSV writer
+// Manifest — durable record of per-shard sizes + processed input files
 // =====================================================================================
 
-/// Streaming sharded CSV.gz writer. Files are opened lazily — a shard that
-/// receives no entries leaves no file behind.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Manifest {
+    pub version: u32,
+    pub release: String,
+    /// `None` = no magnitude limit. We avoid storing `f64::INFINITY` directly
+    /// because JSON has no representation for non-finite floats.
+    pub mag_limit: Option<f64>,
+    pub sharder: ShardKeyDescription,
+    /// Byte length of each shard file as of the most recent successful commit.
+    /// `truncate(file, shard_sizes[i])` discards anything written after.
+    pub shard_sizes: Vec<u64>,
+    /// Row count per shard, as of the most recent successful commit.
+    pub shard_rows: Vec<u64>,
+    pub processed_files: BTreeSet<String>,
+    pub kept_rows: u64,
+}
+
+impl Manifest {
+    fn fresh<R: GaiaRelease, S: ShardKey<R::Entry>>(sharder: &S, mag_limit: f64) -> Self {
+        let n = sharder.num_shards() as usize;
+        Self {
+            version: MANIFEST_VERSION,
+            release: format!("{:?}", R::RELEASE),
+            mag_limit: encode_mag_limit(mag_limit),
+            sharder: sharder.describe(),
+            shard_sizes: vec![0; n],
+            shard_rows: vec![0; n],
+            processed_files: BTreeSet::new(),
+            kept_rows: 0,
+        }
+    }
+
+    fn validate_against<R: GaiaRelease, S: ShardKey<R::Entry>>(
+        &self,
+        sharder: &S,
+        mag_limit: f64,
+    ) -> Result<()> {
+        let want_release = format!("{:?}", R::RELEASE);
+        if self.release != want_release {
+            return Err(StarfieldError::DataError(format!(
+                "manifest release mismatch: on-disk={}, requested={}",
+                self.release, want_release
+            )));
+        }
+        let want = encode_mag_limit(mag_limit);
+        if self.mag_limit != want {
+            return Err(StarfieldError::DataError(format!(
+                "manifest mag_limit mismatch: on-disk={:?}, requested={:?}",
+                self.mag_limit, want
+            )));
+        }
+        let want_desc = sharder.describe();
+        if self.sharder != want_desc {
+            return Err(StarfieldError::DataError(format!(
+                "manifest sharder mismatch: on-disk={:?}, requested={:?}",
+                self.sharder, want_desc
+            )));
+        }
+        if self.shard_sizes.len() != sharder.num_shards() as usize {
+            return Err(StarfieldError::DataError(format!(
+                "manifest shard count mismatch: on-disk={}, requested={}",
+                self.shard_sizes.len(),
+                sharder.num_shards()
+            )));
+        }
+        Ok(())
+    }
+
+    fn write_atomic(&self, dir: &Path) -> Result<()> {
+        let final_path = dir.join(MANIFEST_FILE);
+        let tmp_path = dir.join(format!("{}.tmp", MANIFEST_FILE));
+        let json = serde_json::to_vec_pretty(self)
+            .map_err(|e| StarfieldError::DataError(format!("manifest encode: {}", e)))?;
+        let mut f = File::create(&tmp_path).map_err(StarfieldError::IoError)?;
+        f.write_all(&json).map_err(StarfieldError::IoError)?;
+        f.sync_all().map_err(StarfieldError::IoError)?;
+        drop(f);
+        fs::rename(&tmp_path, &final_path).map_err(StarfieldError::IoError)?;
+        Ok(())
+    }
+
+    fn try_load(dir: &Path) -> Result<Option<Self>> {
+        let p = dir.join(MANIFEST_FILE);
+        if !p.exists() {
+            return Ok(None);
+        }
+        let bytes = fs::read(&p).map_err(StarfieldError::IoError)?;
+        let m: Manifest = serde_json::from_slice(&bytes)
+            .map_err(|e| StarfieldError::DataError(format!("manifest decode: {}", e)))?;
+        if m.version != MANIFEST_VERSION {
+            return Err(StarfieldError::DataError(format!(
+                "manifest version {} unsupported (expected {})",
+                m.version, MANIFEST_VERSION
+            )));
+        }
+        Ok(Some(m))
+    }
+}
+
+// =====================================================================================
+// Sharded gzipped CSV writer (resumable + crash-safe)
+// =====================================================================================
+
+/// Per-shard, multi-stream gzip CSV writer with manifest-tracked checkpoints.
+///
+/// Workflow per input file: [`begin_file`](Self::begin_file), [`write`](Self::write)
+/// repeatedly, then [`commit_file`](Self::commit_file). All rows for one file are
+/// buffered in memory between begin and commit; on commit the buffered rows are
+/// gz-encoded as fresh streams (one per shard touched), appended to each shard
+/// file, fsynced, and the manifest is atomically updated. A crash anywhere
+/// before commit completes leaves the on-disk state unchanged from the previous
+/// commit — re-running picks up by skipping `processed_files`.
 pub struct ShardedCsvWriter<R: GaiaRelease, S: ShardKey<R::Entry>> {
     output_dir: PathBuf,
     shard_key: S,
-    writers: Vec<Option<BufWriter<GzEncoder<File>>>>,
-    counts: Vec<u64>,
-    paths: Vec<Option<PathBuf>>,
-    width: usize,
+
+    /// Per-shard final on-disk paths (always set; file may not yet exist).
+    paths: Vec<PathBuf>,
+
+    /// In-memory buffer of formatted CSV rows for the currently-open file,
+    /// keyed by shard index.
+    pending: Vec<Vec<String>>,
+
+    /// On-disk manifest (in-sync with files between commits).
+    manifest: Manifest,
+
     _marker: PhantomData<R>,
 }
 
 impl<R: GaiaRelease, S: ShardKey<R::Entry>> ShardedCsvWriter<R, S> {
-    /// Create a new writer rooted at `output_dir`. Creates the directory if missing.
-    pub fn new(output_dir: impl AsRef<Path>, shard_key: S) -> Result<Self> {
+    /// Open `output_dir`. If a manifest exists there:
+    /// - validate it matches `sharder` / `mag_limit` / release
+    /// - truncate each shard file to its recorded length (paranoia)
+    /// - return a writer that knows which input files have already been processed
+    ///
+    /// If no manifest exists: create the dir + manifest fresh.
+    pub fn new_or_resume(
+        output_dir: impl AsRef<Path>,
+        shard_key: S,
+        mag_limit: f64,
+    ) -> Result<Self> {
         let output_dir = output_dir.as_ref().to_path_buf();
         fs::create_dir_all(&output_dir).map_err(StarfieldError::IoError)?;
         let n = shard_key.num_shards();
@@ -167,83 +342,189 @@ impl<R: GaiaRelease, S: ShardKey<R::Entry>> ShardedCsvWriter<R, S> {
             ));
         }
         let width = digits_for(n);
-        let mut writers = Vec::with_capacity(n as usize);
-        let mut paths = Vec::with_capacity(n as usize);
-        for _ in 0..n {
-            writers.push(None);
-            paths.push(None);
-        }
+        let paths: Vec<PathBuf> = (0..n)
+            .map(|i| output_dir.join(format!("shard_{:0width$}.csv.gz", i, width = width)))
+            .collect();
+
+        let manifest = match Manifest::try_load(&output_dir)? {
+            Some(m) => {
+                m.validate_against::<R, S>(&shard_key, mag_limit)?;
+                // Defensive truncate-to-recorded-length on every shard. If the
+                // last commit's fsync was complete, this is a no-op. If a crash
+                // left bytes after the recorded boundary, this discards them.
+                for (i, path) in paths.iter().enumerate() {
+                    if path.exists() {
+                        let f = OpenOptions::new()
+                            .write(true)
+                            .open(path)
+                            .map_err(StarfieldError::IoError)?;
+                        f.set_len(m.shard_sizes[i])
+                            .map_err(StarfieldError::IoError)?;
+                        f.sync_all().map_err(StarfieldError::IoError)?;
+                    }
+                }
+                m
+            }
+            None => {
+                let m = Manifest::fresh::<R, S>(&shard_key, mag_limit);
+                m.write_atomic(&output_dir)?;
+                m
+            }
+        };
+
         Ok(Self {
             output_dir,
             shard_key,
-            writers,
-            counts: vec![0; n as usize],
             paths,
-            width,
+            pending: vec![Vec::new(); n as usize],
+            manifest,
             _marker: PhantomData,
         })
     }
 
-    /// Write one entry to its shard file, opening the file (and writing the CSV
-    /// header) the first time that shard is touched.
+    /// Files whose rows are already committed to shards. CLI should skip these
+    /// when iterating its input list.
+    pub fn processed_files(&self) -> &BTreeSet<String> {
+        &self.manifest.processed_files
+    }
+
+    /// Rows committed across all input files so far (sum across shards from
+    /// the manifest). Persists across restarts.
+    pub fn kept_so_far(&self) -> u64 {
+        self.manifest.kept_rows
+    }
+
+    /// Begin processing one input file. Clears the in-memory pending buffer.
+    pub fn begin_file(&mut self, _filename: &str) {
+        for buf in &mut self.pending {
+            buf.clear();
+        }
+    }
+
+    /// Buffer a row in memory, routed to its shard. Does not touch disk.
     pub fn write(&mut self, entry: &R::Entry) -> Result<()> {
         let shard = self.shard_key.shard_of(entry);
-        if shard >= self.writers.len() as u32 {
+        if shard >= self.pending.len() as u32 {
             return Err(StarfieldError::DataError(format!(
                 "ShardKey returned {} for num_shards={}",
                 shard,
-                self.writers.len()
+                self.pending.len()
             )));
         }
-        let idx = shard as usize;
-
-        if self.writers[idx].is_none() {
-            let filename = format!("shard_{:0width$}.csv.gz", shard, width = self.width);
-            let path = self.output_dir.join(&filename);
-            let file = File::create(&path).map_err(StarfieldError::IoError)?;
-            let gz = GzEncoder::new(file, Compression::default());
-            let mut buf = BufWriter::new(gz);
-            writeln!(buf, "{}", R::csv_header()).map_err(StarfieldError::IoError)?;
-            self.writers[idx] = Some(buf);
-            self.paths[idx] = Some(path);
-        }
-
-        let row = R::format_csv_row(entry);
-        let writer = self.writers[idx].as_mut().unwrap();
-        writeln!(writer, "{}", row).map_err(StarfieldError::IoError)?;
-        self.counts[idx] += 1;
+        self.pending[shard as usize].push(R::format_csv_row(entry));
         Ok(())
     }
 
-    /// Total rows written so far across every shard. Useful for progress
-    /// reporting and for the CLI's "did this attempt commit anything?" check
-    /// when deciding whether a transient HTTP failure is safe to retry.
-    pub fn kept_so_far(&self) -> u64 {
-        self.counts.iter().sum()
+    /// Atomically commit the in-memory buffer for one input file:
+    /// 1. For each shard with pending rows: open the shard file in append
+    ///    mode, gz-encode the rows as a fresh stream, finish, fsync.
+    ///    (If the file doesn't exist yet, write the CSV header line in its
+    ///    own first gz stream before the row stream.)
+    /// 2. Update manifest with new shard_sizes + processed_files += filename
+    ///    + kept_rows. Atomically rewrite via `.tmp` + `rename`.
+    /// 3. Clear the pending buffer.
+    ///
+    /// If any step errors out, the manifest is unchanged — the caller can
+    /// retry the same input file safely (modulo any download caching they
+    /// might do).
+    pub fn commit_file(&mut self, filename: &str) -> Result<()> {
+        if self.manifest.processed_files.contains(filename) {
+            // Already done in a prior run / call. No-op.
+            for buf in &mut self.pending {
+                buf.clear();
+            }
+            return Ok(());
+        }
+
+        let mut new_sizes = self.manifest.shard_sizes.clone();
+        let mut new_rows = self.manifest.shard_rows.clone();
+        let mut added = 0u64;
+
+        for (idx, rows) in self.pending.iter().enumerate() {
+            if rows.is_empty() {
+                continue;
+            }
+            let path = &self.paths[idx];
+            let need_header = !path.exists() || new_sizes[idx] == 0;
+            let mut f = OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(path)
+                .map_err(StarfieldError::IoError)?;
+
+            if need_header {
+                let mut gz = GzEncoder::new(BufWriter::new(&mut f), Compression::default());
+                writeln!(gz, "{}", R::csv_header()).map_err(StarfieldError::IoError)?;
+                let buf = gz.finish().map_err(StarfieldError::IoError)?;
+                buf.into_inner()
+                    .map_err(|e| StarfieldError::IoError(e.into_error()))?
+                    .flush()
+                    .map_err(StarfieldError::IoError)?;
+            }
+
+            // One gz stream per file's contribution; concatenated into the file.
+            let mut gz = GzEncoder::new(BufWriter::new(&mut f), Compression::default());
+            for row in rows {
+                writeln!(gz, "{}", row).map_err(StarfieldError::IoError)?;
+            }
+            let buf = gz.finish().map_err(StarfieldError::IoError)?;
+            buf.into_inner()
+                .map_err(|e| StarfieldError::IoError(e.into_error()))?
+                .flush()
+                .map_err(StarfieldError::IoError)?;
+
+            f.sync_all().map_err(StarfieldError::IoError)?;
+            new_sizes[idx] = f.metadata().map_err(StarfieldError::IoError)?.len();
+            new_rows[idx] += rows.len() as u64;
+            added += rows.len() as u64;
+        }
+
+        let mut new_manifest = self.manifest.clone();
+        new_manifest.shard_sizes = new_sizes;
+        new_manifest.shard_rows = new_rows;
+        new_manifest.processed_files.insert(filename.to_string());
+        new_manifest.kept_rows += added;
+        new_manifest.write_atomic(&self.output_dir)?;
+        self.manifest = new_manifest;
+
+        for buf in &mut self.pending {
+            buf.clear();
+        }
+        Ok(())
     }
 
-    /// Finalize: flush every open shard file and return a summary.
-    pub fn finish(mut self) -> Result<ExcerptSummary> {
-        for w in self.writers.iter_mut() {
-            if let Some(buf) = w.take() {
-                let gz = buf
-                    .into_inner()
-                    .map_err(|e| StarfieldError::IoError(e.into_error()))?;
-                gz.finish().map_err(StarfieldError::IoError)?;
+    /// Path to the manifest file (callers who want to inspect / archive).
+    pub fn manifest_path(&self) -> PathBuf {
+        self.output_dir.join(MANIFEST_FILE)
+    }
+
+    /// Snapshot the current manifest.
+    pub fn manifest(&self) -> &Manifest {
+        &self.manifest
+    }
+
+    /// Finalize: returns a summary built from the on-disk manifest. The
+    /// writer can also be dropped without calling this; the manifest is
+    /// always up-to-date because every commit is atomic.
+    pub fn finish(self) -> Result<ExcerptSummary> {
+        let mut shard_files = Vec::with_capacity(self.paths.len());
+        for (i, p) in self.paths.iter().enumerate() {
+            if self.manifest.shard_sizes[i] > 0 {
+                shard_files.push(Some(p.clone()));
+            } else {
+                shard_files.push(None);
             }
         }
         Ok(ExcerptSummary {
-            input_rows: 0, // populated by `excerpt_csv_file`
-            kept_rows: self.counts.iter().sum(),
-            per_shard_counts: self.counts,
-            shard_files: self.paths,
+            input_rows: 0,
+            kept_rows: self.manifest.kept_rows,
+            per_shard_counts: self.manifest.shard_rows.clone(),
+            shard_files,
         })
     }
 }
 
 fn digits_for(n: u32) -> usize {
-    // Number of digits needed to represent `n - 1`, with a minimum of 4 so file
-    // listings sort sensibly even for small shard counts.
     let max_idx = n.saturating_sub(1);
     let nd = if max_idx == 0 {
         1
@@ -254,11 +535,9 @@ fn digits_for(n: u32) -> usize {
 }
 
 // =====================================================================================
-// Summary + convenience function
+// Summary + convenience drive functions
 // =====================================================================================
 
-/// What the excerpt run produced. `shard_files[i]` is `Some(path)` iff shard `i`
-/// received at least one entry.
 #[derive(Debug, Clone)]
 pub struct ExcerptSummary {
     pub input_rows: usize,
@@ -268,19 +547,13 @@ pub struct ExcerptSummary {
 }
 
 impl ExcerptSummary {
-    /// Paths of every shard file that was actually written (Some entries only).
     pub fn written_paths(&self) -> impl Iterator<Item = &PathBuf> {
         self.shard_files.iter().flatten()
     }
 }
 
-/// Read a single CSV(.gz) file, apply `predicate` to each row's typed entry,
-/// and stream the kept entries into shard files in `output_dir`.
-///
-/// `mag_limit` is applied at read time as a fast pre-filter on `phot_g_mean_mag`;
-/// rows fainter than the limit never materialize. `predicate` runs after the
-/// mag-limit pass and gets full access to the typed entry (including any nested
-/// sub-structs your release exposes).
+/// One-shot: open `output_dir` (resuming if a manifest exists), process
+/// `input_path` if not already processed, return a summary.
 pub fn excerpt_csv_file<R, S, F>(
     input_path: impl AsRef<Path>,
     mag_limit: f64,
@@ -293,24 +566,28 @@ where
     S: ShardKey<R::Entry>,
     F: FnMut(&R::Entry) -> bool,
 {
-    let reader = CsvSourceReader::<R>::open(input_path, mag_limit)?;
-    let mut writer = ShardedCsvWriter::<R, S>::new(output_dir, sharder)?;
-    let input_rows = drive(reader, &mut writer, predicate)?;
+    let path = input_path.as_ref();
+    let filename = filename_of(path)?;
+    let mut writer = ShardedCsvWriter::<R, S>::new_or_resume(output_dir, sharder, mag_limit)?;
+    let input_rows = if writer.processed_files().contains(&filename) {
+        0
+    } else {
+        excerpt_csv_file_into::<R, S, F>(path, mag_limit, &mut writer, predicate)?
+    };
     let mut summary = writer.finish()?;
     summary.input_rows = input_rows;
     Ok(summary)
 }
 
-/// Same as [`excerpt_csv_file`] but reads from any byte source — typically a
-/// streamed HTTP response from
-/// [`Downloader::stream_file`](crate::download::Downloader::stream_file), so the
-/// raw catalog never has to land on disk.
+/// One-shot variant that reads from any byte source. Caller supplies
+/// `filename` (used as the manifest key for skip-on-resume).
 pub fn excerpt_csv_reader<R, S, F>(
     reader: Box<dyn std::io::Read>,
     is_gz: bool,
     mag_limit: f64,
     output_dir: impl AsRef<Path>,
     sharder: S,
+    filename: &str,
     predicate: F,
 ) -> Result<ExcerptSummary>
 where
@@ -318,43 +595,26 @@ where
     S: ShardKey<R::Entry>,
     F: FnMut(&R::Entry) -> bool,
 {
-    let reader = CsvSourceReader::<R>::from_reader(reader, is_gz, mag_limit)?;
-    let mut writer = ShardedCsvWriter::<R, S>::new(output_dir, sharder)?;
-    let input_rows = drive(reader, &mut writer, predicate)?;
+    let mut writer = ShardedCsvWriter::<R, S>::new_or_resume(output_dir, sharder, mag_limit)?;
+    let input_rows = if writer.processed_files().contains(filename) {
+        0
+    } else {
+        excerpt_csv_reader_into::<R, S, F>(
+            reader,
+            is_gz,
+            mag_limit,
+            &mut writer,
+            filename,
+            predicate,
+        )?
+    };
     let mut summary = writer.finish()?;
     summary.input_rows = input_rows;
     Ok(summary)
 }
 
-/// Stream `reader` through `predicate` into an existing `writer`. Returns the
-/// number of input rows seen (post-mag-limit, pre-predicate). Use this when you
-/// have multiple input files that should write into a single shared output set
-/// — calling [`excerpt_csv_file`] once per input file would `File::create`-truncate
-/// every shard each time, losing all but the last input's data per shard.
-pub fn drive<R, S, F>(
-    reader: CsvSourceReader<R>,
-    writer: &mut ShardedCsvWriter<R, S>,
-    mut predicate: F,
-) -> Result<usize>
-where
-    R: GaiaRelease,
-    S: ShardKey<R::Entry>,
-    F: FnMut(&R::Entry) -> bool,
-{
-    let mut input_rows = 0usize;
-    for entry in reader {
-        let entry = entry?;
-        input_rows += 1;
-        if predicate(&entry) {
-            writer.write(&entry)?;
-        }
-    }
-    Ok(input_rows)
-}
-
-/// `excerpt_csv_file` variant that uses an *existing* writer (so multi-file
-/// runs can stream into one shared shard set). Returns the number of input
-/// rows seen.
+/// Process one input file into an existing writer. Filename is derived from
+/// the path's last component and used as the manifest key.
 pub fn excerpt_csv_file_into<R, S, F>(
     input_path: impl AsRef<Path>,
     mag_limit: f64,
@@ -366,17 +626,20 @@ where
     S: ShardKey<R::Entry>,
     F: FnMut(&R::Entry) -> bool,
 {
-    let reader = CsvSourceReader::<R>::open(input_path, mag_limit)?;
-    drive(reader, writer, predicate)
+    let path = input_path.as_ref();
+    let filename = filename_of(path)?;
+    let reader = CsvSourceReader::<R>::open(path, mag_limit)?;
+    drive(reader, writer, &filename, predicate)
 }
 
-/// `excerpt_csv_reader` variant that uses an *existing* writer. Same multi-file
-/// rationale as [`excerpt_csv_file_into`].
+/// Process one input reader into an existing writer. Caller supplies the
+/// manifest key.
 pub fn excerpt_csv_reader_into<R, S, F>(
     reader: Box<dyn std::io::Read>,
     is_gz: bool,
     mag_limit: f64,
     writer: &mut ShardedCsvWriter<R, S>,
+    filename: &str,
     predicate: F,
 ) -> Result<usize>
 where
@@ -385,5 +648,43 @@ where
     F: FnMut(&R::Entry) -> bool,
 {
     let reader = CsvSourceReader::<R>::from_reader(reader, is_gz, mag_limit)?;
-    drive(reader, writer, predicate)
+    drive(reader, writer, filename, predicate)
+}
+
+/// Stream `reader` through `predicate` into `writer`, framed by
+/// `begin_file` + `commit_file` so the per-file commit is atomic.
+pub fn drive<R, S, F>(
+    reader: CsvSourceReader<R>,
+    writer: &mut ShardedCsvWriter<R, S>,
+    filename: &str,
+    mut predicate: F,
+) -> Result<usize>
+where
+    R: GaiaRelease,
+    S: ShardKey<R::Entry>,
+    F: FnMut(&R::Entry) -> bool,
+{
+    writer.begin_file(filename);
+    let mut input_rows = 0usize;
+    for entry in reader {
+        let entry = entry?;
+        input_rows += 1;
+        if predicate(&entry) {
+            writer.write(&entry)?;
+        }
+    }
+    writer.commit_file(filename)?;
+    Ok(input_rows)
+}
+
+fn filename_of(path: &Path) -> Result<String> {
+    path.file_name()
+        .and_then(|s| s.to_str())
+        .map(|s| s.to_string())
+        .ok_or_else(|| {
+            StarfieldError::DataError(format!(
+                "input path has no UTF-8 file name: {}",
+                path.display()
+            ))
+        })
 }

--- a/crates/gaia/tests/dr3_excerpt.rs
+++ b/crates/gaia/tests/dr3_excerpt.rs
@@ -9,7 +9,8 @@ use std::io::Write;
 
 use starfield::catalogs::StarCatalog;
 use starfield_gaia::excerpt::{
-    excerpt_csv_file, HashIdShard, HealpixShard, IdRangeShard, ShardKey,
+    excerpt_csv_file, excerpt_csv_file_into, HashIdShard, HealpixShard, IdRangeShard, ShardKey,
+    ShardedCsvWriter,
 };
 use starfield_gaia::{Dr3, Dr3Catalog};
 
@@ -211,6 +212,7 @@ fn excerpt_from_reader_streams_without_disk() {
         f64::INFINITY,
         out.path(),
         HashIdShard { num_shards: 4 },
+        "synthetic.csv",
         |_| true,
     )
     .expect("excerpt from reader");
@@ -233,4 +235,135 @@ fn healpix_shard_returns_in_range() {
     // Every shard count must be in 0..num_shards; sum equals kept.
     assert_eq!(summary.per_shard_counts.len(), 32);
     assert_eq!(summary.per_shard_counts.iter().sum::<u64>(), 50);
+}
+
+#[test]
+fn resume_skips_already_processed_files_no_dups() {
+    // Process 3 distinct fixtures into the same output dir across two writer
+    // sessions. The second session must skip files already in the manifest
+    // and end up with EXACTLY the union of rows, no duplicates.
+    fn make_fixture(start_id: u64, n: u64) -> tempfile::NamedTempFile {
+        let mut f = tempfile::Builder::new().suffix(".csv").tempfile().unwrap();
+        writeln!(f, "{}", HEADER).unwrap();
+        for i in 0..n {
+            let id = start_id + i;
+            let row = row_from(&HashMap::from([
+                ("source_id", id.to_string().as_str()),
+                ("solution_id", "1635721458409799680"),
+                ("ref_epoch", "2016.0"),
+                ("ra", "10.0"),
+                ("ra_error", "0.04"),
+                ("dec", "20.0"),
+                ("dec_error", "0.04"),
+                ("l", "0.0"),
+                ("b", "0.0"),
+                ("ecl_lon", "0.0"),
+                ("ecl_lat", "0.0"),
+                ("phot_g_mean_mag", "10.0"),
+                ("phot_variable_flag", "NOT_AVAILABLE"),
+            ]));
+            writeln!(f, "{}", row).unwrap();
+        }
+        f.flush().unwrap();
+        f
+    }
+
+    let f1 = make_fixture(1_000_000, 60);
+    let f2 = make_fixture(2_000_000, 80);
+    let f3 = make_fixture(3_000_000, 100);
+    let out = tempfile::tempdir().unwrap();
+
+    // Session 1: process f1 + f2
+    {
+        let mut writer = ShardedCsvWriter::<Dr3, _>::new_or_resume(
+            out.path(),
+            HashIdShard { num_shards: 4 },
+            f64::INFINITY,
+        )
+        .expect("open writer");
+        excerpt_csv_file_into::<Dr3, _, _>(f1.path(), f64::INFINITY, &mut writer, |_| true)
+            .expect("f1 first time");
+        excerpt_csv_file_into::<Dr3, _, _>(f2.path(), f64::INFINITY, &mut writer, |_| true)
+            .expect("f2 first time");
+        let s = writer.finish().unwrap();
+        assert_eq!(s.kept_rows, 140);
+    }
+
+    // Session 2 (simulates resume after a crash): pretend we don't know
+    // what was processed, just iterate all 3 fixtures. Writer skips f1/f2,
+    // processes f3.
+    {
+        let mut writer = ShardedCsvWriter::<Dr3, _>::new_or_resume(
+            out.path(),
+            HashIdShard { num_shards: 4 },
+            f64::INFINITY,
+        )
+        .expect("re-open writer");
+        let already = writer.processed_files().clone();
+        assert!(already.contains(f1.path().file_name().unwrap().to_str().unwrap()));
+        assert!(already.contains(f2.path().file_name().unwrap().to_str().unwrap()));
+
+        for path in [f1.path(), f2.path(), f3.path()] {
+            let name = path.file_name().unwrap().to_str().unwrap().to_string();
+            if already.contains(&name) {
+                continue;
+            }
+            excerpt_csv_file_into::<Dr3, _, _>(path, f64::INFINITY, &mut writer, |_| true)
+                .expect("f3 first time");
+        }
+        let s = writer.finish().unwrap();
+        // Must equal the union, not double-count f1+f2.
+        assert_eq!(s.kept_rows, 240, "resume double-counted or missed rows");
+        assert_eq!(s.per_shard_counts.iter().sum::<u64>(), 240);
+    }
+
+    // Round-trip: reload every shard via Dr3Catalog and verify every
+    // expected source_id is present exactly once.
+    let mut all_ids = Vec::new();
+    for shard in std::fs::read_dir(out.path()).unwrap() {
+        let p = shard.unwrap().path();
+        if !p.to_string_lossy().ends_with(".csv.gz") {
+            continue;
+        }
+        let cat = Dr3Catalog::from_csv_file(&p, f64::INFINITY).expect("reload shard");
+        for s in cat.stars() {
+            all_ids.push(s.core.source_id);
+        }
+    }
+    all_ids.sort();
+    let mut expected: Vec<u64> = Vec::with_capacity(240);
+    expected.extend(1_000_000..1_000_060);
+    expected.extend(2_000_000..2_000_080);
+    expected.extend(3_000_000..3_000_100);
+    expected.sort();
+    assert_eq!(all_ids, expected, "resume corrupted round-trip");
+}
+
+#[test]
+fn manifest_validation_rejects_mismatched_resume() {
+    // First run with 4 shards. Second run with 8 shards must refuse to attach.
+    let fixture = write_n_row_fixture(20);
+    let out = tempfile::tempdir().unwrap();
+    excerpt_csv_file::<Dr3, _, _>(
+        fixture.path(),
+        f64::INFINITY,
+        out.path(),
+        HashIdShard { num_shards: 4 },
+        |_| true,
+    )
+    .unwrap();
+
+    let err = ShardedCsvWriter::<Dr3, _>::new_or_resume(
+        out.path(),
+        HashIdShard { num_shards: 8 }, // mismatch
+        f64::INFINITY,
+    )
+    .err()
+    .expect("must reject mismatched shard count");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("sharder mismatch") || msg.contains("shard count mismatch"),
+        "unexpected error message: {}",
+        msg
+    );
 }


### PR DESCRIPTION
## Summary

Two correctness bugs surfaced when running the excerpt against the full DR3 catalog (3,386 files / ~750 GB compressed) post-#27. This PR fixes both, plus extends `--clean-after-excerpt` so disk usage stays bounded when staging-then-evicting from the CDN.

### Bug 1 — per-file `File::create` truncation

`excerpt_csv_file` constructed a fresh `ShardedCsvWriter` per input file. The writer's first-touch on a shard called `File::create()`, which **truncates**. Multi-input runs lost everything but the last input's data per shard. Caught after a 10-hour run produced *shrinking* on-disk output.

### Bug 2 — mid-stream HTTP failure → unrecoverable loss

Pure streaming mode (`--from-release dr3` without `--cache-raw`) has no MD5 verification and no resume. Mid-stream connection drops left partial rows in shards that couldn't be safely re-fetched. ~18 files × ~150k rows lost on one run.

## Library changes

- `ShardedCsvWriter` and `drive` now `pub`; new `excerpt_csv_file_into` and `excerpt_csv_reader_into` accept an existing writer so multi-file callers share one writer.
- `ShardedCsvWriter::kept_so_far()` exposes cumulative committed-row count for retry-safety checks.
- Blanket `impl<E, S: ?Sized + ShardKey<E>> ShardKey<E> for Box<S>` — CLI can hold a boxed sharder and still pass it where `S: ShardKey<E>` is required.

## CLI changes

- Dispatches release once at the top; one `ShardedCsvWriter` lives across the whole run.
- Per-file retry on transient HTTP errors (5 attempts, 1/2/4/8/16 s backoff) with each retry logged with the filename. Mid-stream failures (any row already committed) are **not** retried — they would duplicate.
- `--clean-after-excerpt` extended to also evict cached raw files in `--cache-raw` mode. The combination gives an **atomic per-file pipeline**: download (MD5-verified, resumable) → extract → evict, with steady-state raw-cache disk usage ≈ one file in flight (~250 MB).

## Temporary file

This PR also includes `IN_PROGRESS_dr3_mag20_excerpt.md` at repo root — a durable note about the long-running DR3 excerpt that's currently chewing through ~750 GB on this branch's binary. **Will be deleted in the follow-up PR** once the excerpt completes. It exists so a future session can pick up context without re-deriving it.

## Test plan

- [x] 2-file synthetic smoke confirms multi-file accumulation works (305,715 rows in → 305,715 rows summed across 16 shards out)
- [x] 2-file CDN smoke with `--cache-raw --clean-after-excerpt`: raw cache empty after run, all rows extracted
- [x] All 12 existing gaia tests pass (`cargo test -p starfield-gaia --features all-releases`)
- [x] `cargo fmt --check` clean
- [ ] CI green
- [ ] DR3 full run completes without the truncation or mid-stream loss issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)