### PR TITLE
gaia-catalog: LazyLoadingCatalog::entries_in_cell + cell_count

### DIFF
--- a/crates/gaia/src/common/lazy.rs
+++ b/crates/gaia/src/common/lazy.rs
@@ -97,6 +97,44 @@ impl<R: GaiaRelease> LazyLoadingCatalog<R> {
     pub fn healpix_level(&self) -> u8 {
         self.healpix_level
     }
+
+    /// Number of HEALPix cells in this directory's layout
+    /// (`12 · 4^level`). Cell ids run `0..cell_count()`.
+    pub fn cell_count(&self) -> u32 {
+        self.dir.num_shards()
+    }
+
+    /// Stream every entry in HEALPix cell `cell_id` whose
+    /// `phot_g_mean_mag <= mag_limit`. Returns an empty iterator when
+    /// the cell received no rows during ingest (no shard file on
+    /// disk).
+    ///
+    /// Use this to drive a cell-at-a-time index builder: the caller
+    /// iterates `0..cell_count()`, processes one cell's worth of
+    /// entries at a time, and never has to materialize the whole
+    /// catalog. Combined with the manifest's per-cell row count
+    /// (`ExcerptDir::manifest.shard_rows[cell_id]`), the caller can
+    /// pre-allocate exact-size buffers per cell.
+    ///
+    /// `cell_id >= cell_count()` returns `Err`.
+    pub fn entries_in_cell<'a>(
+        &'a self,
+        cell_id: u32,
+        mag_limit: f64,
+    ) -> Result<Box<dyn Iterator<Item = Result<R::Entry>> + 'a>> {
+        if cell_id >= self.cell_count() {
+            return Err(StarfieldError::DataError(format!(
+                "entries_in_cell: cell_id {} out of range (cell_count={})",
+                cell_id,
+                self.cell_count()
+            )));
+        }
+        let Some(path) = self.dir.existing_shard_path(cell_id) else {
+            return Ok(Box::new(std::iter::empty()));
+        };
+        let reader = CsvSourceReader::<R>::open(&path, mag_limit)?;
+        Ok(Box::new(reader))
+    }
 }
 
 impl<R: GaiaRelease> GaiaCatalog<R> for LazyLoadingCatalog<R> {

--- a/crates/gaia/tests/dr3_excerpt_cone.rs
+++ b/crates/gaia/tests/dr3_excerpt_cone.rs
@@ -484,3 +484,170 @@ fn lazy_open_validates_release() {
         msg
     );
 }
