### PR TITLE
nsa: Part 2 — broadband photometry + isophote series + gated radial profiles

### DIFF
--- a/crates/nsa/Cargo.toml
+++ b/crates/nsa/Cargo.toml
@@ -1,13 +1,23 @@
 [package]
 name = "starfield-nsa"
-version = "0.1.0"
+version = "0.2.0"
 description = "NASA-Sloan Atlas (NSA) galaxy catalog loader and downloader"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[features]
+default = []
+# Opts in to loading the per-entry radial-profile and Stokes-isophote arrays
+# (PROFTHETA, PROFMEAN, PROFMEAN_IVAR, QSTOKES, USTOKES, BASTOKES, PHISTOKES).
+# Adds ~2.6 KB/entry × 640k galaxies ≈ 1.6 GB of in-memory storage. Without
+# the feature these fields are absent from `NsaEntry` and the `RadialProfile`
+# trait impl is omitted; callers that only need photometry / cheap morphology
+# don't pay for it.
+radial-profiles = []
+
 [dependencies]
-starfield = { workspace = true }
+starfield = { workspace = true, features = ["photometry"] }
 serde = { workspace = true }
 thiserror = { workspace = true }
 nalgebra = { workspace = true }

--- a/crates/nsa/src/catalog.rs
+++ b/crates/nsa/src/catalog.rs
@@ -11,13 +11,16 @@ use std::path::Path;
 
 use nalgebra as na;
 use serde::{Deserialize, Serialize};
-use starfield::catalogs::{StarCatalog, StarData};
+use starfield::catalogs::{IsophoteSample, StarCatalog, StarData};
 use starfield::{Result, StarfieldError};
 
 use fitsio_pure::bintable::{
     parse_binary_table_columns, read_binary_column, BinaryColumnData, BinaryColumnDescriptor,
 };
 use fitsio_pure::hdu::{parse_fits, Hdu, HduInfo};
+
+#[cfg(feature = "radial-profiles")]
+use std::sync::OnceLock;
 
 /// Number of bands in `NsaEntry`'s flux arrays. Always 7; v0_1_2 (5-band)
 /// files are padded with zeros in the FUV/NUV slots so the in-memory layout
@@ -73,11 +76,26 @@ impl NsaVersion {
     }
 }
 
+/// Number of radii at which the NSA stores its measured azimuthally-averaged
+/// surface-brightness profile and its Stokes-derived isophote series. Always
+/// 15 for both v0_1_2 and v1_0_1.
+#[cfg(feature = "radial-profiles")]
+pub const N_PROFILE_RADII: usize = 15;
+
 /// One galaxy from the NASA-Sloan Atlas.
 ///
-/// All units follow NSA's published conventions (mostly arcsec, deg,
-/// nanomaggies). See <https://www.sdss.org/dr17/manga/manga-target-selection/nsa/>
-/// for the full column reference.
+/// Field naming follows the underlying NSA columns case-flattened to snake
+/// case; units follow NSA's conventions (arcsec, degrees, nanomaggies, mag).
+/// See <https://www.sdss.org/dr17/manga/manga-target-selection/nsa/> for the
+/// full reference.
+///
+/// All [f32; 7] band-arrays use the canonical 7-slot layout
+/// `[FUV, NUV, u, g, r, i, z]`. v0_1_2 (5-band) source files have FUV/NUV
+/// padded with zero so callers see a stable shape regardless of source.
+///
+/// Most non-Sérsic fields are `Option`-typed because v0_1_2 doesn't carry
+/// every column v1_0_1 does. A `None` means the column was absent from the
+/// source FITS file.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NsaEntry {
     /// NSA's stable per-galaxy ID (`NSAID` column).
