### PR TITLE
Add starfield-nsa crate: NASA-Sloan Atlas galaxy catalog loader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/gaia-tools",
     "crates/hipparcos",
     "crates/mpc",
+    "crates/nsa",
     "crates/rubin",
     "crates/starfield-datasources",
 ]
@@ -34,3 +35,4 @@ indicatif = "0.17"
 arrow = "58"
 cdshealpix = "0.9.1"
 clap = { version = "4", features = ["derive"] }
+fitsio-pure = "0.11"

--- a/crates/nsa/Cargo.toml
+++ b/crates/nsa/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "starfield-nsa"
+version = "0.1.0"
+description = "NASA-Sloan Atlas (NSA) galaxy catalog loader and downloader"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+starfield = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
+nalgebra = { workspace = true }
+fitsio-pure = { workspace = true }
+starfield-datasource-utils = { version = "0.1.0", path = "../datasource-utils" }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/nsa/src/catalog.rs
+++ b/crates/nsa/src/catalog.rs
@@ -1,0 +1,362 @@
+//! NSA `NsaEntry` type and FITS BinTable loader.
+//!
+//! v1 surface area: a curated subset of NSA columns (position, redshift,
+//! Sérsic structural fit, per-band fluxes + ivars). Adding more columns is
+//! a matter of (1) extending [`NsaEntry`], (2) adding another column read
+//! in [`NsaCatalog::from_fits_file`], (3) wiring the per-row materializer.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use nalgebra as na;
+use serde::{Deserialize, Serialize};
+use starfield::catalogs::{StarCatalog, StarData};
+use starfield::{Result, StarfieldError};
+
+use fitsio_pure::bintable::{
+    parse_binary_table_columns, read_binary_column, BinaryColumnData, BinaryColumnDescriptor,
+};
+use fitsio_pure::hdu::{parse_fits, Hdu, HduInfo};
+
+/// SDSS+GALEX broad-band order used in NSA's `SERSIC_FLUX` / `SERSIC_FLUX_IVAR`
+/// arrays. Column index `i` in either array corresponds to `BANDS[i]`.
+pub const BANDS: [&str; 7] = ["FUV", "NUV", "u", "g", "r", "i", "z"];
+
+/// One galaxy from the NASA-Sloan Atlas.
+///
+/// All units follow NSA's published conventions (mostly arcsec, deg,
+/// nanomaggies). See <https://www.sdss.org/dr17/manga/manga-target-selection/nsa/>
+/// for the full column reference.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NsaEntry {
+    /// NSA's stable per-galaxy ID (`NSAID` column).
+    pub nsaid: u32,
+    /// J2000 right ascension (degrees).
+    pub ra: f64,
+    /// J2000 declination (degrees).
+    pub dec: f64,
+    /// Heliocentric redshift.
+    pub z: f32,
+    /// Sérsic effective (half-light) radius, arcsec, fit in r-band.
+    pub sersic_th50: f32,
+    /// Sérsic index *n*.
+    pub sersic_n: f32,
+    /// Sérsic axis ratio *b/a*.
+    pub sersic_ba: f32,
+    /// Sérsic position angle, degrees east of north.
+    pub sersic_phi: f32,
+    /// Total Sérsic flux per band (FUV, NUV, u, g, r, i, z), nanomaggies.
+    pub sersic_flux: [f32; 7],
+    /// Inverse variance of the Sérsic flux per band.
+    pub sersic_flux_ivar: [f32; 7],
+}
+
+impl NsaEntry {
+    /// Convert J2000 RA/Dec to a unit vector in ICRS Cartesian coordinates.
+    pub fn unit_vector(&self) -> na::Vector3<f64> {
+        let ra = self.ra.to_radians();
+        let dec = self.dec.to_radians();
+        na::Vector3::new(dec.cos() * ra.cos(), dec.cos() * ra.sin(), dec.sin())
+    }
+
+    /// Approximate AB magnitude for one band from the Sérsic flux. Returns
+    /// `None` if the flux is non-positive (NSA stores zero/negative for
+    /// unmeasured or pathological cases).
+    pub fn ab_magnitude(&self, band_idx: usize) -> Option<f64> {
+        let f = *self.sersic_flux.get(band_idx)?;
+        if f <= 0.0 {
+            return None;
+        }
+        Some(22.5 - 2.5 * (f as f64).log10())
+    }
+}
+
+/// In-memory NSA catalog keyed on `NSAID`.
+#[derive(Debug, Clone)]
+pub struct NsaCatalog {
+    entries: HashMap<u32, NsaEntry>,
+}
+
+impl NsaCatalog {
+    pub fn new() -> Self {
+        Self {
+            entries: HashMap::new(),
+        }
+    }
+
+    /// Load every galaxy from a NSA `.fits` file. Reads the file into memory,
+    /// finds the first BinTable extension, and materializes the curated set
+    /// of columns into [`NsaEntry`]s.
+    ///
+    /// Memory: ~3 GB peak for the raw file bytes plus ~80 MB for the typed
+    /// entries (~120 B each × 640 k galaxies).
+    pub fn from_fits_file(path: impl AsRef<Path>) -> Result<Self> {
+        let path = path.as_ref();
+        let bytes = fs::read(path).map_err(StarfieldError::IoError)?;
+
+        let fits = parse_fits(&bytes).map_err(|e| {
+            StarfieldError::DataError(format!("parse_fits({}): {}", path.display(), e))
+        })?;
+
+        let (hdu, tfields) = first_bintable(&fits.hdus).ok_or_else(|| {
+            StarfieldError::DataError(format!("no BinTable extension found in {}", path.display()))
+        })?;
+
+        let columns = parse_binary_table_columns(&hdu.cards, tfields)
+            .map_err(|e| StarfieldError::DataError(format!("parse_binary_table_columns: {}", e)))?;
+
+        let by_name: HashMap<&str, usize> = columns
+            .iter()
+            .enumerate()
+            .filter_map(|(i, c)| c.name.as_deref().map(|n| (n, i)))
+            .collect();
+
+        let nsaid = read_u32_col(&bytes, hdu, &columns, &by_name, "NSAID")?;
+        let ra = read_f64_col(&bytes, hdu, &columns, &by_name, "RA")?;
+        let dec = read_f64_col(&bytes, hdu, &columns, &by_name, "DEC")?;
+        let z = read_f32_col(&bytes, hdu, &columns, &by_name, "Z")?;
+        let th50 = read_f32_col(&bytes, hdu, &columns, &by_name, "SERSIC_TH50")?;
+        let nser = read_f32_col(&bytes, hdu, &columns, &by_name, "SERSIC_N")?;
+        let ba = read_f32_col(&bytes, hdu, &columns, &by_name, "SERSIC_BA")?;
+        let phi = read_f32_col(&bytes, hdu, &columns, &by_name, "SERSIC_PHI")?;
+        let flux = read_f32_array_col(&bytes, hdu, &columns, &by_name, "SERSIC_FLUX", 7)?;
+        let flux_ivar = read_f32_array_col(&bytes, hdu, &columns, &by_name, "SERSIC_FLUX_IVAR", 7)?;
+
+        let n = nsaid.len();
+        for (label, len) in [
+            ("RA", ra.len()),
+            ("DEC", dec.len()),
+            ("Z", z.len()),
+            ("SERSIC_TH50", th50.len()),
+            ("SERSIC_N", nser.len()),
+            ("SERSIC_BA", ba.len()),
+            ("SERSIC_PHI", phi.len()),
+            ("SERSIC_FLUX", flux.len()),
+            ("SERSIC_FLUX_IVAR", flux_ivar.len()),
+        ] {
+            if len != n {
+                return Err(StarfieldError::DataError(format!(
+                    "NSA column {} has {} rows but NSAID has {}",
+                    label, len, n
+                )));
+            }
+        }
+
+        let mut entries = HashMap::with_capacity(n);
+        for i in 0..n {
+            let entry = NsaEntry {
+                nsaid: nsaid[i],
+                ra: ra[i],
+                dec: dec[i],
+                z: z[i],
+                sersic_th50: th50[i],
+                sersic_n: nser[i],
+                sersic_ba: ba[i],
+                sersic_phi: phi[i],
+                sersic_flux: flux[i],
+                sersic_flux_ivar: flux_ivar[i],
+            };
+            entries.insert(entry.nsaid, entry);
+        }
+
+        Ok(Self { entries })
+    }
+
+    pub fn insert(&mut self, e: NsaEntry) {
+        self.entries.insert(e.nsaid, e);
+    }
+}
+
+impl Default for NsaCatalog {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl StarCatalog for NsaCatalog {
+    type Star = NsaEntry;
+
+    fn get_star(&self, id: usize) -> Option<&Self::Star> {
+        self.entries.get(&(id as u32))
+    }
+    fn stars(&self) -> impl Iterator<Item = &Self::Star> {
+        self.entries.values()
+    }
+    fn len(&self) -> usize {
+        self.entries.len()
+    }
+    fn filter<F>(&self, pred: F) -> Vec<&Self::Star>
+    where
+        F: Fn(&Self::Star) -> bool,
+    {
+        self.entries.values().filter(|e| pred(e)).collect()
+    }
+    fn star_data(&self) -> impl Iterator<Item = StarData> + '_ {
+        // r-band Sérsic mag stands in for the magnitude scalar; g-r color
+        // stands in for the b-v slot. Galaxies aren't stars, but downstream
+        // tooling that operates on `StarData` (cone-search, mag filter)
+        // still works for first-pass spatial / brightness queries.
+        self.entries.values().map(|e| {
+            let mag = e.ab_magnitude(4).unwrap_or(f64::INFINITY);
+            let g_r = match (e.ab_magnitude(3), e.ab_magnitude(4)) {
+                (Some(g), Some(r)) => Some(g - r),
+                _ => None,
+            };
+            StarData::new(e.nsaid as u64, e.ra, e.dec, mag, g_r)
+        })
+    }
+    fn filter_star_data<F>(&self, pred: F) -> Vec<StarData>
+    where
+        F: Fn(&StarData) -> bool,
+    {
+        self.star_data().filter(|s| pred(s)).collect()
+    }
+    fn brighter_than(&self, magnitude: f64) -> Vec<StarData> {
+        self.filter_star_data(|s| s.magnitude <= magnitude)
+    }
+    fn stars_in_field(&self, ra_deg: f64, dec_deg: f64, fov_deg: f64) -> Vec<StarData> {
+        let center = unit_vec(ra_deg, dec_deg);
+        let cos_fov = (fov_deg.to_radians() / 2.0).cos();
+        self.filter_star_data(|s| unit_vec(s.ra_deg(), s.dec_deg()).dot(&center) >= cos_fov)
+    }
+}
+
+fn unit_vec(ra_deg: f64, dec_deg: f64) -> na::Vector3<f64> {
+    let ra = ra_deg.to_radians();
+    let dec = dec_deg.to_radians();
+    na::Vector3::new(dec.cos() * ra.cos(), dec.cos() * ra.sin(), dec.sin())
+}
+
+// ---- column helpers --------------------------------------------------------
+
+/// Return `(hdu, tfields)` for the first `BinaryTable` HDU in the file.
+fn first_bintable(hdus: &[Hdu]) -> Option<(&Hdu, usize)> {
+    hdus.iter().find_map(|h| match h.info {
+        HduInfo::BinaryTable { tfields, .. } => Some((h, tfields)),
+        _ => None,
+    })
+}
+
+fn col_index(by_name: &HashMap<&str, usize>, name: &str) -> Result<usize> {
+    by_name.get(name).copied().ok_or_else(|| {
+        StarfieldError::DataError(format!("NSA: missing required column `{}`", name))
+    })
+}
+
+fn read_col(
+    bytes: &[u8],
+    hdu: &Hdu,
+    by_name: &HashMap<&str, usize>,
+    name: &str,
+) -> Result<BinaryColumnData> {
+    let idx = col_index(by_name, name)?;
+    read_binary_column(bytes, hdu, idx)
+        .map_err(|e| StarfieldError::DataError(format!("read_binary_column({}): {}", name, e)))
+}
+
+fn read_u32_col(
+    bytes: &[u8],
+    hdu: &Hdu,
+    _columns: &[BinaryColumnDescriptor],
+    by_name: &HashMap<&str, usize>,
+    name: &str,
+) -> Result<Vec<u32>> {
+    match read_col(bytes, hdu, by_name, name)? {
+        BinaryColumnData::Int(v) => Ok(v.into_iter().map(|x| x as u32).collect()),
+        BinaryColumnData::Long(v) => Ok(v.into_iter().map(|x| x as u32).collect()),
+        BinaryColumnData::Short(v) => Ok(v.into_iter().map(|x| x as u32).collect()),
+        BinaryColumnData::Byte(v) => Ok(v.into_iter().map(|x| x as u32).collect()),
+        other => Err(StarfieldError::DataError(format!(
+            "NSA column `{}` expected integer, got {:?}",
+            name,
+            std::mem::discriminant(&other)
+        ))),
+    }
+}
+
+fn read_f64_col(
+    bytes: &[u8],
+    hdu: &Hdu,
+    _columns: &[BinaryColumnDescriptor],
+    by_name: &HashMap<&str, usize>,
+    name: &str,
+) -> Result<Vec<f64>> {
+    match read_col(bytes, hdu, by_name, name)? {
+        BinaryColumnData::Double(v) => Ok(v),
+        BinaryColumnData::Float(v) => Ok(v.into_iter().map(|x| x as f64).collect()),
+        other => Err(StarfieldError::DataError(format!(
+            "NSA column `{}` expected float, got {:?}",
+            name,
+            std::mem::discriminant(&other)
+        ))),
+    }
+}
+
+fn read_f32_col(
+    bytes: &[u8],
+    hdu: &Hdu,
+    _columns: &[BinaryColumnDescriptor],
+    by_name: &HashMap<&str, usize>,
+    name: &str,
+) -> Result<Vec<f32>> {
+    match read_col(bytes, hdu, by_name, name)? {
+        BinaryColumnData::Float(v) => Ok(v),
+        BinaryColumnData::Double(v) => Ok(v.into_iter().map(|x| x as f32).collect()),
+        other => Err(StarfieldError::DataError(format!(
+            "NSA column `{}` expected float, got {:?}",
+            name,
+            std::mem::discriminant(&other)
+        ))),
+    }
+}
+
+fn read_f32_array_col(
+    bytes: &[u8],
+    hdu: &Hdu,
+    columns: &[BinaryColumnDescriptor],
+    by_name: &HashMap<&str, usize>,
+    name: &str,
+    expected_len: usize,
+) -> Result<Vec<[f32; 7]>> {
+    assert_eq!(
+        expected_len, 7,
+        "NSA per-band arrays are always 7-element (FUV/NUV/u/g/r/i/z)"
+    );
+    let idx = col_index(by_name, name)?;
+    if columns[idx].repeat != expected_len {
+        return Err(StarfieldError::DataError(format!(
+            "NSA column `{}` has TFORM repeat {}, expected {}",
+            name, columns[idx].repeat, expected_len
+        )));
+    }
+    let flat: Vec<f32> = match read_binary_column(bytes, hdu, idx)
+        .map_err(|e| StarfieldError::DataError(format!("read_binary_column({}): {}", name, e)))?
+    {
+        BinaryColumnData::Float(v) => v,
+        BinaryColumnData::Double(v) => v.into_iter().map(|x| x as f32).collect(),
+        other => {
+            return Err(StarfieldError::DataError(format!(
+                "NSA column `{}` expected float array, got {:?}",
+                name,
+                std::mem::discriminant(&other)
+            )))
+        }
+    };
+    if !flat.len().is_multiple_of(expected_len) {
+        return Err(StarfieldError::DataError(format!(
+            "NSA column `{}` flattened length {} is not a multiple of {}",
+            name,
+            flat.len(),
+            expected_len
+        )));
+    }
+    let n_rows = flat.len() / expected_len;
+    let mut out = Vec::with_capacity(n_rows);
+    for chunk in flat.chunks_exact(expected_len) {
+        let mut a = [0f32; 7];
+        a.copy_from_slice(chunk);
+        out.push(a);
+    }
+    Ok(out)
+}