+
+// ====================================================================
+// Per-cell access: drives the cell-at-a-time iteration pattern needed
+// by downstream index builders (zodiacal#65). Empty cells return an
+// empty iterator (no I/O); out-of-range cell ids error.
+// ====================================================================
+
+#[test]
+fn entries_in_cell_returns_only_that_cell() {
+    // Build a fixture spread across the sky, ingest healpix-3 (768 cells),
+    // then iterate cells and check that the union of every cell's entries
+    // equals the whole catalog and no entry appears in more than one cell.
+    let (fixture, _ids) = fixture_with_cone(80, 120, 30.0, 10.0, 0.5);
+    let out = tempfile::tempdir().unwrap();
+    excerpt_csv_file::<Dr3, _, _>(
+        fixture.path(),
+        f64::INFINITY,
+        out.path(),
+        HealpixShard { level: 3 },
+        |_| true,
+    )
+    .unwrap();
+
+    let lazy = LazyLoadingCatalog::<Dr3>::open(out.path()).unwrap();
+    assert_eq!(lazy.cell_count(), 12 << (2 * 3)); // 768 for level-3
+
+    let mut union: std::collections::HashSet<u64> = std::collections::HashSet::new();
+    let mut total_via_cells = 0u64;
+    for cell in 0..lazy.cell_count() {
+        let cell_ids: Vec<u64> = lazy
+            .entries_in_cell(cell, f64::INFINITY)
+            .unwrap()
+            .map(|r| r.unwrap().core.source_id)
+            .collect();
+        for id in &cell_ids {
+            assert!(
+                union.insert(*id),
+                "id {} appeared in cell {} after already appearing in another cell",
+                id,
+                cell
+            );
+        }
+        total_via_cells += cell_ids.len() as u64;
+    }
+    // Every committed row should be accounted for exactly once.
+    assert_eq!(total_via_cells, <_ as GaiaCatalog<Dr3>>::len(&lazy));
+}
+
+#[test]
+fn entries_in_cell_empty_cell_yields_empty_iterator() {
+    // Single-row fixture forces all but one cell to be empty. Pick any
+    // cell other than the one we know got data and assert the iterator
+    // yields nothing.
+    let mut f = tempfile::Builder::new().suffix(".csv").tempfile().unwrap();
+    writeln!(f, "{}", HEADER).unwrap();
+    write_row(&mut f, 1, 0.0, 0.0, 10.0); // (ra=0, dec=0) lands in some level-3 cell
+    f.flush().unwrap();
+
+    let out = tempfile::tempdir().unwrap();
+    excerpt_csv_file::<Dr3, _, _>(
+        f.path(),
+        f64::INFINITY,
+        out.path(),
+        HealpixShard { level: 3 },
+        |_| true,
+    )
+    .unwrap();
+
+    let lazy = LazyLoadingCatalog::<Dr3>::open(out.path()).unwrap();
+    // Find the cell that got the row, then walk every other cell and
+    // confirm an empty iterator.
+    let occupied: u32 = (0..lazy.cell_count())
+        .find(|&c| {
+            lazy.entries_in_cell(c, f64::INFINITY)
+                .unwrap()
+                .next()
+                .is_some()
+        })
+        .expect("at least one cell got the row");
+    let mut empty_cells_checked = 0;
+    for cell in 0..lazy.cell_count() {
+        if cell == occupied {
+            continue;
+        }
+        let any = lazy
+            .entries_in_cell(cell, f64::INFINITY)
+            .unwrap()
+            .next()
+            .is_some();
+        assert!(!any, "cell {} unexpectedly returned a row", cell);
+        empty_cells_checked += 1;
+    }
+    assert_eq!(empty_cells_checked, lazy.cell_count() - 1);
+}
+
+#[test]
+fn entries_in_cell_rejects_out_of_range_id() {
+    // Empty fixture, but a level-3 layout still has 768 cells.
+    let mut f = tempfile::Builder::new().suffix(".csv").tempfile().unwrap();
+    writeln!(f, "{}", HEADER).unwrap();
+    write_row(&mut f, 1, 0.0, 0.0, 10.0);
+    f.flush().unwrap();
+    let out = tempfile::tempdir().unwrap();
+    excerpt_csv_file::<Dr3, _, _>(
+        f.path(),
+        f64::INFINITY,
+        out.path(),
+        HealpixShard { level: 3 },
+        |_| true,
+    )
+    .unwrap();
+
+    let lazy = LazyLoadingCatalog::<Dr3>::open(out.path()).unwrap();
+    let bad_id = lazy.cell_count(); // first invalid id
+                                    // `expect_err` would require `Debug` on the `Ok` variant — and
+                                    // `Box<dyn Iterator<...>>` doesn't impl `Debug` — so match instead.
+    match lazy.entries_in_cell(bad_id, f64::INFINITY) {
+        Ok(_) => panic!("out-of-range cell_id should error"),
+        Err(e) => assert!(
+            e.to_string().contains("out of range"),
+            "error should mention out of range, got: {}",
+            e
+        ),
+    };
+}
+
+#[test]
+fn entries_in_cell_honours_mag_limit() {
+    // Single cell with both bright and faint stars; mag_limit gates them.
+    let mut f = tempfile::Builder::new().suffix(".csv").tempfile().unwrap();
+    writeln!(f, "{}", HEADER).unwrap();
+    for i in 0..10u64 {
+        write_row(&mut f, i, 100.0, 30.0, 8.0);
+    }
+    for i in 10..20u64 {
+        write_row(&mut f, i, 100.001, 30.001, 18.0);
+    }
+    f.flush().unwrap();
+
+    let out = tempfile::tempdir().unwrap();
+    excerpt_csv_file::<Dr3, _, _>(
+        f.path(),
+        f64::INFINITY,
+        out.path(),
+        HealpixShard { level: 3 },
+        |_| true,
+    )
+    .unwrap();
+
+    let lazy = LazyLoadingCatalog::<Dr3>::open(out.path()).unwrap();
+    // Find the cell holding our 20 stars (they're all within ~0.001° of
+    // each other so they'll land together).
+    let occupied = (0..lazy.cell_count())
+        .find(|&c| {
+            lazy.entries_in_cell(c, f64::INFINITY)
+                .unwrap()
+                .next()
+                .is_some()
+        })
+        .unwrap();
+    let n_bright = lazy
+        .entries_in_cell(occupied, 10.0)
+        .unwrap()
+        .filter_map(|r| r.ok())
+        .count();
+    assert_eq!(n_bright, 10, "mag_limit=10 should drop the mag-18 cohort");
+}


