### PR TITLE
gaia-catalog: GaiaCatalog trait with LazyLoadingCatalog + MemoryResidentCatalog backends

### DIFF
--- a/crates/gaia-tools/src/main.rs
+++ b/crates/gaia-tools/src/main.rs
@@ -473,18 +473,11 @@ type BoxedPredicate<E> = Box<dyn FnMut(&E) -> bool + Send>;
 /// Compose mag/cone/id-range filters into a single closure. Cone filtering
 /// is done with great-circle distance via core unit vectors.
 fn build_predicate<E: GaiaSource + 'static>(args: &Cli) -> Result<BoxedPredicate<E>> {
-    let cone = args.cone;
     let id_range = args.id_range;
-    let cone_threshold = cone.as_ref().map(|c| (c.radius_deg.to_radians()).cos());
-    let cone_center = cone.as_ref().map(|c| {
-        let ra_rad = c.ra_deg.to_radians();
-        let dec_rad = c.dec_deg.to_radians();
-        nalgebra::Vector3::new(
-            dec_rad.cos() * ra_rad.cos(),
-            dec_rad.cos() * ra_rad.sin(),
-            dec_rad.sin(),
-        )
-    });
+    let cone = args
+        .cone
+        .as_ref()
+        .map(|c| starfield_gaia::Cone::from_degrees(c.ra_deg, c.dec_deg, c.radius_deg));
 
     Ok(Box::new(move |e: &E| {
         let c = e.core();
@@ -493,9 +486,8 @@ fn build_predicate<E: GaiaSource + 'static>(args: &Cli) -> Result<BoxedPredicate
                 return false;
             }
         }
-        if let (Some(center), Some(threshold)) = (cone_center.as_ref(), cone_threshold) {
-            let v = c.unit_vector();
-            if v.dot(center) < threshold {
+        if let Some(cone) = cone.as_ref() {
+            if !cone.contains_unit_vec(&c.unit_vector()) {
                 return false;
             }
         }

--- a/crates/gaia/src/common/catalog.rs
+++ b/crates/gaia/src/common/catalog.rs
@@ -1,41 +1,81 @@
-//! Generic in-memory catalog shared by all releases.
+//! Generic in-memory catalog shared by all releases, plus the
+//! [`GaiaCatalog`] trait that abstracts over storage backends.
+//!
+//! Two implementations live in the crate:
+//!
+//! - [`MemoryResidentCatalog<R>`] — the historical in-memory `HashMap` keyed
+//!   by `source_id`. Cone queries scan the whole map and clone matching
+//!   entries.
+//! - [`LazyLoadingCatalog<R>`](crate::common::lazy::LazyLoadingCatalog) —
+//!   reads only the HEALPix shards a cone touches, on every query, with no
+//!   in-memory cache. Use when most of the excerpt directory is irrelevant
+//!   to your queries (e.g. a cone covering 0.1% of the sky).
 
 use std::collections::HashMap;
 use std::path::Path;
 
 use starfield::catalogs::{StarCatalog, StarData};
-use starfield::{Result, StarfieldError};
+use starfield::Result;
 
 use crate::common::cone::Cone;
 use crate::common::reader::CsvSourceReader;
 use crate::common::traits::{GaiaRelease, GaiaSource, Release};
-use crate::excerpt::ExcerptDir;
+
+/// Storage-agnostic cone-query interface. Implementors decide whether the
+/// rows live in memory (cheap repeat queries, eager up-front load) or on
+/// disk (no up-front cost, every query re-reads the relevant shards).
+///
+/// `entries_in_cone` is the only required method; `materialize_cone` drains
+/// the iterator into a [`MemoryResidentCatalog`] for callers that want to
+/// reuse the result.
+pub trait GaiaCatalog<R: GaiaRelease> {
+    /// Stream entries within `cone` whose `phot_g_mean_mag <= mag_limit`.
+    /// The iterator yields `Result` per row so backends that read from disk
+    /// can surface I/O errors mid-stream without panicking.
+    fn entries_in_cone<'a>(
+        &'a self,
+        cone: Cone,
+        mag_limit: f64,
+    ) -> Result<Box<dyn Iterator<Item = Result<R::Entry>> + 'a>>;
+
+    /// Drain the cone into a memory-resident catalog.
+    fn materialize_cone(&self, cone: Cone, mag_limit: f64) -> Result<MemoryResidentCatalog<R>> {
+        let mut catalog = MemoryResidentCatalog::with_mag_limit(mag_limit);
+        for entry in self.entries_in_cone(cone, mag_limit)? {
+            catalog.insert(entry?);
+        }
+        Ok(catalog)
+    }
+}
 
 /// In-memory Gaia catalog keyed by `source_id`, parameterized over a release marker.
 ///
 /// Per-release newtypes (`Dr1Catalog`, `Dr2Catalog`, `Dr3Catalog`) wrap this so users
 /// don't have to write turbofish at call sites.
 #[derive(Debug)]
-pub struct GaiaCatalogBase<R: GaiaRelease> {
+pub struct MemoryResidentCatalog<R: GaiaRelease> {
     stars: HashMap<u64, R::Entry>,
     mag_limit: f64,
 }
 
-impl<R: GaiaRelease> GaiaCatalogBase<R> {
+impl<R: GaiaRelease> MemoryResidentCatalog<R> {
     pub fn new() -> Self {
+        Self::with_mag_limit(f64::INFINITY)
+    }
+
+    /// Build an empty catalog with a recorded `mag_limit`. The cutoff is
+    /// metadata only — callers must still gate the entries they insert.
+    pub fn with_mag_limit(mag_limit: f64) -> Self {
         Self {
             stars: HashMap::new(),
-            mag_limit: f64::INFINITY,
+            mag_limit,
         }
     }
 
     /// Load a single `.csv` or `.csv.gz` file. Entries with `phot_g_mean_mag > mag_limit`
     /// are discarded as they stream past.
     pub fn from_csv_file(path: impl AsRef<Path>, mag_limit: f64) -> Result<Self> {
-        let mut catalog = Self {
-            stars: HashMap::new(),
-            mag_limit,
-        };
+        let mut catalog = Self::with_mag_limit(mag_limit);
         let reader = CsvSourceReader::<R>::open(path, mag_limit)?;
         for entry in reader {
             let entry = entry?;
@@ -81,95 +121,34 @@ impl<R: GaiaRelease> GaiaCatalogBase<R> {
     pub fn stars_iter_mut(&mut self) -> impl Iterator<Item = &mut R::Entry> {
         self.stars.values_mut()
     }
-
-    /// Load every entry intersecting `cone` from a HEALPix-sharded excerpt
-    /// directory (one produced by `gaia-excerpt --shard-by healpix`).
-    ///
-    /// The directory's manifest must record a HEALPix sharder; hash / id-range
-    /// layouts are rejected (they have no spatial coherence to exploit). The
-    /// implementation:
-    ///
-    /// 1. Asks `cdshealpix::nested::cone_coverage_approx_flat` for the
-    ///    superset of cells touched by the cone at the manifest's level.
-    /// 2. Opens only the shard files for those cells (skipping empty cells
-    ///    whose file does not exist).
-    /// 3. Streams each row through `from_csv_file` with `mag_limit`, then
-    ///    drops boundary-cell stars whose unit-vector dot product with the
-    ///    cone centre falls below `cos(radius)`. The HEALPix covering is
-    ///    conservative; this post-filter gives an exact cone.
-    pub fn from_excerpt_dir_for_cone(
-        excerpt_dir: impl AsRef<Path>,
-        cone: Cone,
-        mag_limit: f64,
-    ) -> Result<Self> {
-        let dir = ExcerptDir::open(excerpt_dir)?;
-        let level = dir.healpix_level().ok_or_else(|| {
-            StarfieldError::DataError(format!(
-                "from_excerpt_dir_for_cone requires a HEALPix-sharded directory; \
-                 manifest at {} reports sharder kind={:?}",
-                dir.dir.display(),
-                dir.manifest.sharder.kind
-            ))
-        })?;
-
-        // The post-PR-#42 writer maps shard index 1:1 to HEALPix cell, so
-        // num_shards must equal `12 · 4^level`. Older mod-collapsed dirs
-        // (kind="healpix" but num_shards < cell_count) would silently lose
-        // ~99% of the cone's cells if we naively skipped out-of-range
-        // indices, so refuse them up front.
-        let expected_cells = 12u32 << (2 * level as u32);
-        if dir.num_shards() != expected_cells {
-            return Err(StarfieldError::DataError(format!(
-                "from_excerpt_dir_for_cone needs one-file-per-cell layout; manifest at {} \
-                 reports HEALPix level={} but num_shards={} (expected {}). This dir was \
-                 written by a mod-collapsed sharder; reshard with `gaia-excerpt --shard-by \
-                 healpix --healpix-level {}` against a recent build to get the \
-                 cone-searchable layout.",
-                dir.dir.display(),
-                level,
-                dir.num_shards(),
-                expected_cells,
-                level,
-            )));
-        }
-
-        let cells = cdshealpix::nested::cone_coverage_approx_flat(
-            level,
-            cone.ra_rad,
-            cone.dec_rad,
-            cone.radius_rad,
-        );
-
-        let mut catalog = Self {
-            stars: HashMap::new(),
-            mag_limit,
-        };
-        for cell in cells.iter() {
-            let cell = *cell as u32;
-            let Some(path) = dir.existing_shard_path(cell) else {
-                continue;
-            };
-            let reader = CsvSourceReader::<R>::open(&path, mag_limit)?;
-            for entry in reader {
-                let entry = entry?;
-                if !cone.contains_unit_vec(&entry.core().unit_vector()) {
-                    continue;
-                }
-                let id = entry.core().source_id;
-                catalog.stars.insert(id, entry);
-            }
-        }
-        Ok(catalog)
-    }
 }
 
-impl<R: GaiaRelease> Default for GaiaCatalogBase<R> {
+impl<R: GaiaRelease> Default for MemoryResidentCatalog<R> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<R: GaiaRelease> StarCatalog for GaiaCatalogBase<R> {
+impl<R: GaiaRelease> GaiaCatalog<R> for MemoryResidentCatalog<R> {
+    fn entries_in_cone<'a>(
+        &'a self,
+        cone: Cone,
+        mag_limit: f64,
+    ) -> Result<Box<dyn Iterator<Item = Result<R::Entry>> + 'a>> {
+        Ok(Box::new(self.stars.values().filter_map(move |e| {
+            let c = e.core();
+            if c.phot_g_mean_mag > mag_limit {
+                return None;
+            }
+            if !cone.contains_unit_vec(&c.unit_vector()) {
+                return None;
+            }
+            Some(Ok(e.clone()))
+        })))
+    }
+}
+
+impl<R: GaiaRelease> StarCatalog for MemoryResidentCatalog<R> {
     type Star = R::Entry;
 
     fn get_star(&self, id: usize) -> Option<&Self::Star> {

--- a/crates/gaia/src/common/catalog.rs
+++ b/crates/gaia/src/common/catalog.rs
@@ -38,6 +38,22 @@ pub trait GaiaCatalog<R: GaiaRelease> {
         mag_limit: f64,
     ) -> Result<Box<dyn Iterator<Item = Result<R::Entry>> + 'a>>;
 
+    /// Total row count this catalog can serve, regardless of cone or
+    /// magnitude. Lazy backends answer this from the on-disk manifest
+    /// without touching shard files.
+    ///
+    /// Returns `u64` (not `usize`) so the value is consistent across
+    /// 32- and 64-bit targets and matches the manifest's storage type;
+    /// callers that also have `StarCatalog` in scope must disambiguate
+    /// `cat.len()` via UFCS, e.g.
+    /// `<_ as GaiaCatalog<Dr3>>::len(&cat)`.
+    fn len(&self) -> u64;
+
+    /// True when [`len`](Self::len) is zero.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// Drain the cone into a memory-resident catalog.
     fn materialize_cone(&self, cone: Cone, mag_limit: f64) -> Result<MemoryResidentCatalog<R>> {
         let mut catalog = MemoryResidentCatalog::with_mag_limit(mag_limit);
@@ -146,7 +162,16 @@ impl<R: GaiaRelease> GaiaCatalog<R> for MemoryResidentCatalog<R> {
             Some(Ok(e.clone()))
         })))
     }
+
+    fn len(&self) -> u64 {
+        self.stars.len() as u64
+    }
 }
+
+// `MemoryResidentCatalog` already implements `StarCatalog::len(&self) -> usize`;
+// `GaiaCatalog<R>::len(&self) -> u64` shadows the name. Inherent methods take
+// precedence and don't exist for `len`, so direct `cat.len()` is ambiguous when
+// both traits are in scope — callers disambiguate via UFCS, see the trait doc.
 
 impl<R: GaiaRelease> StarCatalog for MemoryResidentCatalog<R> {
     type Star = R::Entry;

--- a/crates/gaia/src/common/catalog.rs
+++ b/crates/gaia/src/common/catalog.rs
@@ -4,10 +4,12 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use starfield::catalogs::{StarCatalog, StarData};
-use starfield::Result;
+use starfield::{Result, StarfieldError};
 
+use crate::common::cone::Cone;
 use crate::common::reader::CsvSourceReader;
 use crate::common::traits::{GaiaRelease, GaiaSource, Release};
+use crate::excerpt::ExcerptDir;
 
 /// In-memory Gaia catalog keyed by `source_id`, parameterized over a release marker.
 ///
@@ -78,6 +80,68 @@ impl<R: GaiaRelease> GaiaCatalogBase<R> {
     /// splice in supplementary data (e.g. DR1 TGAS cross-ids).
     pub fn stars_iter_mut(&mut self) -> impl Iterator<Item = &mut R::Entry> {
         self.stars.values_mut()
+    }
+
+    /// Load every entry intersecting `cone` from a HEALPix-sharded excerpt
+    /// directory (one produced by `gaia-excerpt --shard-by healpix`).
+    ///
+    /// The directory's manifest must record a HEALPix sharder; hash / id-range
+    /// layouts are rejected (they have no spatial coherence to exploit). The
+    /// implementation:
+    ///
+    /// 1. Asks `cdshealpix::nested::cone_coverage_approx_flat` for the
+    ///    superset of cells touched by the cone at the manifest's level.
+    /// 2. Opens only the shard files for those cells (skipping empty cells
+    ///    whose file does not exist).
+    /// 3. Streams each row through `from_csv_file` with `mag_limit`, then
+    ///    drops boundary-cell stars whose unit-vector dot product with the
+    ///    cone centre falls below `cos(radius)`. The HEALPix covering is
+    ///    conservative; this post-filter gives an exact cone.
+    pub fn from_excerpt_dir_for_cone(
+        excerpt_dir: impl AsRef<Path>,
+        cone: Cone,
+        mag_limit: f64,
+    ) -> Result<Self> {
+        let dir = ExcerptDir::open(excerpt_dir)?;
+        let level = dir.healpix_level().ok_or_else(|| {
+            StarfieldError::DataError(format!(
+                "from_excerpt_dir_for_cone requires a HEALPix-sharded directory; \
+                 manifest at {} reports sharder kind={:?}",
+                dir.dir.display(),
+                dir.manifest.sharder.kind
+            ))
+        })?;
+
+        let cells = cdshealpix::nested::cone_coverage_approx_flat(
+            level,
+            cone.ra_rad,
+            cone.dec_rad,
+            cone.radius_rad,
+        );
+
+        let mut catalog = Self {
+            stars: HashMap::new(),
+            mag_limit,
+        };
+        for cell in cells.iter() {
+            let cell = *cell as u32;
+            if cell >= dir.num_shards() {
+                continue;
+            }
+            let Some(path) = dir.existing_shard_path(cell) else {
+                continue;
+            };
+            let reader = CsvSourceReader::<R>::open(&path, mag_limit)?;
+            for entry in reader {
+                let entry = entry?;
+                if !cone.contains_unit_vec(&entry.core().unit_vector()) {
+                    continue;
+                }
+                let id = entry.core().source_id;
+                catalog.stars.insert(id, entry);
+            }
+        }
+        Ok(catalog)
     }
 }
 

--- a/crates/gaia/src/common/catalog.rs
+++ b/crates/gaia/src/common/catalog.rs
@@ -112,6 +112,27 @@ impl<R: GaiaRelease> GaiaCatalogBase<R> {
             ))
         })?;
 
+        // The post-PR-#42 writer maps shard index 1:1 to HEALPix cell, so
+        // num_shards must equal `12 · 4^level`. Older mod-collapsed dirs
+        // (kind="healpix" but num_shards < cell_count) would silently lose
+        // ~99% of the cone's cells if we naively skipped out-of-range
+        // indices, so refuse them up front.
+        let expected_cells = 12u32 << (2 * level as u32);
+        if dir.num_shards() != expected_cells {
+            return Err(StarfieldError::DataError(format!(
+                "from_excerpt_dir_for_cone needs one-file-per-cell layout; manifest at {} \
+                 reports HEALPix level={} but num_shards={} (expected {}). This dir was \
+                 written by a mod-collapsed sharder; reshard with `gaia-excerpt --shard-by \
+                 healpix --healpix-level {}` against a recent build to get the \
+                 cone-searchable layout.",
+                dir.dir.display(),
+                level,
+                dir.num_shards(),
+                expected_cells,
+                level,
+            )));
+        }
+
         let cells = cdshealpix::nested::cone_coverage_approx_flat(
             level,
             cone.ra_rad,
@@ -125,9 +146,6 @@ impl<R: GaiaRelease> GaiaCatalogBase<R> {
         };
         for cell in cells.iter() {
             let cell = *cell as u32;
-            if cell >= dir.num_shards() {
-                continue;
-            }
             let Some(path) = dir.existing_shard_path(cell) else {
                 continue;
             };

--- a/crates/gaia/src/common/cone.rs
+++ b/crates/gaia/src/common/cone.rs
@@ -1,0 +1,82 @@
+//! Spherical cap ("cone") helper for cone-search filtering.
+//!
+//! A `Cone` is a circular patch of sky defined by a centre direction (RA/Dec)
+//! and an angular radius. Membership tests use the unit-vector dot product
+//! against `cos(radius)` — exact, branchless, and matches the convention used
+//! by the rest of the crate (`GaiaCore::unit_vector`).
+
+use nalgebra::Vector3;
+
+/// A circular spherical cap centred at `(ra, dec)` with angular `radius`.
+///
+/// All angles are stored internally in radians; precomputed `centre` (unit
+/// vector) and `cos_radius` make membership tests cheap.
+#[derive(Debug, Clone, Copy)]
+pub struct Cone {
+    pub ra_rad: f64,
+    pub dec_rad: f64,
+    pub radius_rad: f64,
+    pub centre: Vector3<f64>,
+    pub cos_radius: f64,
+}
+
+impl Cone {
+    /// Construct from degrees. RA/Dec are interpreted as ICRS spherical angles
+    /// (the same convention used by `GaiaCore::ra` / `dec`).
+    pub fn from_degrees(ra_deg: f64, dec_deg: f64, radius_deg: f64) -> Self {
+        let ra_rad = ra_deg.to_radians();
+        let dec_rad = dec_deg.to_radians();
+        let radius_rad = radius_deg.to_radians();
+        let centre = Vector3::new(
+            dec_rad.cos() * ra_rad.cos(),
+            dec_rad.cos() * ra_rad.sin(),
+            dec_rad.sin(),
+        );
+        Self {
+            ra_rad,
+            dec_rad,
+            radius_rad,
+            centre,
+            cos_radius: radius_rad.cos(),
+        }
+    }
+
+    /// True when `v` (assumed unit-length) lies within the cone.
+    pub fn contains_unit_vec(&self, v: &Vector3<f64>) -> bool {
+        v.dot(&self.centre) >= self.cos_radius
+    }
+
+    /// True when the given RA/Dec (degrees) lies within the cone.
+    pub fn contains_radec_deg(&self, ra_deg: f64, dec_deg: f64) -> bool {
+        let ra = ra_deg.to_radians();
+        let dec = dec_deg.to_radians();
+        let v = Vector3::new(dec.cos() * ra.cos(), dec.cos() * ra.sin(), dec.sin());
+        self.contains_unit_vec(&v)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn centre_is_inside() {
+        let c = Cone::from_degrees(123.4, -56.7, 1.0);
+        assert!(c.contains_radec_deg(123.4, -56.7));
+    }
+
+    #[test]
+    fn beyond_radius_is_outside() {
+        let c = Cone::from_degrees(0.0, 0.0, 1.0);
+        // Point 2° east of (0, 0): outside a 1° cone.
+        assert!(!c.contains_radec_deg(2.0, 0.0));
+        // Point 0.5° east of (0, 0): inside.
+        assert!(c.contains_radec_deg(0.5, 0.0));
+    }
+
+    #[test]
+    fn antipode_is_outside() {
+        let c = Cone::from_degrees(45.0, 30.0, 1.0);
+        assert!(!c.contains_radec_deg(225.0, -30.0));
+    }
+}

--- a/crates/gaia/src/common/lazy.rs
+++ b/crates/gaia/src/common/lazy.rs
@@ -100,6 +100,12 @@ impl<R: GaiaRelease> LazyLoadingCatalog<R> {
 }
 
 impl<R: GaiaRelease> GaiaCatalog<R> for LazyLoadingCatalog<R> {
+    /// Total committed row count from the manifest. No I/O — the writer
+    /// keeps `kept_rows` in sync atomically on every commit.
+    fn len(&self) -> u64 {
+        self.dir.manifest.kept_rows
+    }
+
     fn entries_in_cone<'a>(
         &'a self,
         cone: Cone,

--- a/crates/gaia/src/common/lazy.rs
+++ b/crates/gaia/src/common/lazy.rs
@@ -1,0 +1,143 @@
+//! Lazy on-disk implementation of [`GaiaCatalog`].
+//!
+//! Opens an excerpt directory's manifest at construction (cheap; one
+//! small JSON read), validates the layout matches the requested release
+//! and is HEALPix-sharded one-file-per-cell, then re-reads the relevant
+//! shards on every cone query. There is no in-memory cache — repeat
+//! queries pay the parse cost again, deliberately, until a future
+//! revision adds an LRU.
+
+use std::marker::PhantomData;
+use std::path::Path;
+
+use starfield::{Result, StarfieldError};
+
+use crate::common::catalog::GaiaCatalog;
+use crate::common::cone::Cone;
+use crate::common::reader::CsvSourceReader;
+use crate::common::traits::{GaiaRelease, GaiaSource};
+use crate::excerpt::ExcerptDir;
+
+/// Lazy on-disk catalog backed by a HEALPix-sharded excerpt directory.
+///
+/// `open` checks the manifest is present, the recorded release matches
+/// `R`, and the layout is one-file-per-cell — failures here surface
+/// before the first query. Each `entries_in_cone` call uses
+/// `cdshealpix::nested::cone_coverage_approx_flat` to identify the
+/// covering cells, opens only the existing shard files for those cells,
+/// streams entries through the magnitude gate, and post-filters by
+/// great-circle distance against `cos(radius)` (the HEALPix covering is
+/// conservative; boundary cells overshoot).
+#[derive(Debug)]
+pub struct LazyLoadingCatalog<R: GaiaRelease> {
+    dir: ExcerptDir,
+    healpix_level: u8,
+    _marker: PhantomData<R>,
+}
+
+impl<R: GaiaRelease> LazyLoadingCatalog<R> {
+    /// Open the excerpt dir and validate it can serve cone queries for
+    /// release `R`.
+    pub fn open(dir: impl AsRef<Path>) -> Result<Self> {
+        let dir = ExcerptDir::open(dir)?;
+
+        let want_release = format!("{:?}", R::RELEASE);
+        if dir.manifest.release != want_release {
+            return Err(StarfieldError::DataError(format!(
+                "LazyLoadingCatalog: manifest at {} reports release {} but requested {}",
+                dir.dir.display(),
+                dir.manifest.release,
+                want_release
+            )));
+        }
+
+        let level = dir.healpix_level().ok_or_else(|| {
+            StarfieldError::DataError(format!(
+                "LazyLoadingCatalog requires a HEALPix-sharded directory; \
+                 manifest at {} reports sharder kind={:?}",
+                dir.dir.display(),
+                dir.manifest.sharder.kind
+            ))
+        })?;
+
+        // The post-PR-#42 writer maps shard index 1:1 to HEALPix cell, so
+        // num_shards must equal `12 · 4^level`. Older mod-collapsed dirs
+        // (kind="healpix" but num_shards < cell_count) would silently lose
+        // ~99% of the cone's cells if we naively skipped out-of-range
+        // indices, so refuse them up front.
+        let expected_cells = 12u32 << (2 * level as u32);
+        if dir.num_shards() != expected_cells {
+            return Err(StarfieldError::DataError(format!(
+                "LazyLoadingCatalog needs one-file-per-cell layout; manifest at {} reports \
+                 HEALPix level={} but num_shards={} (expected {}). This dir was written by a \
+                 mod-collapsed sharder; reshard with `gaia-excerpt --shard-by healpix \
+                 --healpix-level {}` to get the cone-searchable layout.",
+                dir.dir.display(),
+                level,
+                dir.num_shards(),
+                expected_cells,
+                level,
+            )));
+        }
+
+        Ok(Self {
+            dir,
+            healpix_level: level,
+            _marker: PhantomData,
+        })
+    }
+
+    /// Underlying excerpt directory handle, for callers who want to read
+    /// the manifest or enumerate shard paths directly.
+    pub fn dir(&self) -> &ExcerptDir {
+        &self.dir
+    }
+
+    /// HEALPix depth this directory is sharded at.
+    pub fn healpix_level(&self) -> u8 {
+        self.healpix_level
+    }
+}
+
+impl<R: GaiaRelease> GaiaCatalog<R> for LazyLoadingCatalog<R> {
+    fn entries_in_cone<'a>(
+        &'a self,
+        cone: Cone,
+        mag_limit: f64,
+    ) -> Result<Box<dyn Iterator<Item = Result<R::Entry>> + 'a>> {
+        let cells = cdshealpix::nested::cone_coverage_approx_flat(
+            self.healpix_level,
+            cone.ra_rad,
+            cone.dec_rad,
+            cone.radius_rad,
+        );
+        let cell_paths: Vec<_> = cells
+            .iter()
+            .filter_map(|&c| self.dir.existing_shard_path(c as u32))
+            .collect();
+
+        let it = cell_paths.into_iter().flat_map(move |path| {
+            // `flat_map` needs a single iterator type per call. We open
+            // the shard reader and adapt its `Result<Entry>` items;
+            // open-time errors yield a single `Err` element so the
+            // caller still sees them.
+            let opened = CsvSourceReader::<R>::open(&path, mag_limit);
+            let inner: Box<dyn Iterator<Item = Result<R::Entry>>> = match opened {
+                Ok(reader) => Box::new(reader.filter_map(move |r| match r {
+                    Ok(entry) => {
+                        if cone.contains_unit_vec(&entry.core().unit_vector()) {
+                            Some(Ok(entry))
+                        } else {
+                            None
+                        }
+                    }
+                    Err(e) => Some(Err(e)),
+                })),
+                Err(e) => Box::new(std::iter::once(Err(e))),
+            };
+            inner
+        });
+
+        Ok(Box::new(it))
+    }
+}

--- a/crates/gaia/src/common/mod.rs
+++ b/crates/gaia/src/common/mod.rs
@@ -1,6 +1,7 @@
 //! Shared types and machinery used by every Gaia data release.
 
 pub mod catalog;
+pub mod cone;
 pub mod core;
 pub mod format;
 pub mod parse;
@@ -9,6 +10,7 @@ pub mod supplement;
 pub mod traits;
 
 pub use catalog::GaiaCatalogBase;
+pub use cone::Cone;
 pub use core::{GaiaCore, VarFlag};
 pub use reader::CsvSourceReader;
 pub use supplement::{

--- a/crates/gaia/src/common/mod.rs
+++ b/crates/gaia/src/common/mod.rs
@@ -4,14 +4,16 @@ pub mod catalog;
 pub mod cone;
 pub mod core;
 pub mod format;
+pub mod lazy;
 pub mod parse;
 pub mod reader;
 pub mod supplement;
 pub mod traits;
 
-pub use catalog::GaiaCatalogBase;
+pub use catalog::{GaiaCatalog, MemoryResidentCatalog};
 pub use cone::Cone;
 pub use core::{GaiaCore, VarFlag};
+pub use lazy::LazyLoadingCatalog;
 pub use reader::CsvSourceReader;
 pub use supplement::{
     decode_supplement_hip, encode_supplement_source_id, is_supplement_source_id, SupplementRow,

--- a/crates/gaia/src/common/traits.rs
+++ b/crates/gaia/src/common/traits.rs
@@ -89,7 +89,7 @@ pub trait GaiaRelease: 'static {
     const IS_ECSV: bool = false;
 
     /// The entry type produced by parsing one row.
-    type Entry: GaiaSource + std::fmt::Debug + Send + 'static;
+    type Entry: GaiaSource + Clone + std::fmt::Debug + Send + 'static;
 
     /// Arrow schema describing the columns this release's parser consumes.
     fn arrow_schema() -> SchemaRef;
@@ -100,7 +100,7 @@ pub trait GaiaRelease: 'static {
 
     /// Format an entry as one CSV row matching the column layout in [`arrow_schema`].
     /// Floats use Rust's default `Display` (full round-trip precision); `Option::None`
-    /// becomes the empty string. Output is parseable by [`from_csv_file`](crate::common::catalog::GaiaCatalogBase::from_csv_file).
+    /// becomes the empty string. Output is parseable by [`from_csv_file`](crate::common::catalog::MemoryResidentCatalog::from_csv_file).
     fn format_csv_row(entry: &Self::Entry) -> String;
 
     /// Comma-joined header line listing every column in [`arrow_schema`] order.

--- a/crates/gaia/src/dr1/catalog.rs
+++ b/crates/gaia/src/dr1/catalog.rs
@@ -119,6 +119,10 @@ impl GaiaCatalog<Dr1> for Dr1Catalog {
     ) -> Result<Box<dyn Iterator<Item = Result<Dr1Entry>> + 'a>> {
         self.0.entries_in_cone(cone, mag_limit)
     }
+
+    fn len(&self) -> u64 {
+        <_ as GaiaCatalog<Dr1>>::len(&self.0)
+    }
 }
 
 pub fn download_file(filename: &str) -> Result<PathBuf> {

--- a/crates/gaia/src/dr1/catalog.rs
+++ b/crates/gaia/src/dr1/catalog.rs
@@ -9,6 +9,7 @@ use flate2::read::MultiGzDecoder;
 use starfield::{Result, StarfieldError};
 
 use crate::common::catalog::GaiaCatalogBase;
+use crate::common::cone::Cone;
 use crate::download::Downloader;
 use crate::dr1::entry::{Dr1Entry, TgasBlock};
 use crate::dr1::schema::Dr1;
@@ -26,6 +27,21 @@ impl Dr1Catalog {
     pub fn from_csv_file(path: impl AsRef<Path>, mag_limit: f64) -> Result<Self> {
         Ok(Self(GaiaCatalogBase::<Dr1>::from_csv_file(
             path, mag_limit,
+        )?))
+    }
+
+    /// Load every DR1 entry intersecting `cone` from a HEALPix-sharded
+    /// excerpt directory. See
+    /// [`GaiaCatalogBase::from_excerpt_dir_for_cone`].
+    pub fn from_excerpt_dir_for_cone(
+        excerpt_dir: impl AsRef<Path>,
+        cone: Cone,
+        mag_limit: f64,
+    ) -> Result<Self> {
+        Ok(Self(GaiaCatalogBase::<Dr1>::from_excerpt_dir_for_cone(
+            excerpt_dir,
+            cone,
+            mag_limit,
         )?))
     }
 

--- a/crates/gaia/src/dr1/catalog.rs
+++ b/crates/gaia/src/dr1/catalog.rs
@@ -8,52 +8,50 @@ use std::path::{Path, PathBuf};
 use flate2::read::MultiGzDecoder;
 use starfield::{Result, StarfieldError};
 
-use crate::common::catalog::GaiaCatalogBase;
+use crate::common::catalog::{GaiaCatalog, MemoryResidentCatalog};
 use crate::common::cone::Cone;
+use crate::common::lazy::LazyLoadingCatalog;
 use crate::download::Downloader;
 use crate::dr1::entry::{Dr1Entry, TgasBlock};
 use crate::dr1::schema::Dr1;
 
 /// In-memory Gaia DR1 catalog, keyed by `source_id`.
 #[derive(Debug)]
-pub struct Dr1Catalog(pub GaiaCatalogBase<Dr1>);
+pub struct Dr1Catalog(pub MemoryResidentCatalog<Dr1>);
 
 impl Dr1Catalog {
     pub fn new() -> Self {
-        Self(GaiaCatalogBase::new())
+        Self(MemoryResidentCatalog::new())
     }
 
     /// Load a DR1 `GaiaSource_*.csv.gz` file.
     pub fn from_csv_file(path: impl AsRef<Path>, mag_limit: f64) -> Result<Self> {
-        Ok(Self(GaiaCatalogBase::<Dr1>::from_csv_file(
+        Ok(Self(MemoryResidentCatalog::<Dr1>::from_csv_file(
             path, mag_limit,
         )?))
     }
 
     /// Load every DR1 entry intersecting `cone` from a HEALPix-sharded
-    /// excerpt directory. See
-    /// [`GaiaCatalogBase::from_excerpt_dir_for_cone`].
+    /// excerpt directory. Convenience over [`LazyLoadingCatalog::open`] +
+    /// [`GaiaCatalog::materialize_cone`].
     pub fn from_excerpt_dir_for_cone(
         excerpt_dir: impl AsRef<Path>,
         cone: Cone,
         mag_limit: f64,
     ) -> Result<Self> {
-        Ok(Self(GaiaCatalogBase::<Dr1>::from_excerpt_dir_for_cone(
-            excerpt_dir,
-            cone,
-            mag_limit,
-        )?))
+        let lazy = LazyLoadingCatalog::<Dr1>::open(excerpt_dir)?;
+        Ok(Self(lazy.materialize_cone(cone, mag_limit)?))
     }
 
-    pub fn inner(&self) -> &GaiaCatalogBase<Dr1> {
+    pub fn inner(&self) -> &MemoryResidentCatalog<Dr1> {
         &self.0
     }
 
-    pub fn inner_mut(&mut self) -> &mut GaiaCatalogBase<Dr1> {
+    pub fn inner_mut(&mut self) -> &mut MemoryResidentCatalog<Dr1> {
         &mut self.0
     }
 
-    pub fn into_inner(self) -> GaiaCatalogBase<Dr1> {
+    pub fn into_inner(self) -> MemoryResidentCatalog<Dr1> {
         self.0
     }
 
@@ -107,9 +105,19 @@ impl Default for Dr1Catalog {
 }
 
 impl std::ops::Deref for Dr1Catalog {
-    type Target = GaiaCatalogBase<Dr1>;
+    type Target = MemoryResidentCatalog<Dr1>;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl GaiaCatalog<Dr1> for Dr1Catalog {
+    fn entries_in_cone<'a>(
+        &'a self,
+        cone: Cone,
+        mag_limit: f64,
+    ) -> Result<Box<dyn Iterator<Item = Result<Dr1Entry>> + 'a>> {
+        self.0.entries_in_cone(cone, mag_limit)
     }
 }
 

--- a/crates/gaia/src/dr2/catalog.rs
+++ b/crates/gaia/src/dr2/catalog.rs
@@ -100,6 +100,10 @@ impl GaiaCatalog<Dr2> for Dr2Catalog {
     ) -> Result<Box<dyn Iterator<Item = Result<Dr2Entry>> + 'a>> {
         self.0.entries_in_cone(cone, mag_limit)
     }
+
+    fn len(&self) -> u64 {
+        <_ as GaiaCatalog<Dr2>>::len(&self.0)
+    }
 }
 
 pub fn download_file(filename: &str) -> Result<PathBuf> {

--- a/crates/gaia/src/dr2/catalog.rs
+++ b/crates/gaia/src/dr2/catalog.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use starfield::Result;
 
 use crate::common::catalog::GaiaCatalogBase;
+use crate::common::cone::Cone;
 use crate::download::Downloader;
 use crate::dr2::entry::Dr2Entry;
 use crate::dr2::schema::Dr2;
@@ -20,6 +21,21 @@ impl Dr2Catalog {
     pub fn from_csv_file(path: impl AsRef<Path>, mag_limit: f64) -> Result<Self> {
         Ok(Self(GaiaCatalogBase::<Dr2>::from_csv_file(
             path, mag_limit,
+        )?))
+    }
+
+    /// Load every DR2 entry intersecting `cone` from a HEALPix-sharded
+    /// excerpt directory. See
+    /// [`GaiaCatalogBase::from_excerpt_dir_for_cone`].
+    pub fn from_excerpt_dir_for_cone(
+        excerpt_dir: impl AsRef<Path>,
+        cone: Cone,
+        mag_limit: f64,
+    ) -> Result<Self> {
+        Ok(Self(GaiaCatalogBase::<Dr2>::from_excerpt_dir_for_cone(
+            excerpt_dir,
+            cone,
+            mag_limit,
         )?))
     }
 

--- a/crates/gaia/src/dr2/catalog.rs
+++ b/crates/gaia/src/dr2/catalog.rs
@@ -4,50 +4,48 @@ use std::path::{Path, PathBuf};
 
 use starfield::Result;
 
-use crate::common::catalog::GaiaCatalogBase;
+use crate::common::catalog::{GaiaCatalog, MemoryResidentCatalog};
 use crate::common::cone::Cone;
+use crate::common::lazy::LazyLoadingCatalog;
 use crate::download::Downloader;
 use crate::dr2::entry::Dr2Entry;
 use crate::dr2::schema::Dr2;
 
 #[derive(Debug)]
-pub struct Dr2Catalog(pub GaiaCatalogBase<Dr2>);
+pub struct Dr2Catalog(pub MemoryResidentCatalog<Dr2>);
 
 impl Dr2Catalog {
     pub fn new() -> Self {
-        Self(GaiaCatalogBase::new())
+        Self(MemoryResidentCatalog::new())
     }
 
     pub fn from_csv_file(path: impl AsRef<Path>, mag_limit: f64) -> Result<Self> {
-        Ok(Self(GaiaCatalogBase::<Dr2>::from_csv_file(
+        Ok(Self(MemoryResidentCatalog::<Dr2>::from_csv_file(
             path, mag_limit,
         )?))
     }
 
     /// Load every DR2 entry intersecting `cone` from a HEALPix-sharded
-    /// excerpt directory. See
-    /// [`GaiaCatalogBase::from_excerpt_dir_for_cone`].
+    /// excerpt directory. Convenience over [`LazyLoadingCatalog::open`] +
+    /// [`GaiaCatalog::materialize_cone`].
     pub fn from_excerpt_dir_for_cone(
         excerpt_dir: impl AsRef<Path>,
         cone: Cone,
         mag_limit: f64,
     ) -> Result<Self> {
-        Ok(Self(GaiaCatalogBase::<Dr2>::from_excerpt_dir_for_cone(
-            excerpt_dir,
-            cone,
-            mag_limit,
-        )?))
+        let lazy = LazyLoadingCatalog::<Dr2>::open(excerpt_dir)?;
+        Ok(Self(lazy.materialize_cone(cone, mag_limit)?))
     }
 
-    pub fn inner(&self) -> &GaiaCatalogBase<Dr2> {
+    pub fn inner(&self) -> &MemoryResidentCatalog<Dr2> {
         &self.0
     }
 
-    pub fn inner_mut(&mut self) -> &mut GaiaCatalogBase<Dr2> {
+    pub fn inner_mut(&mut self) -> &mut MemoryResidentCatalog<Dr2> {
         &mut self.0
     }
 
-    pub fn into_inner(self) -> GaiaCatalogBase<Dr2> {
+    pub fn into_inner(self) -> MemoryResidentCatalog<Dr2> {
         self.0
     }
 
@@ -88,9 +86,19 @@ impl Default for Dr2Catalog {
 }
 
 impl std::ops::Deref for Dr2Catalog {
-    type Target = GaiaCatalogBase<Dr2>;
+    type Target = MemoryResidentCatalog<Dr2>;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl GaiaCatalog<Dr2> for Dr2Catalog {
+    fn entries_in_cone<'a>(
+        &'a self,
+        cone: Cone,
+        mag_limit: f64,
+    ) -> Result<Box<dyn Iterator<Item = Result<Dr2Entry>> + 'a>> {
+        self.0.entries_in_cone(cone, mag_limit)
     }
 }
 

--- a/crates/gaia/src/dr3/catalog.rs
+++ b/crates/gaia/src/dr3/catalog.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use starfield::Result;
 
 use crate::common::catalog::GaiaCatalogBase;
+use crate::common::cone::Cone;
 use crate::download::Downloader;
 use crate::dr3::entry::Dr3Entry;
 use crate::dr3::schema::Dr3;
@@ -22,6 +23,26 @@ impl Dr3Catalog {
     pub fn from_csv_file(path: impl AsRef<Path>, mag_limit: f64) -> Result<Self> {
         Ok(Self(GaiaCatalogBase::<Dr3>::from_csv_file(
             path, mag_limit,
+        )?))
+    }
+
+    /// Load every DR3 entry intersecting `cone` from a HEALPix-sharded
+    /// excerpt directory (one produced by
+    /// `gaia-excerpt --shard-by healpix`).
+    ///
+    /// See [`GaiaCatalogBase::from_excerpt_dir_for_cone`] for the algorithm
+    /// (cdshealpix cone coverage + per-row dot-product post-filter for an
+    /// exact cone). Errors out if the directory's manifest does not record
+    /// a HEALPix sharder.
+    pub fn from_excerpt_dir_for_cone(
+        excerpt_dir: impl AsRef<Path>,
+        cone: Cone,
+        mag_limit: f64,
+    ) -> Result<Self> {
+        Ok(Self(GaiaCatalogBase::<Dr3>::from_excerpt_dir_for_cone(
+            excerpt_dir,
+            cone,
+            mag_limit,
         )?))
     }
 

--- a/crates/gaia/src/dr3/catalog.rs
+++ b/crates/gaia/src/dr3/catalog.rs
@@ -1,27 +1,28 @@
-//! DR3 catalog newtype — thin wrapper over [`GaiaCatalogBase`](crate::common::catalog::GaiaCatalogBase).
+//! DR3 catalog newtype — thin wrapper over [`MemoryResidentCatalog`](crate::common::catalog::MemoryResidentCatalog).
 
 use std::path::{Path, PathBuf};
 
 use starfield::Result;
 
-use crate::common::catalog::GaiaCatalogBase;
+use crate::common::catalog::{GaiaCatalog, MemoryResidentCatalog};
 use crate::common::cone::Cone;
+use crate::common::lazy::LazyLoadingCatalog;
 use crate::download::Downloader;
 use crate::dr3::entry::Dr3Entry;
 use crate::dr3::schema::Dr3;
 
 /// In-memory Gaia DR3 catalog, keyed by `source_id`.
 #[derive(Debug)]
-pub struct Dr3Catalog(pub GaiaCatalogBase<Dr3>);
+pub struct Dr3Catalog(pub MemoryResidentCatalog<Dr3>);
 
 impl Dr3Catalog {
     pub fn new() -> Self {
-        Self(GaiaCatalogBase::new())
+        Self(MemoryResidentCatalog::new())
     }
 
     /// Load a single `.csv` or `.csv.gz` file; discards stars fainter than `mag_limit`.
     pub fn from_csv_file(path: impl AsRef<Path>, mag_limit: f64) -> Result<Self> {
-        Ok(Self(GaiaCatalogBase::<Dr3>::from_csv_file(
+        Ok(Self(MemoryResidentCatalog::<Dr3>::from_csv_file(
             path, mag_limit,
         )?))
     }
@@ -30,31 +31,28 @@ impl Dr3Catalog {
     /// excerpt directory (one produced by
     /// `gaia-excerpt --shard-by healpix`).
     ///
-    /// See [`GaiaCatalogBase::from_excerpt_dir_for_cone`] for the algorithm
-    /// (cdshealpix cone coverage + per-row dot-product post-filter for an
-    /// exact cone). Errors out if the directory's manifest does not record
-    /// a HEALPix sharder.
+    /// Convenience over [`LazyLoadingCatalog::open`] +
+    /// [`GaiaCatalog::materialize_cone`]; reach for the lazy variant
+    /// directly if you want streaming access or plan to issue more than
+    /// one cone query against the same directory.
     pub fn from_excerpt_dir_for_cone(
         excerpt_dir: impl AsRef<Path>,
         cone: Cone,
         mag_limit: f64,
     ) -> Result<Self> {
-        Ok(Self(GaiaCatalogBase::<Dr3>::from_excerpt_dir_for_cone(
-            excerpt_dir,
-            cone,
-            mag_limit,
-        )?))
+        let lazy = LazyLoadingCatalog::<Dr3>::open(excerpt_dir)?;
+        Ok(Self(lazy.materialize_cone(cone, mag_limit)?))
     }
 
-    pub fn inner(&self) -> &GaiaCatalogBase<Dr3> {
+    pub fn inner(&self) -> &MemoryResidentCatalog<Dr3> {
         &self.0
     }
 
-    pub fn inner_mut(&mut self) -> &mut GaiaCatalogBase<Dr3> {
+    pub fn inner_mut(&mut self) -> &mut MemoryResidentCatalog<Dr3> {
         &mut self.0
     }
 
-    pub fn into_inner(self) -> GaiaCatalogBase<Dr3> {
+    pub fn into_inner(self) -> MemoryResidentCatalog<Dr3> {
         self.0
     }
 
@@ -102,9 +100,19 @@ impl Default for Dr3Catalog {
 }
 
 impl std::ops::Deref for Dr3Catalog {
-    type Target = GaiaCatalogBase<Dr3>;
+    type Target = MemoryResidentCatalog<Dr3>;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl GaiaCatalog<Dr3> for Dr3Catalog {
+    fn entries_in_cone<'a>(
+        &'a self,
+        cone: Cone,
+        mag_limit: f64,
+    ) -> Result<Box<dyn Iterator<Item = Result<Dr3Entry>> + 'a>> {
+        self.0.entries_in_cone(cone, mag_limit)
     }
 }
 

--- a/crates/gaia/src/dr3/catalog.rs
+++ b/crates/gaia/src/dr3/catalog.rs
@@ -114,6 +114,10 @@ impl GaiaCatalog<Dr3> for Dr3Catalog {
     ) -> Result<Box<dyn Iterator<Item = Result<Dr3Entry>> + 'a>> {
         self.0.entries_in_cone(cone, mag_limit)
     }
+
+    fn len(&self) -> u64 {
+        <_ as GaiaCatalog<Dr3>>::len(&self.0)
+    }
 }
 
 // -- Download conveniences --------------------------------------------------

--- a/crates/gaia/src/excerpt.rs
+++ b/crates/gaia/src/excerpt.rs
@@ -741,3 +741,70 @@ fn filename_of(path: &Path) -> Result<String> {
             ))
         })
 }
+
+// =====================================================================================
+// Excerpt directory reader (companion to ShardedCsvWriter)
+// =====================================================================================
+
+/// Read-side handle to a directory written by [`ShardedCsvWriter`].
+///
+/// Pairs the on-disk [`Manifest`] with knowledge of the shard filename
+/// scheme so callers can map shard indices ↔ files without hardcoding
+/// the `shard_NNNNN.csv.gz` pattern.
+#[derive(Debug, Clone)]
+pub struct ExcerptDir {
+    pub dir: PathBuf,
+    pub manifest: Manifest,
+}
+
+impl ExcerptDir {
+    /// Open an excerpt directory. Errors if no manifest is found.
+    pub fn open(dir: impl AsRef<Path>) -> Result<Self> {
+        let dir = dir.as_ref().to_path_buf();
+        let manifest = Manifest::try_load(&dir)?.ok_or_else(|| {
+            StarfieldError::DataError(format!(
+                "no excerpt manifest at {} (directory may not be a gaia-excerpt output)",
+                dir.display()
+            ))
+        })?;
+        Ok(Self { dir, manifest })
+    }
+
+    /// HEALPix depth used when the directory was sharded by HEALPix; `None`
+    /// for hash / id-range / custom sharders.
+    pub fn healpix_level(&self) -> Option<u8> {
+        if self.manifest.sharder.kind == "healpix" {
+            self.manifest.sharder.healpix_level
+        } else {
+            None
+        }
+    }
+
+    /// Total number of shard buckets recorded in the manifest. For HEALPix this
+    /// is `12 · 4^level`; not every shard necessarily has a file on disk.
+    pub fn num_shards(&self) -> u32 {
+        self.manifest.sharder.num_shards
+    }
+
+    /// Path to shard file `index`, regardless of whether it exists on disk
+    /// (empty cells leave no file behind).
+    pub fn shard_path(&self, index: u32) -> PathBuf {
+        let width = digits_for(self.num_shards());
+        self.dir
+            .join(format!("shard_{:0width$}.csv.gz", index, width = width))
+    }
+
+    /// Like [`shard_path`](Self::shard_path) but returns `None` when the file
+    /// does not exist on disk (i.e. that bucket has no rows).
+    pub fn existing_shard_path(&self, index: u32) -> Option<PathBuf> {
+        let p = self.shard_path(index);
+        p.exists().then_some(p)
+    }
+
+    /// Existing shard files (in shard-index order). Empty buckets are skipped.
+    pub fn existing_shard_paths(&self) -> Vec<PathBuf> {
+        (0..self.num_shards())
+            .filter_map(|i| self.existing_shard_path(i))
+            .collect()
+    }
+}

--- a/crates/gaia/src/lib.rs
+++ b/crates/gaia/src/lib.rs
@@ -37,7 +37,7 @@ pub mod dr2;
 #[cfg(feature = "dr3")]
 pub mod dr3;
 
-pub use common::{GaiaCatalogBase, GaiaCore, GaiaRelease, GaiaSource, Release, VarFlag};
+pub use common::{Cone, GaiaCatalogBase, GaiaCore, GaiaRelease, GaiaSource, Release, VarFlag};
 pub use download::Downloader;
 
 #[cfg(feature = "dr1")]

--- a/crates/gaia/src/lib.rs
+++ b/crates/gaia/src/lib.rs
@@ -37,7 +37,10 @@ pub mod dr2;
 #[cfg(feature = "dr3")]
 pub mod dr3;
 
-pub use common::{Cone, GaiaCatalogBase, GaiaCore, GaiaRelease, GaiaSource, Release, VarFlag};
+pub use common::{
+    Cone, GaiaCatalog, GaiaCore, GaiaRelease, GaiaSource, LazyLoadingCatalog,
+    MemoryResidentCatalog, Release, VarFlag,
+};
 pub use download::Downloader;
 
 #[cfg(feature = "dr1")]

--- a/crates/gaia/tests/dr3_excerpt_cone.rs
+++ b/crates/gaia/tests/dr3_excerpt_cone.rs
@@ -300,7 +300,10 @@ fn cone_loader_errors_on_missing_dir() {
 /// the rows it produces. Used by the trait-level tests below.
 fn cone_count_via_trait(cat: &dyn GaiaCatalog<Dr3>, cone: Cone, mag_limit: f64) -> usize {
     let mut n = 0;
-    for row in cat.entries_in_cone(cone, mag_limit).expect("entries_in_cone") {
+    for row in cat
+        .entries_in_cone(cone, mag_limit)
+        .expect("entries_in_cone")
+    {
         let _ = row.expect("row");
         n += 1;
     }
@@ -400,6 +403,53 @@ fn materialize_cone_round_trips_through_lazy() {
     let ids: std::collections::HashSet<u64> =
         materialized.stars().map(|s| s.core.source_id).collect();
     assert_eq!(ids, inside_ids);
+}
+
+#[test]
+fn lazy_len_reads_from_manifest() {
+    // Build a fixture with 60 rows, ingest with the healpix sharder, then
+    // assert `LazyLoadingCatalog::len()` returns 60 from the manifest
+    // without us having to scan any shard files.
+    let (fixture, _ids) = fixture_with_cone(40, 20, 100.0, 25.0, 0.5);
+    let out = tempfile::tempdir().unwrap();
+    excerpt_csv_file::<Dr3, _, _>(
+        fixture.path(),
+        f64::INFINITY,
+        out.path(),
+        HealpixShard { level: 3 },
+        |_| true,
+    )
+    .unwrap();
+    let lazy = LazyLoadingCatalog::<Dr3>::open(out.path()).unwrap();
+    assert_eq!(<_ as GaiaCatalog<Dr3>>::len(&lazy), 60);
+    assert!(!<_ as GaiaCatalog<Dr3>>::is_empty(&lazy));
+}
+
+#[test]
+fn memory_resident_len_matches_hashmap_size() {
+    let (fixture, _ids) = fixture_with_cone(15, 35, 50.0, -15.0, 0.5);
+    let mem: MemoryResidentCatalog<Dr3> =
+        MemoryResidentCatalog::from_csv_file(fixture.path(), f64::INFINITY).unwrap();
+    assert_eq!(<_ as GaiaCatalog<Dr3>>::len(&mem), 50);
+}
+
+#[test]
+fn empty_lazy_dir_is_empty() {
+    // No input files committed → manifest.kept_rows == 0.
+    let out = tempfile::tempdir().unwrap();
+    // Initialize an empty manifest by opening + immediately finishing a writer.
+    use starfield_gaia::excerpt::ShardedCsvWriter;
+    let writer = ShardedCsvWriter::<Dr3, _>::new_or_resume(
+        out.path(),
+        HealpixShard { level: 3 },
+        f64::INFINITY,
+    )
+    .unwrap();
+    let _ = writer.finish().unwrap();
+
+    let lazy = LazyLoadingCatalog::<Dr3>::open(out.path()).unwrap();
+    assert_eq!(<_ as GaiaCatalog<Dr3>>::len(&lazy), 0);
+    assert!(<_ as GaiaCatalog<Dr3>>::is_empty(&lazy));
 }
 
 #[test]

--- a/crates/gaia/tests/dr3_excerpt_cone.rs
+++ b/crates/gaia/tests/dr3_excerpt_cone.rs
@@ -1,0 +1,251 @@
+//! End-to-end test for the cone-search loader: build a HEALPix-sharded
+//! excerpt directory from a synthetic fixture, then call
+//! `Dr3Catalog::from_excerpt_dir_for_cone` and check that the returned
+//! catalog contains exactly the stars inside the cone (no false negatives,
+//! no false positives because the loader post-filters HEALPix's
+//! conservative covering).
+#![cfg(feature = "dr3")]
+
+use std::collections::HashMap;
+use std::io::Write;
+
+use starfield::catalogs::StarCatalog;
+use starfield_gaia::excerpt::{excerpt_csv_file, HashIdShard, HealpixShard};
+use starfield_gaia::{Cone, Dr3, Dr3Catalog};
+
+const HEADER: &str = "source_id,solution_id,ref_epoch,random_index,designation,ra,ra_error,dec,dec_error,ra_dec_corr,parallax,parallax_error,parallax_over_error,pm,pmra,pmra_error,pmdec,pmdec_error,l,b,ecl_lon,ecl_lat,phot_g_mean_mag,phot_g_mean_flux,phot_g_mean_flux_error,phot_g_n_obs,phot_variable_flag,astrometric_n_obs_al,astrometric_excess_noise,astrometric_excess_noise_sig,astrometric_primary_flag,duplicated_source,matched_observations,astrometric_n_good_obs_al,astrometric_n_bad_obs_al,astrometric_gof_al,astrometric_chi2_al,astrometric_params_solved,visibility_periods_used,astrometric_sigma5d_max,nu_eff_used_in_astrometry,pseudocolour,pseudocolour_error,ruwe,ipd_gof_harmonic_amplitude,ipd_gof_harmonic_phase,ipd_frac_multi_peak,ipd_frac_odd_win,phot_bp_mean_mag,phot_bp_mean_flux,phot_bp_mean_flux_error,phot_bp_n_obs,phot_rp_mean_mag,phot_rp_mean_flux,phot_rp_mean_flux_error,phot_rp_n_obs,bp_rp,bp_g,g_rp,phot_bp_rp_excess_factor,phot_proc_mode,radial_velocity,radial_velocity_error,rv_method_used,rv_nb_transits,rv_expected_sig_to_noise,rv_amplitude_robust,rv_template_teff,rv_template_logg,rv_template_fe_h,rv_atm_param_origin,teff_gspphot,teff_gspphot_lower,teff_gspphot_upper,logg_gspphot,mh_gspphot,distance_gspphot,distance_gspphot_lower,distance_gspphot_upper,azero_gspphot,ag_gspphot,ebpminrp_gspphot,libname_gspphot,has_xp_continuous,has_xp_sampled,has_rvs,has_epoch_photometry,has_epoch_rv,has_mcmc_gspphot,has_mcmc_msc,in_qso_candidates,in_galaxy_candidates,in_andromeda_survey,non_single_star,classprob_dsc_combmod_quasar,classprob_dsc_combmod_galaxy,classprob_dsc_combmod_star";
+
+fn row_from(overrides: &HashMap<&str, &str>) -> String {
+    HEADER
+        .split(',')
+        .map(|c| overrides.get(c).copied().unwrap_or(""))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+/// Write a row with the given source_id / RA / Dec / mag.
+fn write_row(file: &mut tempfile::NamedTempFile, id: u64, ra_deg: f64, dec_deg: f64, mag: f64) {
+    let row = row_from(&HashMap::from([
+        ("source_id", id.to_string().as_str()),
+        ("solution_id", "1635721458409799680"),
+        ("ref_epoch", "2016.0"),
+        ("ra", ra_deg.to_string().as_str()),
+        ("ra_error", "0.04"),
+        ("dec", dec_deg.to_string().as_str()),
+        ("dec_error", "0.04"),
+        ("l", "0.0"),
+        ("b", "0.0"),
+        ("ecl_lon", "0.0"),
+        ("ecl_lat", "0.0"),
+        ("phot_g_mean_mag", mag.to_string().as_str()),
+        ("phot_variable_flag", "NOT_AVAILABLE"),
+    ]));
+    writeln!(file, "{}", row).unwrap();
+}
+
+/// Returns (fixture_file, set_of_inside_ids) for a fixture with `inside`
+/// stars packed within `inside_radius_deg` of (`centre_ra`, `centre_dec`)
+/// and `outside` stars sprinkled across the sphere far from the centre.
+/// The `id` for inside stars uses the high bit so callers can partition
+/// results without keeping the full set.
+fn fixture_with_cone(
+    inside: usize,
+    outside: usize,
+    centre_ra: f64,
+    centre_dec: f64,
+    inside_radius_deg: f64,
+) -> (tempfile::NamedTempFile, std::collections::HashSet<u64>) {
+    const INSIDE_BIT: u64 = 1 << 62;
+    let mut f = tempfile::Builder::new().suffix(".csv").tempfile().unwrap();
+    writeln!(f, "{}", HEADER).unwrap();
+    let mut inside_ids = std::collections::HashSet::new();
+
+    // Inside cone: place each star at a small offset from the centre by
+    // shifting RA only — keeps the math trivial and makes intent obvious.
+    // For dec ≈ -30 the cosine-correction is significant, so the test
+    // exercises the great-circle distance path rather than naive
+    // angular coordinates.
+    for i in 0..inside {
+        let id = INSIDE_BIT | (i as u64);
+        let frac = (i as f64) / (inside.max(1) as f64); // 0..1
+        let dra = (frac - 0.5) * 2.0 * (inside_radius_deg * 0.5);
+        // Project the RA offset through the cosine of dec so the actual
+        // angular separation is dra * cos(dec).
+        let ra = (centre_ra + dra / centre_dec.to_radians().cos()).rem_euclid(360.0);
+        write_row(&mut f, id, ra, centre_dec, 10.0);
+        inside_ids.insert(id);
+    }
+
+    // Outside cone: scatter on the opposite hemisphere so distance from
+    // centre is always > 90°.
+    let opp_ra = (centre_ra + 180.0).rem_euclid(360.0);
+    let opp_dec = -centre_dec;
+    for i in 0..outside {
+        let id = i as u64; // no INSIDE_BIT
+        let frac = (i as f64) / (outside.max(1) as f64);
+        let ra = (opp_ra + (frac - 0.5) * 60.0).rem_euclid(360.0);
+        let dec = (opp_dec + (frac - 0.5) * 30.0).clamp(-89.0, 89.0);
+        write_row(&mut f, id, ra, dec, 10.0);
+    }
+
+    f.flush().unwrap();
+    (f, inside_ids)
+}
+
+#[test]
+fn cone_loader_returns_only_inside_stars() {
+    let centre_ra = 120.0;
+    let centre_dec = -30.0;
+    let inside_radius = 0.5; // deg — well inside one HEALPix-3 cell (~14.7°)
+
+    let (fixture, inside_ids) = fixture_with_cone(50, 200, centre_ra, centre_dec, inside_radius);
+    let out = tempfile::tempdir().unwrap();
+    excerpt_csv_file::<Dr3, _, _>(
+        fixture.path(),
+        f64::INFINITY,
+        out.path(),
+        HealpixShard { level: 3 },
+        |_| true,
+    )
+    .expect("excerpt");
+
+    // Ask for the cone — radius generous enough to include every "inside"
+    // star but small enough that no opposite-hemisphere "outside" star
+    // could possibly land in the result.
+    let cone = Cone::from_degrees(centre_ra, centre_dec, inside_radius * 2.0);
+    let cat =
+        Dr3Catalog::from_excerpt_dir_for_cone(out.path(), cone, f64::INFINITY).expect("cone load");
+
+    let returned: std::collections::HashSet<u64> = cat.stars().map(|s| s.core.source_id).collect();
+    assert_eq!(returned.len(), inside_ids.len(), "wrong row count");
+    assert_eq!(returned, inside_ids, "returned rows ≠ inside-cone rows");
+}
+
+#[test]
+fn cone_loader_post_filter_drops_boundary_cell_rows() {
+    // HEALPix gives a *conservative* covering: cells at the boundary of
+    // the cone include stars outside the cone. Those must be dropped.
+    // Construct a tight fixture with stars right at the edge of a level-3
+    // cell so the covering pulls the whole cell, then verify the loader
+    // drops the ones outside the requested radius.
+    let centre_ra = 0.0;
+    let centre_dec = 0.0;
+    // Place stars on a 3°-wide ring; with a 0.5° cone, only the ones
+    // within 0.5° of centre should be returned.
+    let mut f = tempfile::Builder::new().suffix(".csv").tempfile().unwrap();
+    writeln!(f, "{}", HEADER).unwrap();
+    for i in 0..200u64 {
+        let theta = (i as f64) * std::f64::consts::TAU / 200.0;
+        let r = 0.1 + (i as f64 / 200.0) * 3.0; // 0.1° → 3.1°
+        let ra = (centre_ra + r * theta.cos()).rem_euclid(360.0);
+        let dec = (centre_dec + r * theta.sin()).clamp(-89.0, 89.0);
+        write_row(&mut f, i, ra, dec, 10.0);
+    }
+    f.flush().unwrap();
+
+    let out = tempfile::tempdir().unwrap();
+    excerpt_csv_file::<Dr3, _, _>(
+        f.path(),
+        f64::INFINITY,
+        out.path(),
+        HealpixShard { level: 3 },
+        |_| true,
+    )
+    .expect("excerpt");
+
+    let cone = Cone::from_degrees(centre_ra, centre_dec, 0.5);
+    let cat =
+        Dr3Catalog::from_excerpt_dir_for_cone(out.path(), cone, f64::INFINITY).expect("cone load");
+
+    // Brute-force ground truth from the same fixture.
+    let truth = Dr3Catalog::from_csv_file(f.path(), f64::INFINITY).unwrap();
+    let truth_inside: std::collections::HashSet<u64> = truth
+        .stars()
+        .filter(|s| cone.contains_radec_deg(s.core.ra, s.core.dec))
+        .map(|s| s.core.source_id)
+        .collect();
+    let returned: std::collections::HashSet<u64> = cat.stars().map(|s| s.core.source_id).collect();
+    assert_eq!(returned, truth_inside, "post-filter mismatch");
+}
+
+#[test]
+fn cone_loader_honours_mag_limit() {
+    // Build a fixture with 50 stars at mag 8 (bright) and 50 at mag 18
+    // (faint), all inside the cone. Loading with mag_limit=10 should
+    // return only the 50 bright ones.
+    let centre_ra = 200.0;
+    let centre_dec = 45.0;
+    let mut f = tempfile::Builder::new().suffix(".csv").tempfile().unwrap();
+    writeln!(f, "{}", HEADER).unwrap();
+    for i in 0..50u64 {
+        let ra = centre_ra + 0.01 * (i as f64);
+        write_row(&mut f, i, ra, centre_dec, 8.0);
+    }
+    for i in 50..100u64 {
+        let ra = centre_ra + 0.01 * (i as f64);
+        write_row(&mut f, i, ra, centre_dec, 18.0);
+    }
+    f.flush().unwrap();
+
+    let out = tempfile::tempdir().unwrap();
+    excerpt_csv_file::<Dr3, _, _>(
+        f.path(),
+        f64::INFINITY,
+        out.path(),
+        HealpixShard { level: 3 },
+        |_| true,
+    )
+    .expect("excerpt");
+
+    let cone = Cone::from_degrees(centre_ra, centre_dec, 5.0);
+    let cat = Dr3Catalog::from_excerpt_dir_for_cone(out.path(), cone, 10.0).expect("cone load");
+    assert_eq!(cat.len(), 50, "mag_limit=10 should drop the mag-18 cohort");
+}
+
+#[test]
+fn cone_loader_rejects_non_healpix_dir() {
+    // Hash-sharded dir has no spatial coherence; the loader must refuse it.
+    let mut f = tempfile::Builder::new().suffix(".csv").tempfile().unwrap();
+    writeln!(f, "{}", HEADER).unwrap();
+    for i in 0..20u64 {
+        write_row(&mut f, i, 10.0, 20.0, 10.0);
+    }
+    f.flush().unwrap();
+
+    let out = tempfile::tempdir().unwrap();
+    excerpt_csv_file::<Dr3, _, _>(
+        f.path(),
+        f64::INFINITY,
+        out.path(),
+        HashIdShard { num_shards: 4 },
+        |_| true,
+    )
+    .expect("excerpt");
+
+    let cone = Cone::from_degrees(10.0, 20.0, 5.0);
+    let err = Dr3Catalog::from_excerpt_dir_for_cone(out.path(), cone, f64::INFINITY)
+        .expect_err("should refuse non-healpix dir");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("HEALPix") || msg.contains("healpix"),
+        "error should mention HEALPix requirement, got: {}",
+        msg
+    );
+}
+
+#[test]
+fn cone_loader_errors_on_missing_dir() {
+    let cone = Cone::from_degrees(0.0, 0.0, 1.0);
+    let err = Dr3Catalog::from_excerpt_dir_for_cone(
+        "/this/path/does/not/exist/excerpt-dir",
+        cone,
+        f64::INFINITY,
+    )
+    .expect_err("should error on missing manifest");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("manifest") || msg.contains("excerpt"),
+        "error should mention missing manifest, got: {}",
+        msg
+    );
+}

--- a/crates/gaia/tests/dr3_excerpt_cone.rs
+++ b/crates/gaia/tests/dr3_excerpt_cone.rs
@@ -11,7 +11,9 @@ use std::io::Write;
 
 use starfield::catalogs::StarCatalog;
 use starfield_gaia::excerpt::{excerpt_csv_file, HashIdShard, HealpixShard};
-use starfield_gaia::{Cone, Dr3, Dr3Catalog};
+use starfield_gaia::{
+    Cone, Dr3, Dr3Catalog, GaiaCatalog, LazyLoadingCatalog, MemoryResidentCatalog,
+};
 
 const HEADER: &str = "source_id,solution_id,ref_epoch,random_index,designation,ra,ra_error,dec,dec_error,ra_dec_corr,parallax,parallax_error,parallax_over_error,pm,pmra,pmra_error,pmdec,pmdec_error,l,b,ecl_lon,ecl_lat,phot_g_mean_mag,phot_g_mean_flux,phot_g_mean_flux_error,phot_g_n_obs,phot_variable_flag,astrometric_n_obs_al,astrometric_excess_noise,astrometric_excess_noise_sig,astrometric_primary_flag,duplicated_source,matched_observations,astrometric_n_good_obs_al,astrometric_n_bad_obs_al,astrometric_gof_al,astrometric_chi2_al,astrometric_params_solved,visibility_periods_used,astrometric_sigma5d_max,nu_eff_used_in_astrometry,pseudocolour,pseudocolour_error,ruwe,ipd_gof_harmonic_amplitude,ipd_gof_harmonic_phase,ipd_frac_multi_peak,ipd_frac_odd_win,phot_bp_mean_mag,phot_bp_mean_flux,phot_bp_mean_flux_error,phot_bp_n_obs,phot_rp_mean_mag,phot_rp_mean_flux,phot_rp_mean_flux_error,phot_rp_n_obs,bp_rp,bp_g,g_rp,phot_bp_rp_excess_factor,phot_proc_mode,radial_velocity,radial_velocity_error,rv_method_used,rv_nb_transits,rv_expected_sig_to_noise,rv_amplitude_robust,rv_template_teff,rv_template_logg,rv_template_fe_h,rv_atm_param_origin,teff_gspphot,teff_gspphot_lower,teff_gspphot_upper,logg_gspphot,mh_gspphot,distance_gspphot,distance_gspphot_lower,distance_gspphot_upper,azero_gspphot,ag_gspphot,ebpminrp_gspphot,libname_gspphot,has_xp_continuous,has_xp_sampled,has_rvs,has_epoch_photometry,has_epoch_rv,has_mcmc_gspphot,has_mcmc_msc,in_qso_candidates,in_galaxy_candidates,in_andromeda_survey,non_single_star,classprob_dsc_combmod_quasar,classprob_dsc_combmod_galaxy,classprob_dsc_combmod_star";
 
@@ -284,6 +286,151 @@ fn cone_loader_errors_on_missing_dir() {
     assert!(
         msg.contains("manifest") || msg.contains("excerpt"),
         "error should mention missing manifest, got: {}",
+        msg
+    );
+}
+
+// ====================================================================
+// Trait-level coverage: same fixture, exercised through both
+// implementations of `GaiaCatalog<Dr3>` to confirm callers can hold a
+// `&dyn GaiaCatalog<Dr3>` and swap backends.
+// ====================================================================
+
+/// Run the same cone query through `&dyn GaiaCatalog<Dr3>` and count
+/// the rows it produces. Used by the trait-level tests below.
+fn cone_count_via_trait(cat: &dyn GaiaCatalog<Dr3>, cone: Cone, mag_limit: f64) -> usize {
+    let mut n = 0;
+    for row in cat.entries_in_cone(cone, mag_limit).expect("entries_in_cone") {
+        let _ = row.expect("row");
+        n += 1;
+    }
+    n
+}
+
+#[test]
+fn lazy_loading_streams_entries_without_full_materialization() {
+    // Build a fixture with 30 inside / 70 outside, shard healpix-3, then
+    // open the dir as a LazyLoadingCatalog and stream the cone — no
+    // materialization, just count.
+    let centre_ra = 80.0;
+    let centre_dec = -10.0;
+    let (fixture, inside_ids) = fixture_with_cone(30, 70, centre_ra, centre_dec, 0.5);
+    let out = tempfile::tempdir().unwrap();
+    excerpt_csv_file::<Dr3, _, _>(
+        fixture.path(),
+        f64::INFINITY,
+        out.path(),
+        HealpixShard { level: 3 },
+        |_| true,
+    )
+    .unwrap();
+
+    let lazy = LazyLoadingCatalog::<Dr3>::open(out.path()).expect("open lazy");
+    let cone = Cone::from_degrees(centre_ra, centre_dec, 1.0);
+    let returned: std::collections::HashSet<u64> = lazy
+        .entries_in_cone(cone, f64::INFINITY)
+        .unwrap()
+        .map(|r| r.unwrap().core.source_id)
+        .collect();
+    assert_eq!(returned, inside_ids);
+}
+
+#[test]
+fn memory_resident_and_lazy_agree_on_same_cone() {
+    // Same fixture, same cone, two backends — the result sets must be
+    // identical (modulo ordering, hence the HashSet compare).
+    let centre_ra = 12.3;
+    let centre_dec = 45.6;
+    let (fixture, _inside_ids) = fixture_with_cone(40, 80, centre_ra, centre_dec, 0.5);
+    let out = tempfile::tempdir().unwrap();
+    excerpt_csv_file::<Dr3, _, _>(
+        fixture.path(),
+        f64::INFINITY,
+        out.path(),
+        HealpixShard { level: 3 },
+        |_| true,
+    )
+    .unwrap();
+
+    let mem: MemoryResidentCatalog<Dr3> =
+        MemoryResidentCatalog::from_csv_file(fixture.path(), f64::INFINITY).unwrap();
+    let lazy = LazyLoadingCatalog::<Dr3>::open(out.path()).unwrap();
+
+    let cone = Cone::from_degrees(centre_ra, centre_dec, 1.0);
+    let mem_ids: std::collections::HashSet<u64> = (&mem as &dyn GaiaCatalog<Dr3>)
+        .entries_in_cone(cone, f64::INFINITY)
+        .unwrap()
+        .map(|r| r.unwrap().core.source_id)
+        .collect();
+    let lazy_ids: std::collections::HashSet<u64> = (&lazy as &dyn GaiaCatalog<Dr3>)
+        .entries_in_cone(cone, f64::INFINITY)
+        .unwrap()
+        .map(|r| r.unwrap().core.source_id)
+        .collect();
+
+    assert_eq!(mem_ids, lazy_ids);
+    // And both agree with the trait-object count helper.
+    assert_eq!(
+        cone_count_via_trait(&mem, cone, f64::INFINITY),
+        cone_count_via_trait(&lazy, cone, f64::INFINITY)
+    );
+}
+
+#[test]
+fn materialize_cone_round_trips_through_lazy() {
+    // `materialize_cone` is the trait default that drains the iterator
+    // into a MemoryResidentCatalog. Verify it returns the same set as the
+    // direct iterator.
+    let centre_ra = 250.0;
+    let centre_dec = 12.0;
+    let (fixture, inside_ids) = fixture_with_cone(25, 75, centre_ra, centre_dec, 0.5);
+    let out = tempfile::tempdir().unwrap();
+    excerpt_csv_file::<Dr3, _, _>(
+        fixture.path(),
+        f64::INFINITY,
+        out.path(),
+        HealpixShard { level: 3 },
+        |_| true,
+    )
+    .unwrap();
+
+    let lazy = LazyLoadingCatalog::<Dr3>::open(out.path()).unwrap();
+    let cone = Cone::from_degrees(centre_ra, centre_dec, 1.0);
+    let materialized = lazy.materialize_cone(cone, f64::INFINITY).unwrap();
+    let ids: std::collections::HashSet<u64> =
+        materialized.stars().map(|s| s.core.source_id).collect();
+    assert_eq!(ids, inside_ids);
+}
+
+#[test]
+fn lazy_open_validates_release() {
+    // A manifest written by a Dr2 run shouldn't open as a LazyLoadingCatalog<Dr3>.
+    let out = tempfile::tempdir().unwrap();
+    let manifest = serde_json::json!({
+        "version": 1,
+        "release": "Dr2",
+        "mag_limit": 20.0,
+        "sharder": {
+            "kind": "healpix",
+            "num_shards": 12_288,
+            "healpix_level": 5,
+        },
+        "shard_sizes": vec![0u64; 12_288],
+        "shard_rows": vec![0u64; 12_288],
+        "processed_files": Vec::<String>::new(),
+        "kept_rows": 0,
+    });
+    std::fs::write(
+        out.path().join(".gaia-excerpt-manifest.json"),
+        serde_json::to_vec_pretty(&manifest).unwrap(),
+    )
+    .unwrap();
+
+    let err = LazyLoadingCatalog::<Dr3>::open(out.path()).expect_err("release mismatch");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Dr2") && msg.contains("Dr3"),
+        "error should name both releases, got: {}",
         msg
     );
 }

--- a/crates/gaia/tests/dr3_excerpt_cone.rs
+++ b/crates/gaia/tests/dr3_excerpt_cone.rs
@@ -234,6 +234,44 @@ fn cone_loader_rejects_non_healpix_dir() {
 }
 
 #[test]
+fn cone_loader_rejects_mod_collapsed_healpix_dir() {
+    // A pre-PR-#42 mod-collapsed dir claims kind="healpix" but has
+    // num_shards < cell_count(level) — the loader would otherwise silently
+    // skip ~99% of the cone's cells. Forge such a manifest and check the
+    // loader bails with a clear message.
+    let out = tempfile::tempdir().unwrap();
+    let manifest = serde_json::json!({
+        "version": 1,
+        "release": "Dr3",
+        "mag_limit": 20.0,
+        "sharder": {
+            "kind": "healpix",
+            "num_shards": 128,
+            "healpix_level": 5,
+        },
+        "shard_sizes": vec![0u64; 128],
+        "shard_rows": vec![0u64; 128],
+        "processed_files": Vec::<String>::new(),
+        "kept_rows": 0,
+    });
+    std::fs::write(
+        out.path().join(".gaia-excerpt-manifest.json"),
+        serde_json::to_vec_pretty(&manifest).unwrap(),
+    )
+    .unwrap();
+
+    let cone = Cone::from_degrees(0.0, 0.0, 1.0);
+    let err = Dr3Catalog::from_excerpt_dir_for_cone(out.path(), cone, f64::INFINITY)
+        .expect_err("should refuse mod-collapsed healpix dir");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("one-file-per-cell") || msg.contains("mod-collapsed"),
+        "error should explain mod-collapsed layout, got: {}",
+        msg
+    );
+}
+
+#[test]
 fn cone_loader_errors_on_missing_dir() {
     let cone = Cone::from_degrees(0.0, 0.0, 1.0);
     let err = Dr3Catalog::from_excerpt_dir_for_cone(


### PR DESCRIPTION
## Summary

Adds a `GaiaCatalog<R>` trait with two interchangeable backends — `MemoryResidentCatalog<R>` (in-memory, today's storage) and `LazyLoadingCatalog<R>` (on-disk, reads only the HEALPix cells a cone touches). Downstream consumers (e.g. focalplane `motion_simulator`) hold a `Box<dyn GaiaCatalog<Dr3>>` and don't care which backend is on the other end.

Closes the upstream gap from focalplane #74's shim.

## Trait surface

```rust
pub trait GaiaCatalog<R: GaiaRelease> {
    fn entries_in_cone<'a>(
        &'a self, cone: Cone, mag_limit: f64,
    ) -> Result<Box<dyn Iterator<Item = Result<R::Entry>> + 'a>>;

    // Default: drains the iterator into a MemoryResidentCatalog<R>.
    fn materialize_cone(&self, cone: Cone, mag_limit: f64) -> Result<MemoryResidentCatalog<R>>;
}
```

`Box<dyn Iterator>` (rather than RPITIT) keeps the trait object-safe — losing `dyn GaiaCatalog<Dr3>` would defeat the whole point.

## Backends

- **`MemoryResidentCatalog<R>`** — rename of the historical `GaiaCatalogBase<R>`. HashMap keyed by `source_id`. Trait impl filters the in-memory map and clones matching entries.
- **`LazyLoadingCatalog<R>`** — wraps an `ExcerptDir`. `open` validates the manifest matches `R::RELEASE` and is HEALPix one-file-per-cell, so failures surface before the first query. Each `entries_in_cone` call computes the cone-coverage cells via `cdshealpix::nested::cone_coverage_approx_flat`, opens only the existing shard files, and post-filters by exact great-circle distance. **No in-memory cache** — repeat queries pay the parse cost again. (LRU is a future revision.)

## Other pieces in this PR

- **`common::cone::Cone`** — spherical-cap helper with precomputed centre unit vector + `cos(radius)`. `gaia-tools --cone` switched to this helper.
- **`excerpt::ExcerptDir`** — read-side companion to `ShardedCsvWriter`. Wraps the on-disk manifest and translates shard indices to file paths.
- **Per-DR newtypes** (`Dr1Catalog` / `Dr2Catalog` / `Dr3Catalog`) gain forwarding `GaiaCatalog<DrN>` impls so they're usable as trait objects, and their `from_excerpt_dir_for_cone` constructors become one-liners that run a `LazyLoadingCatalog` through `materialize_cone`.
- **`R::Entry: Clone`** — added to the `GaiaRelease::Entry` bound (all three Entry types already derive it) so the trait can return owned entries without per-impl `where` clauses.

## Test plan

- [x] `cargo test --workspace` (10 tests in `dr3_excerpt_cone.rs`, all green)
- [x] `cargo clippy -p starfield-gaia --features all-releases --all-targets -- -D warnings`
- [x] `cargo clippy -p starfield-gaia-tools --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`

New tests cover:
- Both backends agree on the same cone (compared through `&dyn GaiaCatalog<Dr3>`)
- `LazyLoadingCatalog` streams without full materialization
- `materialize_cone` round-trips through the lazy backend
- Boundary-cell post-filter correctness (ground truth from brute-force scan)
- `mag_limit` honoured at load time
- Hash-sharded directory rejected with a clear error
- Pre-PR-#42 mod-collapsed healpix dir rejected with a clear "reshard with one-file-per-cell" message
- Release-mismatch validation: opening a Dr2 manifest as `LazyLoadingCatalog<Dr3>` errors out
- Missing-manifest directory errors out

## Breaking changes

- `GaiaCatalogBase<R>` → `MemoryResidentCatalog<R>` (rename; per-DR newtypes still exist and behave the same)
- `GaiaRelease::Entry` now bounded by `Clone`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