--- a/crates/nsa/src/downloader.rs
+++ b/crates/nsa/src/downloader.rs
@@ -1,0 +1,55 @@
+//! Download the NSA catalog from the SDSS Science Archive Server.
+
+use std::path::PathBuf;
+
+use starfield::{Result, StarfieldError};
+use starfield_datasource_utils::{
+    cache_dir, download_to_file, ensure_cache_subdir, file_exists_and_not_empty,
+};
+
+/// SDSS DR17 hosts the v1.0.1 NSA at this URL. ~3 GB.
+pub const NSA_URL: &str = "https://data.sdss.org/sas/dr17/manga/atlas/v1_0_1/nsa_v1_0_1.fits";
+
+const NSA_FILENAME: &str = "nsa_v1_0_1.fits";
+
+/// Cache subdirectory: `~/.cache/starfield/nsa/`.
+pub fn nsa_cache_dir() -> PathBuf {
+    cache_dir().join("nsa")
+}
+
+fn ensure_nsa_dir() -> Result<PathBuf> {
+    ensure_cache_subdir("nsa").map_err(StarfieldError::IoError)
+}
+
+/// Download the NSA catalog FITS file (~3 GB) into the per-user cache, or
+/// return the cached path if already present and non-empty.
+///
+/// The download is **not** MD5-verified: SDSS doesn't publish a stable
+/// per-file checksum file for atlas releases. The atomic-`.tmp`+rename
+/// behavior in `download_to_file` ensures partial downloads aren't mistaken
+/// for complete ones.
+pub fn download_nsa() -> Result<PathBuf> {
+    let dir = ensure_nsa_dir()?;
+    let dest = dir.join(NSA_FILENAME);
+    if file_exists_and_not_empty(&dest) {
+        return Ok(dest);
+    }
+    eprintln!(
+        "downloading NSA catalog (~3 GB) from {} to {} ...",
+        NSA_URL,
+        dest.display()
+    );
+    download_to_file(NSA_URL, &dest, 3600)?;
+    Ok(dest)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_dir_under_starfield() {
+        let p = nsa_cache_dir();
+        assert!(p.to_string_lossy().contains(".cache/starfield/nsa"));
+    }
+}

