### PR TITLE
gaia-excerpt: --shard-by healpix is one-file-per-cell; reject --shards

### DIFF
--- a/crates/gaia-tools/src/cli.rs
+++ b/crates/gaia-tools/src/cli.rs
@@ -53,12 +53,18 @@ pub struct Cli {
     #[arg(long = "shard-by", value_enum, default_value_t = Sharder::Hash)]
     pub shard_by: Sharder,
 
-    /// Number of shard files to write into.
-    #[arg(long = "shards", default_value_t = 64)]
-    pub shards: u32,
+    /// Number of shard files to write into. Required for `--shard-by hash` and
+    /// `--shard-by id-range`; **must NOT be set** for `--shard-by healpix`
+    /// (the file count is determined by `--healpix-level` — one file per cell
+    /// for spatial coherence).
+    #[arg(long = "shards")]
+    pub shards: Option<u32>,
 
-    /// HEALPix depth used by `--shard-by healpix` (0..=29).
-    #[arg(long = "healpix-level", default_value_t = 6)]
+    /// HEALPix depth for `--shard-by healpix` (0..=29). One output file per
+    /// cell — `12 · 4^level` files total. Higher levels = finer pixels but
+    /// drastically more files (level 5 = 12,288; level 6 = 49,152;
+    /// level 7 = 196,608). Empty cells leave no file behind.
+    #[arg(long = "healpix-level", default_value_t = 5)]
     pub healpix_level: u8,
 
     /// Discard rows with `phot_g_mean_mag` greater than this at read time.
@@ -167,7 +173,33 @@ impl Cli {
                 "must pass either --input <files> or --from-release <release>".into(),
             ));
         }
+        match self.shard_by {
+            Sharder::Healpix => {
+                if self.shards.is_some() {
+                    return Err(StarfieldError::DataError(
+                        "--shards is incompatible with --shard-by healpix; the file count is \
+                         determined by --healpix-level (one file per cell). Drop --shards."
+                            .into(),
+                    ));
+                }
+            }
+            Sharder::Hash | Sharder::IdRange => {
+                if self.shards.is_none() {
+                    return Err(StarfieldError::DataError(format!(
+                        "--shard-by {:?} requires --shards <N> (number of buckets)",
+                        self.shard_by
+                    )));
+                }
+            }
+        }
         Ok(())
+    }
+
+    /// Effective shard count for `Sharder::Hash` and `Sharder::IdRange` (panics
+    /// if called for healpix — those derive their count from `--healpix-level`).
+    pub fn effective_bucket_count(&self) -> u32 {
+        self.shards
+            .expect("shards must be set for hash / id-range; call validate() before this")
     }
 }
 

--- a/crates/gaia-tools/src/main.rs
+++ b/crates/gaia-tools/src/main.rs
@@ -157,7 +157,7 @@ where
             args.mag_limit.unwrap_or(f64::INFINITY),
             &args.output_dir,
             HashIdShard {
-                num_shards: args.shards,
+                num_shards: args.effective_bucket_count(),
             },
             predicate,
         )?,
@@ -166,7 +166,7 @@ where
             args.mag_limit.unwrap_or(f64::INFINITY),
             &args.output_dir,
             IdRangeShard {
-                num_shards: args.shards,
+                num_shards: args.effective_bucket_count(),
             },
             predicate,
         )?,
@@ -175,7 +175,6 @@ where
             args.mag_limit.unwrap_or(f64::INFINITY),
             &args.output_dir,
             HealpixShard {
-                num_shards: args.shards,
                 level: args.healpix_level,
             },
             predicate,
@@ -200,7 +199,7 @@ where
                 args.mag_limit.unwrap_or(f64::INFINITY),
                 &args.output_dir,
                 HashIdShard {
-                    num_shards: args.shards,
+                    num_shards: args.effective_bucket_count(),
                 },
                 predicate,
             )?,
@@ -209,7 +208,7 @@ where
                 args.mag_limit.unwrap_or(f64::INFINITY),
                 &args.output_dir,
                 IdRangeShard {
-                    num_shards: args.shards,
+                    num_shards: args.effective_bucket_count(),
                 },
                 predicate,
             )?,
@@ -218,7 +217,6 @@ where
                 args.mag_limit.unwrap_or(f64::INFINITY),
                 &args.output_dir,
                 HealpixShard {
-                    num_shards: args.shards,
                     level: args.healpix_level,
                 },
                 predicate,
@@ -236,7 +234,7 @@ where
                 args.mag_limit.unwrap_or(f64::INFINITY),
                 &args.output_dir,
                 HashIdShard {
-                    num_shards: args.shards,
+                    num_shards: args.effective_bucket_count(),
                 },
                 predicate,
             )?,
@@ -246,7 +244,7 @@ where
                 args.mag_limit.unwrap_or(f64::INFINITY),
                 &args.output_dir,
                 IdRangeShard {
-                    num_shards: args.shards,
+                    num_shards: args.effective_bucket_count(),
                 },
                 predicate,
             )?,
@@ -256,7 +254,6 @@ where
                 args.mag_limit.unwrap_or(f64::INFINITY),
                 &args.output_dir,
                 HealpixShard {
-                    num_shards: args.shards,
                     level: args.healpix_level,
                 },
                 predicate,

--- a/crates/gaia/src/excerpt.rs
+++ b/crates/gaia/src/excerpt.rs
@@ -107,24 +107,44 @@ impl<E: GaiaSource> ShardKey<E> for IdRangeShard {
     }
 }
 