@@ -88,6 +106,8 @@ pub struct NsaEntry {
     pub dec: f64,
     /// Heliocentric redshift.
     pub z: f32,
+
+    // ---- Sérsic structural fit (always present) -----------------------------
     /// Sérsic effective (half-light) radius, arcsec, fit in r-band.
     pub sersic_th50: f32,
     /// Sérsic index *n*.
@@ -100,6 +120,105 @@ pub struct NsaEntry {
     pub sersic_flux: [f32; 7],
     /// Inverse variance of the Sérsic flux per band.
     pub sersic_flux_ivar: [f32; 7],
+
+    // ---- broadband photometry (NMGY) — drives Photometry trait impl --------
+    /// Per-band broadband flux (`NMGY` column), nanomaggies. Distinct from
+    /// `sersic_flux` (which integrates the parametric Sérsic fit) — `NMGY` is
+    /// a direct aperture-integrated measurement.
+    pub nmgy: Option<[f32; 7]>,
+    /// Inverse variance of `nmgy` (`NMGY_IVAR`).
+    pub nmgy_ivar: Option<[f32; 7]>,
+    /// Galactic extinction per band (`EXTINCTION`), magnitudes.
+    pub extinction: Option<[f32; 7]>,
+    /// K-correction per band (`KCORRECT`), magnitudes.
+    pub kcorrect: Option<[f32; 7]>,
+
+    // ---- cheap morphology proxies (drive IsophoteSeries trait impl) --------
+    /// Axis ratio *b/a* at the 50% light radius (`BA50`).
+    pub ba50: Option<f32>,
+    /// Position angle at the 50% light radius (`PHI50`), degrees east of north.
+    pub phi50: Option<f32>,
+    /// Axis ratio at the 90% light radius (`BA90`).
+    pub ba90: Option<f32>,
+    /// Position angle at the 90% light radius (`PHI90`), degrees east of north.
+    pub phi90: Option<f32>,
+    /// Petrosian half-light radius (`PETROTH50`), arcsec.
+    pub petroth50: Option<f32>,
+    /// Petrosian 90%-light radius (`PETROTH90`), arcsec. The concentration
+    /// index `petroth90 / petroth50` separates early- from late-type morphology.
+    pub petroth90: Option<f32>,
+
+    // ---- disturbance / clumpiness flags ------------------------------------
+    /// Per-band asymmetry index (`ASYMMETRY`); high values indicate disturbed
+    /// or merging systems.
+    pub asymmetry: Option<[f32; 7]>,
+    /// Per-band clumpiness index (`CLUMPY`); high values indicate bright
+    /// star-forming knots not captured by a smooth surface-brightness profile.
+    pub clumpy: Option<[f32; 7]>,
+
+    // ---- distance + mass for science filtering -----------------------------
+    /// Local-flow-corrected distance (`ZDIST`), redshift units (multiply by
+    /// `c` to get km/s, divide by H0 for Mpc).
+    pub zdist: Option<f32>,
+    /// Uncertainty on `zdist` (`ZDIST_ERR`).
+    pub zdist_err: Option<f32>,
+    /// Stellar mass (`MASS`), in solar masses (already divided by *h*).
+    pub mass: Option<f32>,
+    /// Per-band stellar mass-to-light ratio (`MTOL`), solar units.
+    pub mtol: Option<[f32; 7]>,
+
+    /// Pre-materialized 2-sample isophote series at the 50% / 90% Petrosian
+    /// light radii. `None` if any of the six required scalars
+    /// (`BA50`/`PHI50`/`BA90`/`PHI90`/`PETROTH50`/`PETROTH90`) is absent.
+    /// Populated at load time so the [`starfield::catalogs::IsophoteSeries`]
+    /// trait impl returns a slice straight off the entry without allocation.
+    /// Skipped during serialization (upstream `IsophoteSample` doesn't impl
+    /// serde); callers that round-trip the entry through serde must
+    /// reconstruct via [`NsaEntry::rebuild_isophote_cache`].
+    #[serde(skip)]
+    pub isophote_samples: Option<[IsophoteSample; 2]>,
+
+    // ---- measured radial-profile / Stokes-isophote arrays (heavy) ----------
+    /// Radii at which `profmean` is sampled (`PROFTHETA`), arcseconds. Always
+    /// 15 entries (or `None` if the column was absent).
+    #[cfg(feature = "radial-profiles")]
+    pub proftheta: Option<[f32; N_PROFILE_RADII]>,
+    /// Mean surface brightness sampled at `proftheta` per band (`PROFMEAN`),
+    /// nanomaggies / arcsec². Layout is `[radius_idx][band_idx]` with the
+    /// canonical 7-slot band layout (FUV/NUV zeroed for v0_1_2).
+    #[cfg(feature = "radial-profiles")]
+    pub profmean: Option<[[f32; 7]; N_PROFILE_RADII]>,
+    /// Inverse variance of `profmean` (`PROFMEAN_IVAR`), same shape.
+    #[cfg(feature = "radial-profiles")]
+    pub profmean_ivar: Option<[[f32; 7]; N_PROFILE_RADII]>,
+    /// Stokes Q at each radius and band (`QSTOKES`).
+    #[cfg(feature = "radial-profiles")]
+    pub qstokes: Option<[[f32; 7]; N_PROFILE_RADII]>,
+    /// Stokes U at each radius and band (`USTOKES`).
+    #[cfg(feature = "radial-profiles")]
+    pub ustokes: Option<[[f32; 7]; N_PROFILE_RADII]>,
+    /// Axis ratio derived from Q/U at each radius and band (`BASTOKES`).
+    #[cfg(feature = "radial-profiles")]
+    pub bastokes: Option<[[f32; 7]; N_PROFILE_RADII]>,
+    /// Position angle derived from Q/U at each radius and band (`PHISTOKES`),
+    /// degrees east of north.
+    #[cfg(feature = "radial-profiles")]
+    pub phistokes: Option<[[f32; 7]; N_PROFILE_RADII]>,
+
+    /// Cached `f64` view of `proftheta`, lazily filled on first
+    /// [`starfield::catalogs::RadialProfile::profile_radii_arcsec`] call.
+    /// Skipped during serialization (rebuilt on demand from `proftheta`).
+    #[cfg(feature = "radial-profiles")]
+    #[serde(skip)]
+    pub(crate) radii_cache: OnceLock<Vec<f64>>,
+    /// Cached `f64` view of `profmean[band]`, one cell per band.
+    #[cfg(feature = "radial-profiles")]
+    #[serde(skip)]
+    pub(crate) brightness_cache: [OnceLock<Vec<f64>>; 7],
+    /// Cached `f64` view of `profmean_ivar[band]`, one cell per band.
+    #[cfg(feature = "radial-profiles")]
+    #[serde(skip)]
+    pub(crate) brightness_ivar_cache: [OnceLock<Vec<f64>>; 7],
 }
 
 impl NsaEntry {
@@ -110,10 +229,46 @@ impl NsaEntry {
         na::Vector3::new(dec.cos() * ra.cos(), dec.cos() * ra.sin(), dec.sin())
     }
 
-    /// Approximate AB magnitude for one band from the Sérsic flux. Returns
-    /// `None` if the flux is non-positive (NSA stores zero/negative for
-    /// unmeasured or pathological cases).
-    pub fn ab_magnitude(&self, band_idx: usize) -> Option<f64> {
+    /// Rebuild [`Self::isophote_samples`] from the underlying scalars. Useful
+    /// after deserializing an entry, since `isophote_samples` is `#[serde(skip)]`.
+    /// Returns `true` if the cache is now populated, `false` if any required
+    /// scalar was missing.
+    pub fn rebuild_isophote_cache(&mut self) -> bool {
+        let iso = match (
+            self.petroth50,
+            self.petroth90,
+            self.ba50,
+            self.phi50,
+            self.ba90,
+            self.phi90,
+        ) {
+            (Some(p50), Some(p90), Some(b50), Some(ph50), Some(b90), Some(ph90)) => Some([
+                IsophoteSample {
+                    radius_arcsec: p50 as f64,
+                    axis_ratio: b50 as f64,
+                    position_angle_deg: ph50 as f64,
+                },
+                IsophoteSample {
+                    radius_arcsec: p90 as f64,
+                    axis_ratio: b90 as f64,
+                    position_angle_deg: ph90 as f64,
+                },
+            ]),
+            _ => None,
+        };
+        self.isophote_samples = iso;
+        self.isophote_samples.is_some()
+    }
+
+    /// Approximate AB magnitude for one band derived from `sersic_flux` —
+    /// the *parametric* Sérsic-integrated flux. Distinct from the
+    /// [`starfield::catalogs::Photometry`] trait's `ab_magnitude`, which
+    /// uses the broadband `NMGY` aperture flux. Both measurements are
+    /// useful but they're not the same number.
+    ///
+    /// Returns `None` if the flux is non-positive (NSA stores zero/negative
+    /// for unmeasured or pathological cases) or `band_idx` is out of range.
+    pub fn sersic_ab_magnitude(&self, band_idx: usize) -> Option<f64> {
         let f = *self.sersic_flux.get(band_idx)?;
         if f <= 0.0 {
             return None;
@@ -194,6 +349,70 @@ impl NsaCatalog {
         let flux_ivar =
             read_f32_band_array(&bytes, hdu, &columns, &by_name, flux_ivar_name, version)?;
 
+        // ---- Optional Part-2 columns -------------------------------------
+        // Each `_opt` helper returns `Ok(None)` if the column is absent (so
+        // v0_1_2 files that lack a given v1_0_1 column load fine).
+        let nmgy = read_f32_band_array_opt(&bytes, hdu, &columns, &by_name, "NMGY", version)?;
+        let nmgy_ivar =
+            read_f32_band_array_opt(&bytes, hdu, &columns, &by_name, "NMGY_IVAR", version)?;
+        let extinction =
+            read_f32_band_array_opt(&bytes, hdu, &columns, &by_name, "EXTINCTION", version)?;
+        let kcorrect =
+            read_f32_band_array_opt(&bytes, hdu, &columns, &by_name, "KCORRECT", version)?;
+
+        let ba50 = read_f32_col_opt(&bytes, hdu, &columns, &by_name, "BA50")?;
+        let phi50 = read_f32_col_opt(&bytes, hdu, &columns, &by_name, "PHI50")?;
+        let ba90 = read_f32_col_opt(&bytes, hdu, &columns, &by_name, "BA90")?;
+        let phi90 = read_f32_col_opt(&bytes, hdu, &columns, &by_name, "PHI90")?;
+        let petroth50 = read_f32_col_opt(&bytes, hdu, &columns, &by_name, "PETROTH50")?;
+        let petroth90 = read_f32_col_opt(&bytes, hdu, &columns, &by_name, "PETROTH90")?;
+
+        let asymmetry =
+            read_f32_band_array_opt(&bytes, hdu, &columns, &by_name, "ASYMMETRY", version)?;
+        let clumpy = read_f32_band_array_opt(&bytes, hdu, &columns, &by_name, "CLUMPY", version)?;
+
+        let zdist = read_f32_col_opt(&bytes, hdu, &columns, &by_name, "ZDIST")?;
+        let zdist_err = read_f32_col_opt(&bytes, hdu, &columns, &by_name, "ZDIST_ERR")?;
+        let mass = read_f32_col_opt(&bytes, hdu, &columns, &by_name, "MASS")?;
+        let mtol = read_f32_band_array_opt(&bytes, hdu, &columns, &by_name, "MTOL", version)?;
+
+        // Heavy radial-profile / Stokes arrays — only loaded when the feature
+        // is enabled. Each is `15 radii × n_source_bands(version)` flat in the
+        // FITS file, remapped to `[N_PROFILE_RADII][N_BANDS]` in memory with
+        // FUV/NUV padded to zero for v0_1_2.
+        #[cfg(feature = "radial-profiles")]
+        let proftheta = read_f32_fixed_array_opt::<{ N_PROFILE_RADII }>(
+            &bytes,
+            hdu,
+            &columns,
+            &by_name,
+            "PROFTHETA",
+        )?;
+        #[cfg(feature = "radial-profiles")]
+        let profmean =
+            read_f32_radial_band_array_opt(&bytes, hdu, &columns, &by_name, "PROFMEAN", version)?;
+        #[cfg(feature = "radial-profiles")]
+        let profmean_ivar = read_f32_radial_band_array_opt(
+            &bytes,
+            hdu,
+            &columns,
+            &by_name,
+            "PROFMEAN_IVAR",
+            version,
+        )?;
+        #[cfg(feature = "radial-profiles")]
+        let qstokes =
+            read_f32_radial_band_array_opt(&bytes, hdu, &columns, &by_name, "QSTOKES", version)?;
+        #[cfg(feature = "radial-profiles")]
+        let ustokes =
+            read_f32_radial_band_array_opt(&bytes, hdu, &columns, &by_name, "USTOKES", version)?;
+        #[cfg(feature = "radial-profiles")]
+        let bastokes =
+            read_f32_radial_band_array_opt(&bytes, hdu, &columns, &by_name, "BASTOKES", version)?;
+        #[cfg(feature = "radial-profiles")]
+        let phistokes =
+            read_f32_radial_band_array_opt(&bytes, hdu, &columns, &by_name, "PHISTOKES", version)?;
+
         let n = nsaid.len();
         for (label, len) in [
             ("RA", ra.len()),
@@ -216,6 +435,31 @@ impl NsaCatalog {
 
         let mut entries = HashMap::with_capacity(n);
         for i in 0..n {
+            let row_ba50 = ba50.as_ref().map(|v| v[i]);
+            let row_phi50 = phi50.as_ref().map(|v| v[i]);
+            let row_ba90 = ba90.as_ref().map(|v| v[i]);
+            let row_phi90 = phi90.as_ref().map(|v| v[i]);
+            let row_p50 = petroth50.as_ref().map(|v| v[i]);
+            let row_p90 = petroth90.as_ref().map(|v| v[i]);
+            // Pre-materialize the 2-sample isophote series if every required
+            // scalar is present, so the IsophoteSeries trait impl returns a
+            // slice straight off the entry.
+            let iso = match (row_p50, row_p90, row_ba50, row_phi50, row_ba90, row_phi90) {
+                (Some(p50), Some(p90), Some(b50), Some(ph50), Some(b90), Some(ph90)) => Some([
+                    IsophoteSample {
+                        radius_arcsec: p50 as f64,
+                        axis_ratio: b50 as f64,
+                        position_angle_deg: ph50 as f64,
+                    },
+                    IsophoteSample {
+                        radius_arcsec: p90 as f64,
+                        axis_ratio: b90 as f64,
+                        position_angle_deg: ph90 as f64,
+                    },
+                ]),
+                _ => None,
+            };
+
             let entry = NsaEntry {
                 nsaid: nsaid[i],
                 ra: ra[i],
@@ -227,6 +471,43 @@ impl NsaCatalog {
                 sersic_phi: phi[i],
                 sersic_flux: flux[i],
                 sersic_flux_ivar: flux_ivar[i],
+                nmgy: nmgy.as_ref().map(|v| v[i]),
+                nmgy_ivar: nmgy_ivar.as_ref().map(|v| v[i]),
+                extinction: extinction.as_ref().map(|v| v[i]),
+                kcorrect: kcorrect.as_ref().map(|v| v[i]),
+                ba50: row_ba50,
+                phi50: row_phi50,
+                ba90: row_ba90,
+                phi90: row_phi90,
+                petroth50: row_p50,
+                petroth90: row_p90,
+                asymmetry: asymmetry.as_ref().map(|v| v[i]),
+                clumpy: clumpy.as_ref().map(|v| v[i]),
+                zdist: zdist.as_ref().map(|v| v[i]),
+                zdist_err: zdist_err.as_ref().map(|v| v[i]),
+                mass: mass.as_ref().map(|v| v[i]),
+                mtol: mtol.as_ref().map(|v| v[i]),
+                isophote_samples: iso,
+                #[cfg(feature = "radial-profiles")]
+                proftheta: proftheta.as_ref().map(|v| v[i]),
+                #[cfg(feature = "radial-profiles")]
+                profmean: profmean.as_ref().map(|v| v[i]),
+                #[cfg(feature = "radial-profiles")]
+                profmean_ivar: profmean_ivar.as_ref().map(|v| v[i]),
+                #[cfg(feature = "radial-profiles")]
+                qstokes: qstokes.as_ref().map(|v| v[i]),
+                #[cfg(feature = "radial-profiles")]
+                ustokes: ustokes.as_ref().map(|v| v[i]),
+                #[cfg(feature = "radial-profiles")]
+                bastokes: bastokes.as_ref().map(|v| v[i]),
+                #[cfg(feature = "radial-profiles")]
+                phistokes: phistokes.as_ref().map(|v| v[i]),
+                #[cfg(feature = "radial-profiles")]
+                radii_cache: OnceLock::new(),
+                #[cfg(feature = "radial-profiles")]
+                brightness_cache: Default::default(),
+                #[cfg(feature = "radial-profiles")]
+                brightness_ivar_cache: Default::default(),
             };
             entries.insert(entry.nsaid, entry);
         }
@@ -269,8 +550,8 @@ impl StarCatalog for NsaCatalog {
         // tooling that operates on `StarData` (cone-search, mag filter)
         // still works for first-pass spatial / brightness queries.
         self.entries.values().map(|e| {
-            let mag = e.ab_magnitude(4).unwrap_or(f64::INFINITY);
-            let g_r = match (e.ab_magnitude(3), e.ab_magnitude(4)) {
+            let mag = e.sersic_ab_magnitude(4).unwrap_or(f64::INFINITY);
+            let g_r = match (e.sersic_ab_magnitude(3), e.sersic_ab_magnitude(4)) {
                 (Some(g), Some(r)) => Some(g - r),
                 _ => None,
             };
@@ -456,4 +737,153 @@ fn read_f32_band_array(
         out.push(a);
     }
     Ok(out)
+}
+
+/// Optional-column variant of [`read_f32_col`]. Returns `Ok(None)` when the
+/// column is absent so v0_1_2 files (which lack many v1_0_1 columns) load
+/// without error.
+fn read_f32_col_opt(
+    bytes: &[u8],
+    hdu: &Hdu,
+    columns: &[BinaryColumnDescriptor],
+    by_name: &HashMap<&str, usize>,
+    name: &str,
+) -> Result<Option<Vec<f32>>> {
+    if !by_name.contains_key(name) {
+        return Ok(None);
+    }
+    Ok(Some(read_f32_col(bytes, hdu, columns, by_name, name)?))
+}
+
+/// Optional-column variant of [`read_f32_band_array`].
+fn read_f32_band_array_opt(
+    bytes: &[u8],
+    hdu: &Hdu,
+    columns: &[BinaryColumnDescriptor],
+    by_name: &HashMap<&str, usize>,
+    name: &str,
+    version: NsaVersion,
+) -> Result<Option<Vec<[f32; N_BANDS]>>> {
+    if !by_name.contains_key(name) {
+        return Ok(None);
+    }
+    Ok(Some(read_f32_band_array(
+        bytes, hdu, columns, by_name, name, version,
+    )?))
+}
+
+/// Read a fixed-size 1-D float array column (e.g. `PROFTHETA` with repeat=15)
+/// and materialize one `[f32; N]` per row. Returns `Ok(None)` when absent.
+#[cfg(feature = "radial-profiles")]
+fn read_f32_fixed_array_opt<const N: usize>(
+    bytes: &[u8],
+    hdu: &Hdu,
+    columns: &[BinaryColumnDescriptor],
+    by_name: &HashMap<&str, usize>,
+    name: &str,
+) -> Result<Option<Vec<[f32; N]>>> {
+    if !by_name.contains_key(name) {
+        return Ok(None);
+    }
+    let idx = col_index(by_name, name)?;
+    if columns[idx].repeat != N {
+        return Err(StarfieldError::DataError(format!(
+            "NSA column `{}` has TFORM repeat {}, expected {}",
+            name, columns[idx].repeat, N
+        )));
+    }
+    let flat: Vec<f32> = match read_binary_column(bytes, hdu, idx)
+        .map_err(|e| StarfieldError::DataError(format!("read_binary_column({}): {}", name, e)))?
+    {
+        BinaryColumnData::Float(v) => v,
+        BinaryColumnData::Double(v) => v.into_iter().map(|x| x as f32).collect(),
+        other => {
+            return Err(StarfieldError::DataError(format!(
+                "NSA column `{}` expected float array, got {:?}",
+                name,
+                std::mem::discriminant(&other)
+            )))
+        }
+    };
+    if !flat.len().is_multiple_of(N) {
+        return Err(StarfieldError::DataError(format!(
+            "NSA column `{}` flattened length {} is not a multiple of {}",
+            name,
+            flat.len(),
+            N
+        )));
+    }
+    let n_rows = flat.len() / N;
+    let mut out = Vec::with_capacity(n_rows);
+    for chunk in flat.chunks_exact(N) {
+        let mut a = [0f32; N];
+        a.copy_from_slice(chunk);
+        out.push(a);
+    }
+    Ok(Some(out))
+}
+
+/// Read a 2-D radius × band float array (e.g. `PROFMEAN` with repeat=105 for
+/// v1_0_1 or 75 for v0_1_2) and materialize one `[[f32; N_BANDS]; N_PROFILE_RADII]`
+/// per row, with v0_1_2's 5 SDSS bands remapped into the canonical 7-slot layout
+/// (FUV/NUV at indices 0/1 zeroed). Returns `Ok(None)` when absent.
+///
+/// The on-file layout is row-major with `radius_idx` slow and `band_idx` fast,
+/// i.e. `flat[row][r * n_bands + b]`.
+#[cfg(feature = "radial-profiles")]
+fn read_f32_radial_band_array_opt(
+    bytes: &[u8],
+    hdu: &Hdu,
+    columns: &[BinaryColumnDescriptor],
+    by_name: &HashMap<&str, usize>,
+    name: &str,
+    version: NsaVersion,
+) -> Result<Option<Vec<[[f32; N_BANDS]; N_PROFILE_RADII]>>> {
+    if !by_name.contains_key(name) {
+        return Ok(None);
+    }
+    let idx = col_index(by_name, name)?;
+    let n_src = version.n_source_bands();
+    let expected_repeat = N_PROFILE_RADII * n_src;
+    if columns[idx].repeat != expected_repeat {
+        return Err(StarfieldError::DataError(format!(
+            "NSA column `{}` has TFORM repeat {}, expected {} ({} radii × {} bands for {:?})",
+            name, columns[idx].repeat, expected_repeat, N_PROFILE_RADII, n_src, version
+        )));
+    }
+    let flat: Vec<f32> = match read_binary_column(bytes, hdu, idx)
+        .map_err(|e| StarfieldError::DataError(format!("read_binary_column({}): {}", name, e)))?
+    {
+        BinaryColumnData::Float(v) => v,
+        BinaryColumnData::Double(v) => v.into_iter().map(|x| x as f32).collect(),
+        other => {
+            return Err(StarfieldError::DataError(format!(
+                "NSA column `{}` expected float array, got {:?}",
+                name,
+                std::mem::discriminant(&other)
+            )))
+        }
+    };
+    if !flat.len().is_multiple_of(expected_repeat) {
+        return Err(StarfieldError::DataError(format!(
+            "NSA column `{}` flattened length {} is not a multiple of {}",
+            name,
+            flat.len(),
+            expected_repeat
+        )));
+    }
+    let n_rows = flat.len() / expected_repeat;
+    let dst_start = match version {
+        NsaVersion::V1_0_1 => 0,
+        NsaVersion::V0_1_2 => 2,
+    };
+    let mut out = Vec::with_capacity(n_rows);
+    for row_chunk in flat.chunks_exact(expected_repeat) {
+        let mut row_arr = [[0f32; N_BANDS]; N_PROFILE_RADII];
+        for (r, radius_chunk) in row_chunk.chunks_exact(n_src).enumerate() {
+            row_arr[r][dst_start..dst_start + n_src].copy_from_slice(radius_chunk);
+        }
+        out.push(row_arr);
+    }
+    Ok(Some(out))
 }

--- a/crates/nsa/src/lib.rs
+++ b/crates/nsa/src/lib.rs
@@ -28,6 +28,9 @@
 
 pub mod catalog;
 pub mod downloader;
+pub mod traits;
 
+#[cfg(feature = "radial-profiles")]
+pub use catalog::N_PROFILE_RADII;
 pub use catalog::{NsaCatalog, NsaEntry, NsaVersion, BANDS, N_BANDS};
 pub use downloader::download_nsa;

--- a/crates/nsa/src/traits.rs
+++ b/crates/nsa/src/traits.rs
@@ -1,0 +1,116 @@
+//! Trait impls wiring [`crate::NsaEntry`] into the upstream `starfield`
+//! catalog-side traits added in starfield#118 / #119 / #120.
+//!
+//! - [`Photometry`] is unconditional. Maps `Band::Galex{Fuv,Nuv}` and
+//!   `Band::Sdss{U,G,R,I,Z}` onto the broadband `NMGY` measurements; other
+//!   bands return `None`. `EXTINCTION` and `KCORRECT` populate the default
+//!   [`Photometry::ab_magnitude`] composer.
+//! - [`IsophoteSeries`] is unconditional and returns a 2-sample series at
+//!   the Petrosian 50% / 90% light radii (derived from
+//!   `BA50`/`PHI50`/`BA90`/`PHI90` + `PETROTH50`/`PETROTH90`). The samples
+//!   are pre-materialized at load time, so the trait's borrow returns a
+//!   slice straight off the entry without any allocation.
+//! - [`RadialProfile`] is gated behind the `radial-profiles` feature and
+//!   uses the per-band PROFTHETA / PROFMEAN arrays. Since the trait wants
+//!   `&[f64]` but NSA stores `f32`, the conversion is cached lazily per
+//!   entry inside `OnceLock`s. Without the feature, the impl is omitted
+//!   entirely (no per-entry storage cost).
+
+use crate::catalog::NsaEntry;
+
+use starfield::catalogs::{Band, IsophoteSample, IsophoteSeries, Photometry};
+
+#[cfg(feature = "radial-profiles")]
+use starfield::catalogs::RadialProfile;
+
+/// Map a [`Band`] to its index in `NsaEntry`'s canonical 7-slot band layout
+/// `[FUV, NUV, u, g, r, i, z]`. Returns `None` for bands NSA doesn't carry —
+/// 2MASS, Gaia, Hipparcos, Johnson all return `None`.
+pub(crate) fn band_idx(band: Band) -> Option<usize> {
+    match band {
+        Band::GalexFuv => Some(0),
+        Band::GalexNuv => Some(1),
+        Band::SdssU => Some(2),
+        Band::SdssG => Some(3),
+        Band::SdssR => Some(4),
+        Band::SdssI => Some(5),
+        Band::SdssZ => Some(6),
+        _ => None,
+    }
+}
+
+impl Photometry for NsaEntry {
+    fn flux_nmgy(&self, band: Band) -> Option<f64> {
+        let i = band_idx(band)?;
+        let f = self.nmgy.as_ref()?[i];
+        // Zero is NSA's sentinel for "unmeasured" (and for FUV/NUV padding
+        // when the source is v0_1_2). Treat as missing.
+        if f == 0.0 {
+            None
+        } else {
+            Some(f as f64)
+        }
+    }
+
+    fn flux_ivar(&self, band: Band) -> Option<f64> {
+        let i = band_idx(band)?;
+        let v = self.nmgy_ivar.as_ref()?[i];
+        if v == 0.0 {
+            None
+        } else {
+            Some(v as f64)
+        }
+    }
+
+    fn extinction_mag(&self, band: Band) -> Option<f64> {
+        let i = band_idx(band)?;
+        Some(self.extinction.as_ref()?[i] as f64)
+    }
+
+    fn k_correction_mag(&self, band: Band) -> Option<f64> {
+        let i = band_idx(band)?;
+        Some(self.kcorrect.as_ref()?[i] as f64)
+    }
+}
+
+impl IsophoteSeries for NsaEntry {
+    /// Two-sample panchromatic isophote series at the 50%/90% light radii.
+    /// `band` is ignored — NSA's `BA50`/`PHI50`/`BA90`/`PHI90` are derived
+    /// from r-band and there's no per-band variant in the cheap surface.
+    /// Callers that want per-band twist should use the full Stokes series
+    /// (gated behind `radial-profiles`).
+    ///
+    /// Returns `None` if any of the six required scalars
+    /// (`BA50`/`PHI50`/`BA90`/`PHI90`/`PETROTH50`/`PETROTH90`) is missing
+    /// from the source FITS file.
+    fn isophote_samples(&self, _band: Band) -> Option<&[IsophoteSample]> {
+        self.isophote_samples.as_ref().map(|arr| arr.as_slice())
+    }
+}
+
+#[cfg(feature = "radial-profiles")]
+impl RadialProfile for NsaEntry {
+    fn profile_radii_arcsec(&self) -> Option<&[f64]> {
+        let arr = self.proftheta.as_ref()?;
+        let cell = self
+            .radii_cache
+            .get_or_init(|| arr.iter().map(|&x| x as f64).collect::<Vec<f64>>());
+        Some(cell.as_slice())
+    }
+
+    fn profile_surface_brightness(&self, band: Band) -> Option<&[f64]> {
+        let i = band_idx(band)?;
+        let arr = self.profmean.as_ref()?;
+        let cell = self.brightness_cache[i]
+            .get_or_init(|| arr.iter().map(|row| row[i] as f64).collect::<Vec<f64>>());
+        Some(cell.as_slice())
+    }
+
+    fn profile_surface_brightness_ivar(&self, band: Band) -> Option<&[f64]> {
+        let i = band_idx(band)?;
+        let arr = self.profmean_ivar.as_ref()?;
+        let cell = self.brightness_ivar_cache[i]
+            .get_or_init(|| arr.iter().map(|row| row[i] as f64).collect::<Vec<f64>>());
+        Some(cell.as_slice())
+    }
+}

--- a/crates/nsa/tests/part2_traits.rs
+++ b/crates/nsa/tests/part2_traits.rs
@@ -1,0 +1,563 @@
+//! Round-trip tests for the Part-2 surface area: extra columns + the
+//! [`Photometry`], [`IsophoteSeries`], and (gated) [`RadialProfile`] trait
+//! impls on [`NsaEntry`].
+//!
+//! Each test builds a synthetic NSA-shaped binary table HDU containing only
+//! the columns under test (the shared minimum: NSAID/RA/DEC/Z/SERSIC_*) plus
+//! whichever Part-2 columns the test cares about, runs it through
+//! `NsaCatalog::from_fits_file`, and asserts the trait surface returns the
+//! right values.
+
+use std::io::Write;
+
+use fitsio_pure::bintable::{
+    serialize_binary_table_hdu, BinaryColumnData, BinaryColumnDescriptor, BinaryColumnType,
+};
+use fitsio_pure::header::serialize_header;
+use fitsio_pure::primary::build_primary_header;
+
+use starfield::catalogs::{Band, IsophoteSeries, Photometry, StarCatalog};
+use starfield_nsa::NsaCatalog;
+
+#[cfg(feature = "radial-profiles")]
+use starfield::catalogs::RadialProfile;
+
+fn empty_primary_hdu() -> Vec<u8> {
+    let cards = build_primary_header(8, &[]).unwrap();
+    serialize_header(&cards)
+}
+
+/// Build the always-required column descriptors and per-row data for `n_rows`
+/// galaxies (NSAID = `(i+1) * 100`, RA/Dec/Z varying, dummy Sérsic fit).
+fn baseline_columns_and_data(
+    n_rows: usize,
+) -> (Vec<BinaryColumnDescriptor>, Vec<BinaryColumnData>) {
+    let cols = vec![
+        BinaryColumnDescriptor {
+            name: Some(String::from("NSAID")),
+            repeat: 1,
+            col_type: BinaryColumnType::Int,
+            byte_width: 4,
+        },
+        BinaryColumnDescriptor {
+            name: Some(String::from("RA")),
+            repeat: 1,
+            col_type: BinaryColumnType::Double,
+            byte_width: 8,
+        },
+        BinaryColumnDescriptor {
+            name: Some(String::from("DEC")),
+            repeat: 1,
+            col_type: BinaryColumnType::Double,
+            byte_width: 8,
+        },
+        BinaryColumnDescriptor {
+            name: Some(String::from("Z")),
+            repeat: 1,
+            col_type: BinaryColumnType::Float,
+            byte_width: 4,
+        },
+        BinaryColumnDescriptor {
+            name: Some(String::from("SERSIC_TH50")),
+            repeat: 1,
+            col_type: BinaryColumnType::Float,
+            byte_width: 4,
+        },
+        BinaryColumnDescriptor {
+            name: Some(String::from("SERSIC_N")),
+            repeat: 1,
+            col_type: BinaryColumnType::Float,
+            byte_width: 4,
+        },
+        BinaryColumnDescriptor {
+            name: Some(String::from("SERSIC_BA")),
+            repeat: 1,
+            col_type: BinaryColumnType::Float,
+            byte_width: 4,
+        },
+        BinaryColumnDescriptor {
+            name: Some(String::from("SERSIC_PHI")),
+            repeat: 1,
+            col_type: BinaryColumnType::Float,
+            byte_width: 4,
+        },
+        BinaryColumnDescriptor {
+            name: Some(String::from("SERSIC_FLUX")),
+            repeat: 7,
+            col_type: BinaryColumnType::Float,
+            byte_width: 28,
+        },
+        BinaryColumnDescriptor {
+            name: Some(String::from("SERSIC_FLUX_IVAR")),
+            repeat: 7,
+            col_type: BinaryColumnType::Float,
+            byte_width: 28,
+        },
+    ];
+    let nsaid: Vec<i32> = (0..n_rows as i32).map(|i| (i + 1) * 100).collect();
+    let ra: Vec<f64> = (0..n_rows).map(|i| 10.0 + i as f64).collect();
+    let dec: Vec<f64> = (0..n_rows).map(|i| -5.0 + i as f64).collect();
+    let z: Vec<f32> = (0..n_rows).map(|i| 0.01 * (i + 1) as f32).collect();
+    let scalar: Vec<f32> = (0..n_rows).map(|_| 1.0).collect();
+    let band_flat: Vec<f32> = (0..n_rows * 7).map(|i| (i + 1) as f32).collect();
+    let data = vec![
+        BinaryColumnData::Int(nsaid),
+        BinaryColumnData::Double(ra),
+        BinaryColumnData::Double(dec),
+        BinaryColumnData::Float(z),
+        BinaryColumnData::Float(scalar.clone()),
+        BinaryColumnData::Float(scalar.clone()),
+        BinaryColumnData::Float(scalar.clone()),
+        BinaryColumnData::Float(scalar),
+        BinaryColumnData::Float(band_flat.clone()),
+        BinaryColumnData::Float(band_flat),
+    ];
+    (cols, data)
+}
+
+fn write_fits_to_tempfile(
+    columns: &[BinaryColumnDescriptor],
+    col_data: &[BinaryColumnData],
+    n_rows: usize,
+) -> tempfile::NamedTempFile {
+    let bt_ext = serialize_binary_table_hdu(columns, col_data, n_rows).unwrap();
+    let mut fits_bytes = empty_primary_hdu();
+    fits_bytes.extend_from_slice(&bt_ext);
+
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    tmp.as_file().write_all(&fits_bytes).unwrap();
+    tmp.as_file().sync_all().unwrap();
+    tmp
+}
+
+// ===========================================================================
+// Photometry trait
+// ===========================================================================
+
+#[test]
+fn photometry_returns_none_when_columns_absent() {
+    let n_rows = 1;
+    let (cols, data) = baseline_columns_and_data(n_rows);
+    let tmp = write_fits_to_tempfile(&cols, &data, n_rows);
+    let cat = NsaCatalog::from_fits_file(tmp.path()).unwrap();
+    let e = cat.get_star(100).unwrap();
+    // No NMGY/EXTINCTION/KCORRECT in this fixture → every band must yield None.
+    for band in [
+        Band::GalexFuv,
+        Band::GalexNuv,
+        Band::SdssU,
+        Band::SdssG,
+        Band::SdssR,
+        Band::SdssI,
+        Band::SdssZ,
+    ] {
+        assert_eq!(e.flux_nmgy(band), None, "{:?} flux must be None", band);
+        assert_eq!(e.extinction_mag(band), None, "{:?} ext must be None", band);
+        assert_eq!(
+            e.k_correction_mag(band),
+            None,
+            "{:?} kcorr must be None",
+            band
+        );
+    }
+}
+
+#[test]
+fn photometry_with_full_v1_0_1_columns() {
+    let n_rows = 1;
+    let (mut cols, mut data) = baseline_columns_and_data(n_rows);
+    cols.push(BinaryColumnDescriptor {
+        name: Some(String::from("NMGY")),
+        repeat: 7,
+        col_type: BinaryColumnType::Float,
+        byte_width: 28,
+    });
+    cols.push(BinaryColumnDescriptor {
+        name: Some(String::from("NMGY_IVAR")),
+        repeat: 7,
+        col_type: BinaryColumnType::Float,
+        byte_width: 28,
+    });
+    cols.push(BinaryColumnDescriptor {
+        name: Some(String::from("EXTINCTION")),
+        repeat: 7,
+        col_type: BinaryColumnType::Float,
+        byte_width: 28,
+    });
+    cols.push(BinaryColumnDescriptor {
+        name: Some(String::from("KCORRECT")),
+        repeat: 7,
+        col_type: BinaryColumnType::Float,
+        byte_width: 28,
+    });
+    // FUV, NUV, u, g, r, i, z fluxes — distinct values per band.
+    let nmgy: Vec<f32> = vec![0.5, 0.7, 1.0, 2.0, 3.0, 4.0, 5.0];
+    let nmgy_ivar: Vec<f32> = vec![10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0];
+    let ext: Vec<f32> = vec![0.1, 0.08, 0.06, 0.05, 0.04, 0.03, 0.02];
+    let kcor: Vec<f32> = vec![0.3, 0.25, 0.2, 0.15, 0.1, 0.05, 0.0];
+    data.push(BinaryColumnData::Float(nmgy.clone()));
+    data.push(BinaryColumnData::Float(nmgy_ivar.clone()));
+    data.push(BinaryColumnData::Float(ext.clone()));
+    data.push(BinaryColumnData::Float(kcor.clone()));
+
+    let tmp = write_fits_to_tempfile(&cols, &data, n_rows);
+    let cat = NsaCatalog::from_fits_file(tmp.path()).unwrap();
+    let e = cat.get_star(100).unwrap();
+
+    // Bands NSA carries — exact match.
+    let bands = [
+        (Band::GalexFuv, 0),
+        (Band::GalexNuv, 1),
+        (Band::SdssU, 2),
+        (Band::SdssG, 3),
+        (Band::SdssR, 4),
+        (Band::SdssI, 5),
+        (Band::SdssZ, 6),
+    ];
+    for (band, idx) in bands {
+        assert!(
+            (e.flux_nmgy(band).unwrap() - nmgy[idx] as f64).abs() < 1e-6,
+            "{:?} flux",
+            band
+        );
+        assert!(
+            (e.flux_ivar(band).unwrap() - nmgy_ivar[idx] as f64).abs() < 1e-5,
+            "{:?} ivar",
+            band
+        );
+        assert!(
+            (e.extinction_mag(band).unwrap() - ext[idx] as f64).abs() < 1e-6,
+            "{:?} ext",
+            band
+        );
+        assert!(
+            (e.k_correction_mag(band).unwrap() - kcor[idx] as f64).abs() < 1e-6,
+            "{:?} kcorr",
+            band
+        );
+    }
+
+    // Bands NSA does NOT carry — all None.
+    for band in [
+        Band::TwoMassJ,
+        Band::TwoMassH,
+        Band::TwoMassK,
+        Band::GaiaG,
+        Band::GaiaBp,
+        Band::GaiaRp,
+        Band::HipparcosHp,
+        Band::JohnsonV,
+        Band::JohnsonB,
+    ] {
+        assert_eq!(e.flux_nmgy(band), None, "{:?}", band);
+    }
+}
+
+#[test]
+fn ab_magnitude_composes_extinction_and_kcorr() {
+    // r-band flux = 100 nMgy → AB = 22.5 - 2.5*log10(100) = 17.5
+    // ext_r = 0.5, kcorr_r = 0.2
+    // dereddened: 17.5 - 0.5 = 17.0
+    // dered + kcorr: 17.0 - 0.2 = 16.8
+    let n_rows = 1;
+    let (mut cols, mut data) = baseline_columns_and_data(n_rows);
+    for name in ["NMGY", "EXTINCTION", "KCORRECT"] {
+        cols.push(BinaryColumnDescriptor {
+            name: Some(String::from(name)),
+            repeat: 7,
+            col_type: BinaryColumnType::Float,
+            byte_width: 28,
+        });
+    }
+    let nmgy: Vec<f32> = vec![1.0, 1.0, 1.0, 1.0, 100.0, 1.0, 1.0];
+    let ext: Vec<f32> = vec![0.0, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0];
+    let kcor: Vec<f32> = vec![0.0, 0.0, 0.0, 0.0, 0.2, 0.0, 0.0];
+    data.push(BinaryColumnData::Float(nmgy));
+    data.push(BinaryColumnData::Float(ext));
+    data.push(BinaryColumnData::Float(kcor));
+
+    let tmp = write_fits_to_tempfile(&cols, &data, n_rows);
+    let cat = NsaCatalog::from_fits_file(tmp.path()).unwrap();
+    let e = cat.get_star(100).unwrap();
+
+    let raw = e.ab_magnitude(Band::SdssR, false, false).unwrap();
+    let dered = e.ab_magnitude(Band::SdssR, true, false).unwrap();
+    let full = e.ab_magnitude(Band::SdssR, true, true).unwrap();
+    assert!((raw - 17.5).abs() < 1e-6, "raw r mag: {}", raw);
+    assert!((dered - 17.0).abs() < 1e-6, "dered: {}", dered);
+    assert!((full - 16.8).abs() < 1e-6, "full: {}", full);
+}
+
+// ===========================================================================
+// IsophoteSeries trait
+// ===========================================================================
+
+#[test]
+fn isophote_series_none_when_scalars_missing() {
+    let n_rows = 1;
+    let (cols, data) = baseline_columns_and_data(n_rows);
+    let tmp = write_fits_to_tempfile(&cols, &data, n_rows);
+    let cat = NsaCatalog::from_fits_file(tmp.path()).unwrap();
+    let e = cat.get_star(100).unwrap();
+    assert_eq!(e.isophote_samples(Band::SdssR), None);
+}
+
+#[test]
+fn isophote_series_two_samples_at_50_and_90() {
+    let n_rows = 1;
+    let (mut cols, mut data) = baseline_columns_and_data(n_rows);
+    for name in ["BA50", "PHI50", "BA90", "PHI90", "PETROTH50", "PETROTH90"] {
+        cols.push(BinaryColumnDescriptor {
+            name: Some(String::from(name)),
+            repeat: 1,
+            col_type: BinaryColumnType::Float,
+            byte_width: 4,
+        });
+    }
+    data.push(BinaryColumnData::Float(vec![0.85])); // BA50
+    data.push(BinaryColumnData::Float(vec![45.0])); // PHI50
+    data.push(BinaryColumnData::Float(vec![0.55])); // BA90
+    data.push(BinaryColumnData::Float(vec![60.0])); // PHI90
+    data.push(BinaryColumnData::Float(vec![3.5])); // PETROTH50
+    data.push(BinaryColumnData::Float(vec![12.0])); // PETROTH90
+
+    let tmp = write_fits_to_tempfile(&cols, &data, n_rows);
+    let cat = NsaCatalog::from_fits_file(tmp.path()).unwrap();
+    let e = cat.get_star(100).unwrap();
+
+    // Trait ignores `band`; same series returned regardless.
+    for band in [Band::SdssR, Band::SdssG, Band::GalexFuv, Band::JohnsonV] {
+        let samples = e.isophote_samples(band).unwrap();
+        assert_eq!(samples.len(), 2, "expected 2 samples, got {:?}", samples);
+
+        assert!((samples[0].radius_arcsec - 3.5).abs() < 1e-9);
+        assert!((samples[0].axis_ratio - 0.85).abs() < 1e-6);
+        assert!((samples[0].position_angle_deg - 45.0).abs() < 1e-6);
+
+        assert!((samples[1].radius_arcsec - 12.0).abs() < 1e-9);
+        assert!((samples[1].axis_ratio - 0.55).abs() < 1e-6);
+        assert!((samples[1].position_angle_deg - 60.0).abs() < 1e-6);
+    }
+}
+
+// ===========================================================================
+// RadialProfile trait (radial-profiles feature)
+// ===========================================================================
+
+#[cfg(feature = "radial-profiles")]
+#[test]
+fn radial_profile_round_trip_v1_0_1() {
+    use starfield_nsa::N_PROFILE_RADII;
+
+    let n_rows = 1;
+    let (mut cols, mut data) = baseline_columns_and_data(n_rows);
+    cols.push(BinaryColumnDescriptor {
+        name: Some(String::from("PROFTHETA")),
+        repeat: N_PROFILE_RADII,
+        col_type: BinaryColumnType::Float,
+        byte_width: (N_PROFILE_RADII * 4),
+    });
+    cols.push(BinaryColumnDescriptor {
+        name: Some(String::from("PROFMEAN")),
+        repeat: N_PROFILE_RADII * 7,
+        col_type: BinaryColumnType::Float,
+        byte_width: (N_PROFILE_RADII * 7 * 4),
+    });
+    cols.push(BinaryColumnDescriptor {
+        name: Some(String::from("PROFMEAN_IVAR")),
+        repeat: N_PROFILE_RADII * 7,
+        col_type: BinaryColumnType::Float,
+        byte_width: (N_PROFILE_RADII * 7 * 4),
+    });
+
+    // Radii = [0.5, 1.0, 1.5, …, 7.5]
+    let radii: Vec<f32> = (0..N_PROFILE_RADII).map(|i| 0.5 + 0.5 * i as f32).collect();
+    // PROFMEAN[r][b] = (r * 10) + b — distinct per cell, easy to check
+    // FITS layout: row-major flat = radius slow, band fast → flat[r * 7 + b].
+    let mut profmean: Vec<f32> = Vec::with_capacity(N_PROFILE_RADII * 7);
+    for r in 0..N_PROFILE_RADII {
+        for b in 0..7 {
+            profmean.push((r * 10 + b) as f32);
+        }
+    }
+    let profmean_ivar: Vec<f32> = profmean.iter().map(|x| 1.0 / (1.0 + x)).collect();
+
+    data.push(BinaryColumnData::Float(radii.clone()));
+    data.push(BinaryColumnData::Float(profmean.clone()));
+    data.push(BinaryColumnData::Float(profmean_ivar.clone()));
+
+    let tmp = write_fits_to_tempfile(&cols, &data, n_rows);
+    let cat = NsaCatalog::from_fits_file(tmp.path()).unwrap();
+    let e = cat.get_star(100).unwrap();
+
+    let got_radii = e.profile_radii_arcsec().unwrap();
+    assert_eq!(got_radii.len(), N_PROFILE_RADII);
+    for (i, &r) in got_radii.iter().enumerate() {
+        assert!((r - radii[i] as f64).abs() < 1e-6);
+    }
+
+    // Spot-check r-band (idx 4) brightness across all radii.
+    let sb_r = e.profile_surface_brightness(Band::SdssR).unwrap();
+    assert_eq!(sb_r.len(), N_PROFILE_RADII);
+    for (r, &got) in sb_r.iter().enumerate() {
+        let want = (r * 10 + 4) as f64;
+        assert!(
+            (got - want).abs() < 1e-6,
+            "r={} got={} want={}",
+            r,
+            got,
+            want
+        );
+    }
+
+    // Bands NSA doesn't carry → None even when arrays are present.
+    assert_eq!(e.profile_surface_brightness(Band::GaiaG), None);
+
+    // ivar populated.
+    let ivar_r = e.profile_surface_brightness_ivar(Band::SdssR).unwrap();
+    assert_eq!(ivar_r.len(), N_PROFILE_RADII);
+}
+
+#[cfg(feature = "radial-profiles")]
+#[test]
+fn radial_profile_v0_1_2_remaps_5_bands_into_7_slot() {
+    use starfield_nsa::{NsaVersion, N_PROFILE_RADII};
+
+    let n_rows = 1;
+    // v0_1_2 baseline: SERSIC_FLUX repeat=5, no underscore variant.
+    let mut cols = vec![
+        BinaryColumnDescriptor {
+            name: Some(String::from("NSAID")),
+            repeat: 1,
+            col_type: BinaryColumnType::Int,
+            byte_width: 4,
+        },
+        BinaryColumnDescriptor {
+            name: Some(String::from("RA")),
+            repeat: 1,
+            col_type: BinaryColumnType::Double,
+            byte_width: 8,
+        },
+        BinaryColumnDescriptor {
+            name: Some(String::from("DEC")),
+            repeat: 1,
+            col_type: BinaryColumnType::Double,
+            byte_width: 8,
+        },
+        BinaryColumnDescriptor {
+            name: Some(String::from("Z")),
+            repeat: 1,
+            col_type: BinaryColumnType::Float,
+            byte_width: 4,
+        },
+        BinaryColumnDescriptor {
+            name: Some(String::from("SERSIC_TH50")),
+            repeat: 1,
+            col_type: BinaryColumnType::Float,
+            byte_width: 4,
+        },
+        BinaryColumnDescriptor {
+            name: Some(String::from("SERSIC_N")),
+            repeat: 1,
+            col_type: BinaryColumnType::Float,
+            byte_width: 4,
+        },
+        BinaryColumnDescriptor {
+            name: Some(String::from("SERSIC_BA")),
+            repeat: 1,
+            col_type: BinaryColumnType::Float,
+            byte_width: 4,
+        },
+        BinaryColumnDescriptor {
+            name: Some(String::from("SERSIC_PHI")),
+            repeat: 1,
+            col_type: BinaryColumnType::Float,
+            byte_width: 4,
+        },
+        BinaryColumnDescriptor {
+            name: Some(String::from("SERSIC_FLUX")),
+            repeat: 5,
+            col_type: BinaryColumnType::Float,
+            byte_width: 20,
+        },
+        BinaryColumnDescriptor {
+            name: Some(String::from("SERSIC_FLUX_IVAR")),
+            repeat: 5,
+            col_type: BinaryColumnType::Float,
+            byte_width: 20,
+        },
+        BinaryColumnDescriptor {
+            name: Some(String::from("PROFTHETA")),
+            repeat: N_PROFILE_RADII,
+            col_type: BinaryColumnType::Float,
+            byte_width: (N_PROFILE_RADII * 4),
+        },
+        BinaryColumnDescriptor {
+            name: Some(String::from("PROFMEAN")),
+            repeat: N_PROFILE_RADII * 5, // 5-band v0_1_2
+            col_type: BinaryColumnType::Float,
+            byte_width: (N_PROFILE_RADII * 5 * 4),
+        },
+    ];
+    let _ = &mut cols; // silence unused-mut if a reviewer adds more
+
+    // 5-band PROFMEAN: u, g, r, i, z. flat[r * 5 + b].
+    let mut profmean: Vec<f32> = Vec::with_capacity(N_PROFILE_RADII * 5);
+    for r in 0..N_PROFILE_RADII {
+        for b in 0..5 {
+            profmean.push((r * 100 + b) as f32);
+        }
+    }
+    let radii: Vec<f32> = (0..N_PROFILE_RADII).map(|i| 0.1 * (i + 1) as f32).collect();
+
+    let data = vec![
+        BinaryColumnData::Int(vec![777]),
+        BinaryColumnData::Double(vec![0.0]),
+        BinaryColumnData::Double(vec![0.0]),
+        BinaryColumnData::Float(vec![0.05]),
+        BinaryColumnData::Float(vec![1.0]),
+        BinaryColumnData::Float(vec![1.0]),
+        BinaryColumnData::Float(vec![1.0]),
+        BinaryColumnData::Float(vec![0.0]),
+        BinaryColumnData::Float(vec![1.0; 5]),
+        BinaryColumnData::Float(vec![1.0; 5]),
+        BinaryColumnData::Float(radii),
+        BinaryColumnData::Float(profmean),
+    ];
+
+    let tmp = write_fits_to_tempfile(&cols, &data, n_rows);
+    let cat = NsaCatalog::from_fits_file(tmp.path()).unwrap();
+    assert_eq!(cat.version(), NsaVersion::V0_1_2);
+    let e = cat.get_star(777).unwrap();
+
+    // Bands not carried by v0_1_2: FUV/NUV — surface brightness is the
+    // padded zero, but the trait still returns Some(slice). The renderer
+    // should treat zero as "no signal" the same way it does for `flux_nmgy`.
+    let sb_fuv = e.profile_surface_brightness(Band::GalexFuv).unwrap();
+    assert!(sb_fuv.iter().all(|&x| x == 0.0));
+
+    // u-band (v0_1_2 src idx 0 → in-memory idx 2): flat[r*5+0] = r*100
+    let sb_u = e.profile_surface_brightness(Band::SdssU).unwrap();
+    for (r, &got) in sb_u.iter().enumerate() {
+        let want = (r * 100) as f64;
+        assert!(
+            (got - want).abs() < 1e-6,
+            "u r={} got={} want={}",
+            r,
+            got,
+            want
+        );
+    }
+    // r-band (src idx 2 → mem idx 4): flat[r*5+2] = r*100+2
+    let sb_r = e.profile_surface_brightness(Band::SdssR).unwrap();
+    for (r, &got) in sb_r.iter().enumerate() {
+        let want = (r * 100 + 2) as f64;
+        assert!(
+            (got - want).abs() < 1e-6,
+            "r r={} got={} want={}",
+            r,
+            got,
+            want
+        );
+    }
+}

--- a/crates/nsa/tests/round_trip.rs
+++ b/crates/nsa/tests/round_trip.rs
@@ -282,8 +282,12 @@ fn ab_magnitude_handles_zero_flux() {
     let cat = NsaCatalog::from_fits_file(tmp.path()).unwrap();
     use starfield::catalogs::StarCatalog;
     let e = cat.get_star(42).unwrap();
-    assert_eq!(e.ab_magnitude(4), None, "zero r-band flux must yield None");
-    assert!(e.ab_magnitude(0).is_some());
+    assert_eq!(
+        e.sersic_ab_magnitude(4),
+        None,
+        "zero r-band flux must yield None"
+    );
+    assert!(e.sersic_ab_magnitude(0).is_some());
 
     let v = e.unit_vector();
     assert!((v.norm() - 1.0).abs() < 1e-12);
@@ -417,9 +421,17 @@ fn round_trip_v0_1_2_five_band() {
         // ab_magnitude(4) is the canonical r-band slot. For row 0, r-flux=3.0
         // → 22.5 - 2.5*log10(3) ≈ 21.30. ab_magnitude(0) (FUV) returns None
         // because the slot is zero.
-        assert!(e.ab_magnitude(NsaVersion::R_BAND_IDX).is_some());
-        assert_eq!(e.ab_magnitude(0), None, "FUV slot is zero, must be None");
-        assert_eq!(e.ab_magnitude(1), None, "NUV slot is zero, must be None");
+        assert!(e.sersic_ab_magnitude(NsaVersion::R_BAND_IDX).is_some());
+        assert_eq!(
+            e.sersic_ab_magnitude(0),
+            None,
+            "FUV slot is zero, must be None"
+        );
+        assert_eq!(
+            e.sersic_ab_magnitude(1),
+            None,
+            "NUV slot is zero, must be None"
+        );
     }
 }
 


### PR DESCRIPTION
Closes Part 2 of #35.

## Summary
Extends `NsaEntry` with the curated Part-2 column set from issue #35 and wires three upstream `starfield` traits that landed today:

| Trait | Source | Status |
|---|---|---|
| `Photometry` (always on) | `NMGY` / `NMGY_IVAR` / `EXTINCTION` / `KCORRECT` | always exposed |
| `IsophoteSeries` (always on) | `BA50`/`PHI50`/`BA90`/`PHI90` + `PETROTH50`/`PETROTH90` | 2-sample series at 50%/90% light radii, pre-materialized at load time |
| `RadialProfile` (gated) | `PROFTHETA` / `PROFMEAN` / `PROFMEAN_IVAR` | behind `radial-profiles` feature; lazy `f32→f64` conversion via `OnceLock` |

`Band` variants map onto NSA's 7-slot canonical layout `[FUV, NUV, u, g, r, i, z]`; bands NSA doesn't carry (2MASS, Gaia, Hipparcos, Johnson) trivially return `None`. v0_1_2's 5-band data is remapped into the 7-slot layout (FUV/NUV padded zero) including for the radial-profile arrays.

## New cheap fields (always populated when present in source)
`NMGY`, `NMGY_IVAR`, `EXTINCTION`, `KCORRECT`, `BA50`, `PHI50`, `BA90`, `PHI90`, `PETROTH50`, `PETROTH90`, `ASYMMETRY`, `CLUMPY`, `ZDIST`, `ZDIST_ERR`, `MASS`, `MTOL`. Each is `Option<…>` — `None` when the column is absent (so v0_1_2 files load fine despite missing many v1_0_1 columns).

## Heavy fields (under `radial-profiles` feature)
`PROFTHETA`, `PROFMEAN`, `PROFMEAN_IVAR`, `QSTOKES`, `USTOKES`, `BASTOKES`, `PHISTOKES`. ~2.6 KB/entry × 640k galaxies ≈ **1.6 GB at full v1_0_1**. Default-off so consumers that only need photometry don't pay for it.

## Renamed
`NsaEntry::ab_magnitude(idx)` → `sersic_ab_magnitude(idx)`. The Sérsic-flux-derived AB mag and the trait's `Photometry::ab_magnitude(Band, …)` (NMGY-derived) are different measurements; coexisting under different names avoids the inherent-vs-trait shadow conflict and clarifies semantics.

## Workspace
- `starfield-nsa` 0.1.0 → 0.2.0
- `starfield` git pin bumped to `a4a88fb6` (includes the three trait merges)
- `starfield-nsa` enables `starfield/photometry` to pull in the new types

## Test plan
- [x] `cargo test -p starfield-nsa` — 6 round-trip + 5 part2_traits + 1 doctest all pass (cheap path)
- [x] `cargo test -p starfield-nsa --features radial-profiles` — 6 + 7 + 1 all pass (heavy feature exposes 2 extra `RadialProfile` round-trip tests)
- [x] `cargo clippy -p starfield-nsa --all-targets -- -D warnings` — clean both feature configs
- [x] `cargo build -p starfield-datasources` — facade compiles unchanged
- [ ] Manual smoke: `download_nsa()` + load against the live NYU v0_1_2 file (~0.5 GB; not run in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)