### PR DESCRIPTION
## Summary

Two inherent methods on `LazyLoadingCatalog<R>` that downstream index builders need to drive a cell-at-a-time loop:

- `cell_count() -> u32` — number of HEALPix cells in the underlying directory's layout (`12 · 4^level`).
- `entries_in_cell(cell_id, mag_limit) -> Result<Box<dyn Iterator<Item = Result<R::Entry>>>>` — streams every entry in a single cell. Empty cells return an empty iterator (no I/O); out-of-range cell ids return `Err`.

Lets a consumer write:

```rust
let lazy = LazyLoadingCatalog::<Dr3>::open(excerpt_dir)?;
for cell in 0..lazy.cell_count() {
    for entry in lazy.entries_in_cell(cell, mag_limit)? {
        let entry = entry?;
        // process one cell's worth — memory bounded by the largest cell
    }
}
```

For the production DR3 mag-20 bycell excerpt (1.06B rows, 12,288 level-5 cells), this caps RAM at the largest cell's worth of rows (tens of MB for the densest galactic-plane cells) rather than the whole catalog.

## Motivation

Drives the cell-driven build loop discussed in [OrbitalCommons/zodiacal#65](https://github.com/OrbitalCommons/zodiacal/issues/65) — the zodiacal index builder currently loads every shard into RAM up front (hard mag-17 cap because of it). A cell-at-a-time loop unblocks larger mag limits without touching the `.zdcl` file format.

## API placement

Inherent methods on `LazyLoadingCatalog`, not on the `GaiaCatalog<R>` trait. `MemoryResidentCatalog<R>` is a flat HashMap with no notion of "cell N", so the per-cell access surface only makes sense for HEALPix-sharded backends. Putting it on the trait would force every backend to fake it.

## Test plan

- [x] `cargo test -p starfield-gaia --features dr3 --test dr3_excerpt_cone` — 17 passed (4 new)
- [x] `cargo clippy -p starfield-gaia --features all-releases --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`

New tests:
- `entries_in_cell_returns_only_that_cell` — iterates every cell of a level-3 layout, asserts the union of per-cell entries equals `len()` and no entry appears in two cells
- `entries_in_cell_empty_cell_yields_empty_iterator` — single-row fixture; every cell except the occupied one returns nothing
- `entries_in_cell_rejects_out_of_range_id` — `cell_id == cell_count()` errors with "out of range"
- `entries_in_cell_honours_mag_limit` — bright/faint mix in one cell; `mag_limit` gates rows