--- a/crates/nsa/src/lib.rs
+++ b/crates/nsa/src/lib.rs
@@ -1,0 +1,29 @@
+//! NASA-Sloan Atlas (NSA) galaxy catalog loader and downloader.
+//!
+//! The NSA is the canonical SDSS-derived extragalactic catalog: ~640,000
+//! galaxies with positions, redshifts, Sérsic structural fits, and per-band
+//! integrated photometry across the SDSS+GALEX bands (FUV, NUV, u, g, r, i, z).
+//!
+//! This crate exposes a curated subset of the columns relevant for galaxy
+//! rendering pipelines. The full NSA `nsa_v1_0_1.fits` file has ~150 columns;
+//! the unexposed ones (image flags, Petrosian fluxes, K-corrections, PCA
+//! stellar-population fits, etc.) can be added if a downstream needs them.
+//!
+//! Source: https://www.sdss.org/dr17/manga/manga-target-selection/nsa/
+//!
+//! # Example
+//!
+//! ```no_run
+//! use starfield::catalogs::StarCatalog;
+//! use starfield_nsa::{download_nsa, NsaCatalog};
+//! let path = download_nsa()?;
+//! let cat = NsaCatalog::from_fits_file(&path)?;
+//! println!("{} galaxies", cat.len());
+//! # Ok::<(), starfield::StarfieldError>(())
+//! ```
+
+pub mod catalog;
+pub mod downloader;
+
+pub use catalog::{NsaCatalog, NsaEntry};
+pub use downloader::download_nsa;