-/// Shard by HEALPix cell at the given depth, modulo `num_shards`. Computes
-/// the pixel from the entry's RA/Dec via [`cdshealpix::nested::hash`], so it
-/// works identically across DR1/DR2/DR3.
+/// Shard by HEALPix cell at the given depth — exactly one output file per
+/// cell. Computes the pixel from the entry's RA/Dec via
+/// [`cdshealpix::nested::hash`] and uses it as the shard index directly, so
+/// `shard_NNNN.csv.gz` corresponds to HEALPix cell `NNNN` and is spatially
+/// coherent: a cone-search loader can compute the cells the cone covers and
+/// open only those files (instead of scanning all shards).
+///
+/// The number of shards is determined by `level`:
+///
+/// | Level | Cells (12·4ⁿ) | ~Cell side |
+/// |-------|---------------|------------|
+/// | 5     | 12,288        | 1.83°      |
+/// | 6     | 49,152        | 0.92°      |
+/// | 7     | 196,608       | 0.46°      |
+///
+/// File counts scale fast — keep `level` modest unless you really need fine
+/// spatial resolution. Empty cells leave no file behind (the writer opens
+/// shard files lazily on first row).
 #[derive(Debug, Clone, Copy)]
 pub struct HealpixShard {
-    pub num_shards: u32,
-    /// HEALPix depth (0..=29). Higher = finer pixels. Default 6 (49,152 pixels).
+    /// HEALPix depth (0..=29). Higher = finer pixels.
     pub level: u8,
+}
+
+impl HealpixShard {
+    /// Number of HEALPix cells at this depth (`12 · 4^level`).
+    pub const fn cell_count(level: u8) -> u32 {
+        12u32 << (2 * level as u32)
+    }
 }
 
 impl<E: GaiaSource> ShardKey<E> for HealpixShard {
     fn num_shards(&self) -> u32 {
-        self.num_shards
+        HealpixShard::cell_count(self.level)
     }
     fn shard_of(&self, entry: &E) -> u32 {
         let c = entry.core();
-        let pixel = cdshealpix::nested::hash(self.level, c.ra.to_radians(), c.dec.to_radians());
-        (pixel % self.num_shards as u64) as u32
+        cdshealpix::nested::hash(self.level, c.ra.to_radians(), c.dec.to_radians()) as u32
     }
 }
 

--- a/crates/gaia/tests/dr3_excerpt.rs
+++ b/crates/gaia/tests/dr3_excerpt.rs
@@ -220,17 +220,21 @@ fn excerpt_from_reader_streams_without_disk() {
 
 #[test]
 fn healpix_shard_returns_in_range() {
-    let s = HealpixShard {
-        num_shards: 32,
-        level: 6,
-    };
+    // Level-3 = 768 cells. Tiny enough to fit per_shard_counts in a Vec
+    // without bloating the test, large enough to exercise multi-cell
+    // dispatch (50 random rows scattered across the sky → typically lands
+    // in 30+ distinct cells).
+    let level: u8 = 3;
+    let s = HealpixShard { level };
     let fixture = write_n_row_fixture(50);
     let out = tempfile::tempdir().unwrap();
     let summary =
         excerpt_csv_file::<Dr3, _, _>(fixture.path(), f64::INFINITY, out.path(), s, |_| true)
             .unwrap();
     assert_eq!(summary.kept_rows, 50);
-    // Every shard count must be in 0..num_shards; sum equals kept.
-    assert_eq!(summary.per_shard_counts.len(), 32);
+    // The writer's per_shard_counts vector is sized to the cell count
+    // (12 · 4^level); only cells that received entries are non-zero.
+    let expected_cells = HealpixShard::cell_count(level) as usize;
+    assert_eq!(summary.per_shard_counts.len(), expected_cells);
     assert_eq!(summary.per_shard_counts.iter().sum::<u64>(), 50);
 }


### PR DESCRIPTION
## Summary
The CLI accepted \`--shards N\` regardless of sharder, but for \`--shard-by healpix\` the count was applied as \`cell_id % N\` — silently mod-collapsing spatially-adjacent cells into the same bucket. Net result: healpix-sharded excerpts had ~zero spatial coherence (cone-search readers couldn't skip irrelevant shards), defeating the point of the sharder.

## Behavior change
- **Library**: \`HealpixShard\` drops \`num_shards\`. \`shard_of\` returns the raw cell ID; \`num_shards\` returns \`12 · 4^level\`. One output file per cell, \`shard_NNNN.csv.gz\` = HEALPix cell \`NNNN\`. Spatial coherence preserved → cone-search readers can compute the cell IDs the cone covers and open only those files.
- **CLI**: \`--shards\` is \`Option<u32>\`. \`Cli::validate()\` rejects it under \`--shard-by healpix\` and requires it for hash / id-range.
- **Default**: \`--healpix-level\` defaulted to 5 (12,288 cells, ~1.83° per cell). Empty cells leave no file behind.

## Cell counts by level
| Level | Cells | Avg cell side |
|-------|-------|---------------|
| 5     | 12,288 | 1.83° |
| 6     | 49,152 | 0.92° |
| 7     | 196,608 | 0.46° |

Higher levels mean drastically more files; level 5 is a good default.

## Test plan
- [x] \`cargo test -p starfield-gaia -p starfield-gaia-tools\` — all green; \`healpix_shard_returns_in_range\` updated to use \`level=3\` (768 cells) and assert the writer's shard-vector is sized to cell count.
- [x] \`cargo clippy -p starfield-gaia -p starfield-gaia-tools --all-targets -- -D warnings\` — clean.

## Compat note
Anyone constructing \`HealpixShard { num_shards, level }\` directly in Rust gets a compile error pointing at the removed field. To keep the bucketed file-count behavior, switch to \`HashIdShard\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)