### PR TITLE
deps: bump starfield from git → crates.io 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ license = "MIT"
 repository = "https://github.com/OrbitalCommons/starfield-datasources"
 
 [workspace.dependencies]
-starfield = { git = "https://github.com/OrbitalCommons/starfield.git" }
+starfield = "0.12"
 reqwest = { version = "0.12", features = ["blocking", "json", "multipart"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
Closes #40.

## Summary
Single-line workspace `Cargo.toml` change: `starfield = { git = "…" } → starfield = "0.12"`. Cargo.lock locks to **starfield 0.12.1** from `registry+https://github.com/rust-lang/crates.io-index`.

## Why
Per #40: prevents downstream consumers from ending up with two starfield instances (one from crates.io, one from our git pin) in the dep graph at identical versions but different cargo sources, which would otherwise force a `[patch.crates-io]` shim.

## Test plan
- [x] `cargo build --workspace` — green
- [x] `cargo test --workspace` — 200+ tests pass across all crates, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)