### PR TITLE
nsa: impl ExtendedSource for NsaEntry

### DIFF
--- a/crates/nsa/src/catalog.rs
+++ b/crates/nsa/src/catalog.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 
 use nalgebra as na;
 use serde::{Deserialize, Serialize};
-use starfield::catalogs::{IsophoteSample, StarCatalog, StarData};
+use starfield::catalogs::{ExtendedSource, IsophoteSample, SersicProfile, StarCatalog, StarData};
 use starfield::{Result, StarfieldError};
 
 use fitsio_pure::bintable::{
@@ -274,6 +274,29 @@ impl NsaEntry {
             return None;
         }
         Some(22.5 - 2.5 * (f as f64).log10())
+    }
+}
+
+impl ExtendedSource for NsaEntry {
+    /// NSA's r-band Sersic fit. NSA only includes galaxies with a
+    /// successful Sersic fit, so this always returns `Some`. Returns
+    /// `None` only when the stored axis ratio is non-positive (defensive
+    /// against pathological rows that may slip past the upstream cuts).
+    ///
+    /// Field mapping: `sersic_th50` → `theta_half_arcsec`, `sersic_n` →
+    /// `n`, `sersic_ba` → `axis_ratio` (NSA already stores b/a — no flip
+    /// required, unlike `Dr3GalaxyCandidate` and `BrightGalaxy` which
+    /// store `ellipticity = 1 - b/a`), `sersic_phi` → `position_angle_deg`.
+    fn sersic_profile(&self) -> Option<SersicProfile> {
+        if self.sersic_ba <= 0.0 || self.sersic_th50 <= 0.0 || self.sersic_n <= 0.0 {
+            return None;
+        }
+        Some(SersicProfile {
+            theta_half_arcsec: self.sersic_th50 as f64,
+            n: self.sersic_n as f64,
+            axis_ratio: self.sersic_ba as f64,
+            position_angle_deg: self.sersic_phi as f64,
+        })
     }
 }
 

--- a/crates/nsa/tests/extended_source.rs
+++ b/crates/nsa/tests/extended_source.rs
@@ -1,0 +1,171 @@
+//! Verifies `NsaEntry::sersic_profile()` returns a well-shaped
+//! `starfield::catalogs::SersicProfile`.
+//!
+//! Builds a one-row NSA FITS table with known Sersic params, loads it
+//! through the public API, and checks the field mapping + the upstream
+//! `surface_brightness_at` evaluation.
+
+use std::io::Write;
+
+use fitsio_pure::bintable::{
+    serialize_binary_table_hdu, BinaryColumnData, BinaryColumnDescriptor, BinaryColumnType,
+};
+use fitsio_pure::header::serialize_header;
+use fitsio_pure::primary::build_primary_header;
+use starfield::catalogs::{ExtendedSource, StarCatalog};
+use starfield_nsa::{NsaCatalog, NsaVersion};
+
+fn empty_primary_hdu() -> Vec<u8> {
+    let cards = build_primary_header(8, &[]).unwrap();
+    serialize_header(&cards)
+}
+
+fn write_minimal_nsa_fits(
+    sersic_th50: f32,
+    sersic_n: f32,
+    sersic_ba: f32,
+    sersic_phi: f32,
+) -> tempfile::NamedTempFile {
+    let columns = vec![
+        BinaryColumnDescriptor {
+            name: Some("NSAID".into()),
+            repeat: 1,
+            col_type: BinaryColumnType::Int,
+            byte_width: 4,
+        },
+        BinaryColumnDescriptor {
+            name: Some("RA".into()),
+            repeat: 1,
+            col_type: BinaryColumnType::Double,
+            byte_width: 8,
+        },
+        BinaryColumnDescriptor {
+            name: Some("DEC".into()),
+            repeat: 1,
+            col_type: BinaryColumnType::Double,
+            byte_width: 8,
+        },
+        BinaryColumnDescriptor {
+            name: Some("Z".into()),
+            repeat: 1,
+            col_type: BinaryColumnType::Float,
+            byte_width: 4,
+        },
+        BinaryColumnDescriptor {
+            name: Some("SERSIC_TH50".into()),
+            repeat: 1,
+            col_type: BinaryColumnType::Float,
+            byte_width: 4,
+        },
+        BinaryColumnDescriptor {
+            name: Some("SERSIC_N".into()),
+            repeat: 1,
+            col_type: BinaryColumnType::Float,
+            byte_width: 4,
+        },
+        BinaryColumnDescriptor {
+            name: Some("SERSIC_BA".into()),
+            repeat: 1,
+            col_type: BinaryColumnType::Float,
+            byte_width: 4,
+        },
+        BinaryColumnDescriptor {
+            name: Some("SERSIC_PHI".into()),
+            repeat: 1,
+            col_type: BinaryColumnType::Float,
+            byte_width: 4,
+        },
+        BinaryColumnDescriptor {
+            name: Some("SERSIC_FLUX".into()),
+            repeat: 5,
+            col_type: BinaryColumnType::Float,
+            byte_width: 20,
+        },
+        BinaryColumnDescriptor {
+            name: Some("SERSIC_FLUX_IVAR".into()),
+            repeat: 5,
+            col_type: BinaryColumnType::Float,
+            byte_width: 20,
+        },
+    ];
+    let col_data = vec![
+        BinaryColumnData::Int(vec![777]),
+        BinaryColumnData::Double(vec![123.0]),
+        BinaryColumnData::Double(vec![45.0]),
+        BinaryColumnData::Float(vec![0.04]),
+        BinaryColumnData::Float(vec![sersic_th50]),
+        BinaryColumnData::Float(vec![sersic_n]),
+        BinaryColumnData::Float(vec![sersic_ba]),
+        BinaryColumnData::Float(vec![sersic_phi]),
+        BinaryColumnData::Float(vec![1.0; 5]),
+        BinaryColumnData::Float(vec![0.5; 5]),
+    ];
+    let bt = serialize_binary_table_hdu(&columns, &col_data, 1).unwrap();
+    let mut fits = empty_primary_hdu();
+    fits.extend_from_slice(&bt);
+
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    tmp.as_file().write_all(&fits).unwrap();
+    tmp.as_file().sync_all().unwrap();
+    tmp
+}
+
+#[test]
+fn sersic_profile_field_mapping() {
+    // NSA stores `sersic_ba` directly as b/a; upstream's
+    // `axis_ratio` is also b/a — no flip needed (in contrast with
+    // `Dr3GalaxyCandidate` and `BrightGalaxy` which store `1 - b/a`).
+    let tmp = write_minimal_nsa_fits(2.5, 4.0, 0.7, 60.0);
+    let cat = NsaCatalog::from_fits_file(tmp.path()).unwrap();
+    assert_eq!(cat.version(), NsaVersion::V0_1_2);
+
+    let e = cat.get_star(777).unwrap();
+    let p = e.sersic_profile().expect("Sersic params present");
+    assert_eq!(p.theta_half_arcsec, 2.5);
+    assert_eq!(p.n, 4.0);
+    assert!(
+        (p.axis_ratio - 0.7).abs() < 1e-6,
+        "axis_ratio should pass through unchanged: got {}",
+        p.axis_ratio
+    );
+    assert_eq!(p.position_angle_deg, 60.0);
+}
+
+#[test]
+fn sersic_profile_evaluates_surface_brightness() {
+    // Circular n=1 (exponential disk), R_e = 10". At r = R_e the SB
+    // should be exactly I_e (i.e. surface_brightness_at returns 1.0).
+    let tmp = write_minimal_nsa_fits(10.0, 1.0, 1.0, 0.0);
+    let cat = NsaCatalog::from_fits_file(tmp.path()).unwrap();
+    let e = cat.get_star(777).unwrap();
+    let p = e.sersic_profile().unwrap();
+
+    // PA = 0 means major axis along +y → offset (0, 10) is at R_e.
+    let sb_at_re = p.surface_brightness_at(0.0, 10.0);
+    assert!(
+        (sb_at_re - 1.0).abs() < 1e-9,
+        "I(R_e) / I_e should be 1.0 along major axis, got {}",
+        sb_at_re
+    );
+
+    // Centre is exp(b_n) > 1.
+    let sb_centre = p.surface_brightness_at(0.0, 0.0);
+    assert!(
+        sb_centre > 1.0,
+        "centre SB should be exp(b_n) > 1, got {}",
+        sb_centre
+    );
+}
+
+#[test]
+fn sersic_profile_returns_none_on_pathological_axis_ratio() {
+    // sersic_ba ≤ 0 isn't a real NSA value (the fit constrains it
+    // positive), but defend against it anyway.
+    let tmp = write_minimal_nsa_fits(2.5, 4.0, 0.0, 60.0);
+    let cat = NsaCatalog::from_fits_file(tmp.path()).unwrap();
+    let e = cat.get_star(777).unwrap();
+    assert!(
+        e.sersic_profile().is_none(),
+        "axis_ratio = 0 should yield None (degenerate edge-on)"
+    );
+}