--- a/crates/nsa/tests/round_trip.rs
+++ b/crates/nsa/tests/round_trip.rs
@@ -1,0 +1,290 @@
+//! Synthetic FITS round-trip for [`NsaCatalog::from_fits_file`].
+//!
+//! Builds an NSA-shaped binary table HDU (10 columns matching the curated
+//! [`NsaEntry`] surface area) using `fitsio_pure`'s serialization helpers,
+//! writes it to a tempfile, loads it through the public API, and verifies
+//! every field round-trips byte-for-byte.
+
+use std::io::Write;
+
+use fitsio_pure::bintable::{
+    serialize_binary_table_hdu, BinaryColumnData, BinaryColumnDescriptor, BinaryColumnType,
+};
+use fitsio_pure::header::serialize_header;
+use fitsio_pure::primary::build_primary_header;
+
+use starfield_nsa::NsaCatalog;
+
+fn empty_primary_hdu() -> Vec<u8> {
+    let cards = build_primary_header(8, &[]).unwrap();
+    serialize_header(&cards)
+}
+
+#[test]
+fn round_trip_minimal_nsa_table() {
+    let n_rows: usize = 4;
+
+    let columns = vec![
+        BinaryColumnDescriptor {
+            name: Some(String::from("NSAID")),
+            repeat: 1,
+            col_type: BinaryColumnType::Int,
+            byte_width: 4,
+        },
+        BinaryColumnDescriptor {
+            name: Some(String::from("RA")),
+            repeat: 1,
+            col_type: BinaryColumnType::Double,
+            byte_width: 8,
+        },
+        BinaryColumnDescriptor {
+            name: Some(String::from("DEC")),
+            repeat: 1,
+            col_type: BinaryColumnType::Double,
+            byte_width: 8,
+        },
+        BinaryColumnDescriptor {
+            name: Some(String::from("Z")),
+            repeat: 1,
+            col_type: BinaryColumnType::Float,
+            byte_width: 4,
+        },
+        BinaryColumnDescriptor {
+            name: Some(String::from("SERSIC_TH50")),
+            repeat: 1,
+            col_type: BinaryColumnType::Float,
+            byte_width: 4,
+        },
+        BinaryColumnDescriptor {
+            name: Some(String::from("SERSIC_N")),
+            repeat: 1,
+            col_type: BinaryColumnType::Float,
+            byte_width: 4,
+        },
+        BinaryColumnDescriptor {
+            name: Some(String::from("SERSIC_BA")),
+            repeat: 1,
+            col_type: BinaryColumnType::Float,
+            byte_width: 4,
+        },
+        BinaryColumnDescriptor {
+            name: Some(String::from("SERSIC_PHI")),
+            repeat: 1,
+            col_type: BinaryColumnType::Float,
+            byte_width: 4,
+        },
+        BinaryColumnDescriptor {
+            name: Some(String::from("SERSIC_FLUX")),
+            repeat: 7,
+            col_type: BinaryColumnType::Float,
+            byte_width: 28,
+        },
+        BinaryColumnDescriptor {
+            name: Some(String::from("SERSIC_FLUX_IVAR")),
+            repeat: 7,
+            col_type: BinaryColumnType::Float,
+            byte_width: 28,
+        },
+    ];
+
+    let nsaid: Vec<i32> = vec![10, 20, 30, 40];
+    let ra: Vec<f64> = vec![10.5, 175.25, 220.0, 359.875];
+    let dec: Vec<f64> = vec![-30.5, 0.0, 12.125, 60.75];
+    let z: Vec<f32> = vec![0.005, 0.020, 0.080, 0.150];
+    let th50: Vec<f32> = vec![1.5, 3.25, 7.0, 12.5];
+    let nser: Vec<f32> = vec![1.0, 2.0, 4.0, 6.0];
+    let ba: Vec<f32> = vec![0.95, 0.65, 0.40, 0.10];
+    let phi: Vec<f32> = vec![0.0, 45.0, 90.0, 135.0];
+
+    // Per-galaxy 7-band fluxes; flatten to a single Vec<f32> in row-major order.
+    let flux_per_row: Vec<[f32; 7]> = (0..n_rows)
+        .map(|i| {
+            let base = (i as f32) * 10.0;
+            [
+                base + 0.1,
+                base + 0.2,
+                base + 0.3,
+                base + 0.4,
+                base + 0.5,
+                base + 0.6,
+                base + 0.7,
+            ]
+        })
+        .collect();
+    let ivar_per_row: Vec<[f32; 7]> = (0..n_rows)
+        .map(|i| {
+            let base = 100.0 - (i as f32);
+            [
+                base + 1.0,
+                base + 2.0,
+                base + 3.0,
+                base + 4.0,
+                base + 5.0,
+                base + 6.0,
+                base + 7.0,
+            ]
+        })
+        .collect();
+    let flux_flat: Vec<f32> = flux_per_row.iter().flatten().copied().collect();
+    let ivar_flat: Vec<f32> = ivar_per_row.iter().flatten().copied().collect();
+
+    let col_data = vec![
+        BinaryColumnData::Int(nsaid.clone()),
+        BinaryColumnData::Double(ra.clone()),
+        BinaryColumnData::Double(dec.clone()),
+        BinaryColumnData::Float(z.clone()),
+        BinaryColumnData::Float(th50.clone()),
+        BinaryColumnData::Float(nser.clone()),
+        BinaryColumnData::Float(ba.clone()),
+        BinaryColumnData::Float(phi.clone()),
+        BinaryColumnData::Float(flux_flat),
+        BinaryColumnData::Float(ivar_flat),
+    ];
+
+    let bt_ext = serialize_binary_table_hdu(&columns, &col_data, n_rows).unwrap();
+
+    let mut fits_bytes = empty_primary_hdu();
+    fits_bytes.extend_from_slice(&bt_ext);
+
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    tmp.as_file().write_all(&fits_bytes).unwrap();
+    tmp.as_file().sync_all().unwrap();
+
+    let cat = NsaCatalog::from_fits_file(tmp.path()).unwrap();
+    assert_eq!(cat.len(), n_rows);
+
+    use starfield::catalogs::StarCatalog;
+    for i in 0..n_rows {
+        let id = nsaid[i] as u32;
+        let e = cat
+            .get_star(id as usize)
+            .unwrap_or_else(|| panic!("missing NSAID={}", id));
+
+        assert_eq!(e.nsaid, id);
+        assert!((e.ra - ra[i]).abs() < 1e-12);
+        assert!((e.dec - dec[i]).abs() < 1e-12);
+        assert!((e.z - z[i]).abs() < 1e-7);
+        assert!((e.sersic_th50 - th50[i]).abs() < 1e-6);
+        assert!((e.sersic_n - nser[i]).abs() < 1e-6);
+        assert!((e.sersic_ba - ba[i]).abs() < 1e-6);
+        assert!((e.sersic_phi - phi[i]).abs() < 1e-5);
+        for b in 0..7 {
+            assert!(
+                (e.sersic_flux[b] - flux_per_row[i][b]).abs() < 1e-5,
+                "flux row {} band {}: got {} want {}",
+                i,
+                b,
+                e.sersic_flux[b],
+                flux_per_row[i][b]
+            );
+            assert!(
+                (e.sersic_flux_ivar[b] - ivar_per_row[i][b]).abs() < 1e-4,
+                "ivar row {} band {}: got {} want {}",
+                i,
+                b,
+                e.sersic_flux_ivar[b],
+                ivar_per_row[i][b]
+            );
+        }
+    }
+}
+
+#[test]
+fn ab_magnitude_handles_zero_flux() {
+    let n_rows: usize = 1;
+    let columns = vec![
+        BinaryColumnDescriptor {
+            name: Some(String::from("NSAID")),
+            repeat: 1,
+            col_type: BinaryColumnType::Int,
+            byte_width: 4,
+        },
+        BinaryColumnDescriptor {
+            name: Some(String::from("RA")),
+            repeat: 1,
+            col_type: BinaryColumnType::Double,
+            byte_width: 8,
+        },
+        BinaryColumnDescriptor {
+            name: Some(String::from("DEC")),
+            repeat: 1,
+            col_type: BinaryColumnType::Double,
+            byte_width: 8,
+        },
+        BinaryColumnDescriptor {
+            name: Some(String::from("Z")),
+            repeat: 1,
+            col_type: BinaryColumnType::Float,
+            byte_width: 4,
+        },
+        BinaryColumnDescriptor {
+            name: Some(String::from("SERSIC_TH50")),
+            repeat: 1,
+            col_type: BinaryColumnType::Float,
+            byte_width: 4,
+        },
+        BinaryColumnDescriptor {
+            name: Some(String::from("SERSIC_N")),
+            repeat: 1,
+            col_type: BinaryColumnType::Float,
+            byte_width: 4,
+        },
+        BinaryColumnDescriptor {
+            name: Some(String::from("SERSIC_BA")),
+            repeat: 1,
+            col_type: BinaryColumnType::Float,
+            byte_width: 4,
+        },
+        BinaryColumnDescriptor {
+            name: Some(String::from("SERSIC_PHI")),
+            repeat: 1,
+            col_type: BinaryColumnType::Float,
+            byte_width: 4,
+        },
+        BinaryColumnDescriptor {
+            name: Some(String::from("SERSIC_FLUX")),
+            repeat: 7,
+            col_type: BinaryColumnType::Float,
+            byte_width: 28,
+        },
+        BinaryColumnDescriptor {
+            name: Some(String::from("SERSIC_FLUX_IVAR")),
+            repeat: 7,
+            col_type: BinaryColumnType::Float,
+            byte_width: 28,
+        },
+    ];
+    // r-band (index 4) flux is zero: ab_magnitude should return None.
+    let flux: Vec<f32> = vec![1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0];
+    let ivar: Vec<f32> = vec![1.0; 7];
+
+    let col_data = vec![
+        BinaryColumnData::Int(vec![42]),
+        BinaryColumnData::Double(vec![100.0]),
+        BinaryColumnData::Double(vec![10.0]),
+        BinaryColumnData::Float(vec![0.05]),
+        BinaryColumnData::Float(vec![2.0]),
+        BinaryColumnData::Float(vec![1.0]),
+        BinaryColumnData::Float(vec![0.7]),
+        BinaryColumnData::Float(vec![30.0]),
+        BinaryColumnData::Float(flux),
+        BinaryColumnData::Float(ivar),
+    ];
+
+    let bt_ext = serialize_binary_table_hdu(&columns, &col_data, n_rows).unwrap();
+    let mut fits_bytes = empty_primary_hdu();
+    fits_bytes.extend_from_slice(&bt_ext);
+
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    tmp.as_file().write_all(&fits_bytes).unwrap();
+    tmp.as_file().sync_all().unwrap();
+
+    let cat = NsaCatalog::from_fits_file(tmp.path()).unwrap();
+    use starfield::catalogs::StarCatalog;
+    let e = cat.get_star(42).unwrap();
+    assert_eq!(e.ab_magnitude(4), None, "zero r-band flux must yield None");
+    assert!(e.ab_magnitude(0).is_some());
+
+    let v = e.unit_vector();
+    assert!((v.norm() - 1.0).abs() < 1e-12);
+}

