### PR TITLE
gaia: use MultiGzDecoder for excerpt-cache shards

### DIFF
--- a/crates/gaia/src/common/reader.rs
+++ b/crates/gaia/src/common/reader.rs
@@ -15,7 +15,7 @@ use arrow::csv::reader::Format;
 use arrow::csv::ReaderBuilder;
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
-use flate2::read::GzDecoder;
+use flate2::read::MultiGzDecoder;
 
 use crate::common::traits::GaiaRelease;
 use starfield::{Result, StarfieldError};
@@ -59,11 +59,13 @@ impl<R: GaiaRelease> CsvSourceReader<R> {
     /// response, so callers can excerpt without ever writing the raw catalog
     /// to disk.
     ///
-    /// Set `is_gz` true for gzipped streams (this wraps in `flate2::GzDecoder`).
+    /// Set `is_gz` true for gzipped streams (this wraps in `flate2::MultiGzDecoder`,
+    /// which transparently handles multi-member gzip files written by the
+    /// `excerpt` writer).
     /// `mag_limit` is applied per-row at the same point as in [`open`](Self::open).
     pub fn from_reader(reader: Box<dyn Read>, is_gz: bool, mag_limit: f64) -> Result<Self> {
         let raw: Box<dyn Read> = if is_gz {
-            Box::new(BufReader::new(GzDecoder::new(BufReader::new(reader))))
+            Box::new(BufReader::new(MultiGzDecoder::new(BufReader::new(reader))))
         } else {
             Box::new(BufReader::new(reader))
         };

--- a/crates/gaia/src/dr1/catalog.rs
+++ b/crates/gaia/src/dr1/catalog.rs
@@ -5,7 +5,7 @@ use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 
-use flate2::read::GzDecoder;
+use flate2::read::MultiGzDecoder;
 use starfield::{Result, StarfieldError};
 
 use crate::common::catalog::GaiaCatalogBase;
@@ -95,7 +95,7 @@ pub fn load_tgas_block_map(path: impl AsRef<Path>) -> Result<HashMap<u64, TgasBl
     let path = path.as_ref();
     let file = File::open(path).map_err(StarfieldError::IoError)?;
     let reader: Box<dyn BufRead> = if path.extension().is_some_and(|e| e == "gz") {
-        Box::new(BufReader::new(GzDecoder::new(BufReader::new(file))))
+        Box::new(BufReader::new(MultiGzDecoder::new(BufReader::new(file))))
     } else {
         Box::new(BufReader::new(file))
     };


### PR DESCRIPTION
Excerpt-cache shards are multi-member gzip; the single-member `GzDecoder` silently truncates them. Confirmed against a real `~/.cache/starfield/gaia-excerpts/dr3-mag20/shard_0000.csv.gz` — was returning 0 entries, now returns 10,691,303. Single-member files (round-trip tests, raw ESA `GaiaSource_*.csv.gz`) unaffected.