### PR DESCRIPTION
## Summary

Completes the trio. `Dr3GalaxyCandidate` and `BrightGalaxy` got `ExtendedSource` impls in #53; this lands the same for `NsaEntry`. Consumers iterating over Sersic-bearing catalogs through `&dyn ExtendedSource` can now swap any of the three and get a `SersicProfile` back without per-catalog conversion code.

## Field mapping

NSA already stores `sersic_ba` as b/a — same convention as upstream's `axis_ratio` — so **no flip is needed** (in contrast with `Dr3GalaxyCandidate` and `BrightGalaxy` which store `ellipticity = 1 − b/a`).

| NSA field | Upstream `SersicProfile` |
|---|---|
| `sersic_th50` | `theta_half_arcsec` |
| `sersic_n` | `n` |
| `sersic_ba` | `axis_ratio` (no flip) |
| `sersic_phi` | `position_angle_deg` |

## Defensive None

NSA only includes galaxies with successful Sersic fits, so `sersic_profile()` returns `Some` for every real-world row. The impl still guards against `sersic_ba/th50/n ≤ 0` and returns `None` for those, in case a pathological row slips past the upstream cuts.

## Test plan

- [x] `cargo test -p starfield-nsa` — all green (3 new tests in `tests/extended_source.rs`)
- [x] `cargo clippy -p starfield-nsa --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`

New tests:
- `sersic_profile_field_mapping` — builds a one-row NSA FITS with known params, loads via the public API, checks each field on the returned `SersicProfile`.
- `sersic_profile_evaluates_surface_brightness` — circular n=1 R_e=10″; verifies `I(R_e)/I_e = 1.0` along the major axis and that the centre value > 1 (= exp(b_n)).
- `sersic_profile_returns_none_on_pathological_axis_ratio` — `sersic_ba = 0` returns `None`.

## Why no facade bump

Pure additive trait impl on an existing public type. No new public modules, no new feature flag, no new dependency. Doesn't change the surface of `starfield-datasources`.