--- a/crates/starfield-datasources/Cargo.toml
+++ b/crates/starfield-datasources/Cargo.toml
@@ -1,19 +1,20 @@
 [package]
 name = "starfield-datasources"
-version = "0.5.0"
+version = "0.6.0"
 description = "Astronomical data source clients for the starfield ecosystem"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 
 [features]
-default = ["horizons", "sbdb", "gaia", "hipparcos", "mpc", "rubin"]
+default = ["horizons", "sbdb", "gaia", "hipparcos", "mpc", "nsa", "rubin"]
 horizons = ["dep:starfield-horizons"]
 sbdb = ["dep:starfield-sbdb"]
 gaia = ["dep:starfield-gaia"]
 gaia-all = ["gaia", "starfield-gaia/all-releases"]
 hipparcos = ["dep:starfield-hipparcos"]
 mpc = ["dep:starfield-mpc"]
+nsa = ["dep:starfield-nsa"]
 rubin = ["dep:starfield-rubin"]
 
 [dependencies]
@@ -22,4 +23,5 @@ starfield-sbdb = { path = "../sbdb", optional = true }
 starfield-gaia = { path = "../gaia", optional = true }
 starfield-hipparcos = { path = "../hipparcos", optional = true }
 starfield-mpc = { path = "../mpc", optional = true }
+starfield-nsa = { path = "../nsa", optional = true }
 starfield-rubin = { path = "../rubin", optional = true }

--- a/crates/starfield-datasources/src/lib.rs
+++ b/crates/starfield-datasources/src/lib.rs
@@ -11,6 +11,7 @@
 //! - `gaia-all` — adds DR1 and DR2 alongside DR3
 //! - `hipparcos` — Hipparcos star catalog loader
 //! - `mpc` — Minor Planet Center client (MPCORB, observatory codes, observations)
+//! - `nsa` — NASA-Sloan Atlas (NSA) galaxy catalog loader
 //! - `rubin` — Vera C. Rubin Observatory LSST alert broker clients
 
 #[cfg(feature = "horizons")]
@@ -27,6 +28,9 @@ pub use starfield_hipparcos as hipparcos;
 
 #[cfg(feature = "mpc")]
 pub use starfield_mpc as mpc;
+
+#[cfg(feature = "nsa")]
+pub use starfield_nsa as nsa;
 
 #[cfg(feature = "rubin")]
 pub use starfield_rubin as rubin;


### PR DESCRIPTION
## Summary
- Adds `starfield-nsa` crate wrapping the NASA-Sloan Atlas FITS catalog (`nsa_v1_0_1.fits`, ~3 GB, ~640k galaxies) via the pure-Rust `fitsio-pure` crate.
- Curated column subset: `NSAID`, `RA`, `DEC`, `Z`, Sersic structural fit (`SERSIC_TH50/N/BA/PHI`), and per-band flux + inverse variance across `[FUV, NUV, u, g, r, i, z]`.
- `NsaCatalog` implements `StarCatalog` (`r`-band Sersic mag stands in for the magnitude scalar; `g-r` for the color slot — galaxies aren't stars but cone-search/mag-filter still works for spatial queries).
- Wired into facade crate behind the `nsa` feature (default-on); facade bumped 0.5.0 → 0.6.0 per workspace versioning policy.
- Closes #29.

## Test plan
- [x] `cargo test -p starfield-nsa` — 1 unit + 2 round-trip tests pass (synthetic 10-column FITS table built via `fitsio_pure::serialize_binary_table_hdu`, parsed back through public API, every field verified).
- [x] `cargo clippy -p starfield-nsa -p starfield-datasources --all-targets -- -D warnings` — clean.
- [x] `cargo test --workspace` — full workspace green.
- [ ] Manual smoke: `download_nsa()` against live SDSS endpoint (3 GB; not run in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)