### PR TITLE
gaia-extended: new crate for DR3 galaxy_candidates + qso_candidates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/horizons",
     "crates/sbdb",
     "crates/gaia",
+    "crates/gaia-extended",
     "crates/gaia-tools",
     "crates/hipparcos",
     "crates/mpc",

--- a/crates/gaia-extended/Cargo.toml
+++ b/crates/gaia-extended/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "starfield-gaia-extended"
+version = "0.1.0"
+description = "ESA Gaia DR3 extended-source catalogs (galaxy_candidates, qso_candidates)"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+starfield = { workspace = true }
+starfield-gaia = { version = "0.2.0", path = "../gaia" }
+serde = { workspace = true }
+flate2 = { workspace = true }
+nalgebra = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/gaia-extended/src/galaxy.rs
+++ b/crates/gaia-extended/src/galaxy.rs
@@ -1,0 +1,187 @@
+//! `gaiadr3.galaxy_candidates` loader.
+//!
+//! The published table records DSC class probabilities and Sersic morphology
+//! fits for ~6.6 M extragalactic candidates. The catalog has no `phot_g_mean_mag`
+//! of its own — to render with photometry, join `source_id` against the
+//! corresponding `gaia_source` row.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+use starfield::{Result, StarfieldError};
+
+use crate::parse::{
+    open_csv, parse_opt_f32, parse_opt_string, require_f64, require_u64, ColumnIndex,
+};
+use starfield_gaia::Cone;
+
+/// One galaxy-candidate entry.
+///
+/// Fields beyond the mandatory `source_id` / `ra` / `dec` are `Option`
+/// because the published CSV may omit columns or leave individual cells
+/// blank. Rendering consumers should fall back to a default Sersic when a
+/// fit is missing.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Dr3GalaxyCandidate {
+    /// Foreign key to `gaia_source.source_id`. Use this to fetch
+    /// photometry / parallax / proper motion when needed.
+    pub source_id: u64,
+    pub ra: f64,
+    pub dec: f64,
+
+    // ------------------------------------------------------------------
+    // DSC (Discrete Source Classifier) outputs
+    // ------------------------------------------------------------------
+    /// DSC label (e.g. `"galaxy"`) when present.
+    pub classlabel_dsc: Option<String>,
+    /// Joint label combining DSC + further classifiers.
+    pub classlabel_dsc_joint: Option<String>,
+    /// DSC combined-mod galaxy class probability (0..=1).
+    pub classprob_dsc_combmod_galaxy: Option<f32>,
+    /// DSC combined-mod quasar class probability (0..=1) — present here
+    /// because the same DSC gates both `galaxy_candidates` and
+    /// `qso_candidates`.
+    pub classprob_dsc_combmod_quasar: Option<f32>,
+
+    // ------------------------------------------------------------------
+    // Sersic morphology fit
+    // ------------------------------------------------------------------
+    /// Sersic effective radius (arcsec).
+    pub radius_sersic: Option<f32>,
+    /// Sersic index n (1.0 = exponential disk, 4.0 = de Vaucouleurs bulge).
+    pub n_sersic: Option<f32>,
+    /// Ellipticity e = 1 - b/a (0 = circular).
+    pub ellipticity_sersic: Option<f32>,
+    /// Position angle of major axis, degrees east of north.
+    pub pa_sersic: Option<f32>,
+    /// Goodness-of-fit statistic from the galaxy morphology fit.
+    pub gof_galaxy: Option<f32>,
+
+    // ------------------------------------------------------------------
+    // Variability classifier
+    // ------------------------------------------------------------------
+    /// Best-class label from the variability pipeline.
+    pub vari_best_class_name: Option<String>,
+    /// Score for the best variability class (0..=1).
+    pub vari_best_class_score: Option<f32>,
+}
+
+/// In-memory catalog of [`Dr3GalaxyCandidate`] keyed by `source_id`.
+#[derive(Debug, Default)]
+pub struct Dr3GalaxyCatalog {
+    entries: HashMap<u64, Dr3GalaxyCandidate>,
+}
+
+impl Dr3GalaxyCatalog {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Load every row from a `.csv` or `.csv.gz` file.
+    ///
+    /// Errors out when the file doesn't have at least the
+    /// `source_id`, `ra`, and `dec` columns. Other columns are looked up
+    /// by name and stored as `None` if missing.
+    pub fn from_csv_file(path: impl AsRef<Path>) -> Result<Self> {
+        let path = path.as_ref();
+        let mut reader = open_csv(path)?;
+        let mut header_line = String::new();
+        let n = reader
+            .read_line(&mut header_line)
+            .map_err(StarfieldError::IoError)?;
+        if n == 0 {
+            return Err(StarfieldError::DataError(format!(
+                "{}: file is empty",
+                path.display()
+            )));
+        }
+        let cols = ColumnIndex::from_header(&header_line, path.display().to_string());
+
+        let i_source_id = cols.require("source_id")?;
+        let i_ra = cols.require("ra")?;
+        let i_dec = cols.require("dec")?;
+
+        let i_classlabel_dsc = cols.optional("classlabel_dsc");
+        let i_classlabel_dsc_joint = cols.optional("classlabel_dsc_joint");
+        let i_classprob_dsc_galaxy = cols.optional("classprob_dsc_combmod_galaxy");
+        let i_classprob_dsc_quasar = cols.optional("classprob_dsc_combmod_quasar");
+
+        let i_radius_sersic = cols.optional("radius_sersic");
+        let i_n_sersic = cols.optional("n_sersic");
+        let i_ellipticity_sersic = cols.optional("ellipticity_sersic");
+        let i_pa_sersic = cols.optional("pa_sersic");
+        let i_gof_galaxy = cols.optional("gof_galaxy");
+
+        let i_vari_best_class_name = cols.optional("vari_best_class_name");
+        let i_vari_best_class_score = cols.optional("vari_best_class_score");
+
+        let mut entries = HashMap::new();
+        let mut line = String::new();
+        loop {
+            line.clear();
+            let n = reader
+                .read_line(&mut line)
+                .map_err(StarfieldError::IoError)?;
+            if n == 0 {
+                break;
+            }
+            if line.trim().is_empty() {
+                continue;
+            }
+            let fields: Vec<&str> = line.trim_end().split(',').collect();
+            let source_id = require_u64(&fields, i_source_id, "source_id", &cols.source)?;
+            let ra = require_f64(&fields, i_ra, "ra", &cols.source)?;
+            let dec = require_f64(&fields, i_dec, "dec", &cols.source)?;
+
+            let entry = Dr3GalaxyCandidate {
+                source_id,
+                ra,
+                dec,
+                classlabel_dsc: parse_opt_string(&fields, i_classlabel_dsc),
+                classlabel_dsc_joint: parse_opt_string(&fields, i_classlabel_dsc_joint),
+                classprob_dsc_combmod_galaxy: parse_opt_f32(&fields, i_classprob_dsc_galaxy)?,
+                classprob_dsc_combmod_quasar: parse_opt_f32(&fields, i_classprob_dsc_quasar)?,
+                radius_sersic: parse_opt_f32(&fields, i_radius_sersic)?,
+                n_sersic: parse_opt_f32(&fields, i_n_sersic)?,
+                ellipticity_sersic: parse_opt_f32(&fields, i_ellipticity_sersic)?,
+                pa_sersic: parse_opt_f32(&fields, i_pa_sersic)?,
+                gof_galaxy: parse_opt_f32(&fields, i_gof_galaxy)?,
+                vari_best_class_name: parse_opt_string(&fields, i_vari_best_class_name),
+                vari_best_class_score: parse_opt_f32(&fields, i_vari_best_class_score)?,
+            };
+            entries.insert(source_id, entry);
+        }
+        Ok(Self { entries })
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &Dr3GalaxyCandidate> {
+        self.entries.values()
+    }
+
+    pub fn get(&self, source_id: u64) -> Option<&Dr3GalaxyCandidate> {
+        self.entries.get(&source_id)
+    }
+
+    pub fn insert(&mut self, entry: Dr3GalaxyCandidate) {
+        self.entries.insert(entry.source_id, entry);
+    }
+
+    /// Galaxies whose `(ra, dec)` falls inside `cone`. Linear scan; use
+    /// when the catalog comfortably fits in memory (today's ~6.6 M rows
+    /// do).
+    pub fn in_cone(&self, cone: &Cone) -> Vec<&Dr3GalaxyCandidate> {
+        self.entries
+            .values()
+            .filter(|g| cone.contains_radec_deg(g.ra, g.dec))
+            .collect()
+    }
+}

--- a/crates/gaia-extended/src/lib.rs
+++ b/crates/gaia-extended/src/lib.rs
@@ -1,0 +1,55 @@
+//! ESA Gaia DR3 extended-source catalogs.
+//!
+//! DR3 publishes two morphology-aware catalogs of extended sources, in
+//! addition to the main `gaia_source` table that `starfield-gaia` covers:
+//!
+//! - **`gaiadr3.galaxy_candidates`** (~6.6 M rows) — galaxy candidates
+//!   with Sersic morphology fits and DSC class probabilities.
+//! - **`gaiadr3.qso_candidates`** (~6.6 M rows) — QSO candidates with
+//!   photometric redshifts and ICRF cross-matches.
+//!
+//! Neither table carries `phot_g_mean_mag` directly — they reference the
+//! `gaia_source` row via `source_id`. To attach photometry, join with
+//! the matching DR3 row in `starfield-gaia` (e.g. via
+//! [`Dr3Catalog`](starfield_gaia::Dr3Catalog)).
+//!
+//! # Data acquisition
+//!
+//! The two CSVs ship from ESA's CDN at:
+//!
+//! - `https://cdn.gea.esac.esa.int/Gaia/gdr3/Misc/galaxy_candidates/`
+//! - `https://cdn.gea.esac.esa.int/Gaia/gdr3/Misc/qso_candidates/`
+//!
+//! For now this crate just parses the published CSV files (`.csv` or
+//! `.csv.gz`). A bulk downloader is left as future work — the row counts
+//! are small enough (~6.6 M each) that one-shot manual downloads are
+//! tolerable.
+//!
+//! # Schema flexibility
+//!
+//! The parsers look up columns by **header name**, not position. Unknown
+//! columns are ignored. Required columns (`source_id`, `ra`, `dec`)
+//! produce a typed error if missing; everything else is optional and
+//! degrades to `None` when the column isn't present in the file.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use starfield_gaia_extended::{Dr3GalaxyCatalog, Dr3QsoCatalog};
+//! use starfield_gaia::Cone;
+//!
+//! let galaxies = Dr3GalaxyCatalog::from_csv_file("galaxy_candidates.csv.gz")?;
+//! let quasars = Dr3QsoCatalog::from_csv_file("qso_candidates.csv.gz")?;
+//!
+//! let cone = Cone::from_degrees(266.4, -29.0, 5.0);
+//! let nearby_galaxies = galaxies.in_cone(&cone);
+//! let nearby_quasars = quasars.in_cone(&cone);
+//! # Ok::<(), starfield::StarfieldError>(())
+//! ```
+
+pub mod galaxy;
+pub mod parse;
+pub mod qso;
+
+pub use galaxy::{Dr3GalaxyCandidate, Dr3GalaxyCatalog};
+pub use qso::{Dr3QsoCandidate, Dr3QsoCatalog};

--- a/crates/gaia-extended/src/parse.rs
+++ b/crates/gaia-extended/src/parse.rs
@@ -1,0 +1,159 @@
+//! Header-driven CSV parser shared by both extended-source loaders.
+//!
+//! The published DR3 extended-source CSVs have ~50–80 columns each, of which
+//! we only model the morphology / classification subset most useful for
+//! rendering. To stay tolerant to schema drift we look up columns by header
+//! name and pass back `None` for anything missing — only `source_id`, `ra`,
+//! and `dec` are mandatory (signaled by [`ColumnIndex::require`]).
+
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+use flate2::read::MultiGzDecoder;
+use starfield::{Result, StarfieldError};
+
+/// Header → column-index lookup over the first line of a CSV file.
+///
+/// Use [`require`](Self::require) for columns that must be present and
+/// [`optional`](Self::optional) for columns that may be absent. Returned
+/// indices are positions in the comma-split row.
+pub struct ColumnIndex<'a> {
+    by_name: HashMap<&'a str, usize>,
+    pub source: String,
+}
+
+impl<'a> ColumnIndex<'a> {
+    pub fn from_header(header: &'a str, source: impl Into<String>) -> Self {
+        let by_name = header
+            .trim_end()
+            .split(',')
+            .enumerate()
+            .map(|(i, name)| (name, i))
+            .collect();
+        Self {
+            by_name,
+            source: source.into(),
+        }
+    }
+
+    /// Index of `name`, or an error naming the source file.
+    pub fn require(&self, name: &str) -> Result<usize> {
+        self.by_name.get(name).copied().ok_or_else(|| {
+            StarfieldError::DataError(format!(
+                "{}: required column {:?} missing from header",
+                self.source, name
+            ))
+        })
+    }
+
+    /// `Some(index)` if `name` is in the header, else `None`.
+    pub fn optional(&self, name: &str) -> Option<usize> {
+        self.by_name.get(name).copied()
+    }
+}
+
+/// Read field at `idx` from `fields`, returning `Ok(None)` for empty cells.
+pub fn parse_opt_f64(fields: &[&str], idx: Option<usize>) -> Result<Option<f64>> {
+    let Some(i) = idx else { return Ok(None) };
+    let s = fields.get(i).copied().unwrap_or("").trim();
+    if s.is_empty() || s.eq_ignore_ascii_case("null") {
+        return Ok(None);
+    }
+    s.parse::<f64>().map(Some).map_err(|e| {
+        StarfieldError::DataError(format!(
+            "column at index {} not f64: {} (got {:?})",
+            i, e, s
+        ))
+    })
+}
+
+pub fn parse_opt_f32(fields: &[&str], idx: Option<usize>) -> Result<Option<f32>> {
+    parse_opt_f64(fields, idx).map(|opt| opt.map(|v| v as f32))
+}
+
+pub fn parse_opt_u64(fields: &[&str], idx: Option<usize>) -> Result<Option<u64>> {
+    let Some(i) = idx else { return Ok(None) };
+    let s = fields.get(i).copied().unwrap_or("").trim();
+    if s.is_empty() || s.eq_ignore_ascii_case("null") {
+        return Ok(None);
+    }
+    s.parse::<u64>().map(Some).map_err(|e| {
+        StarfieldError::DataError(format!(
+            "column at index {} not u64: {} (got {:?})",
+            i, e, s
+        ))
+    })
+}
+
+pub fn parse_opt_bool(fields: &[&str], idx: Option<usize>) -> Result<Option<bool>> {
+    let Some(i) = idx else { return Ok(None) };
+    let s = fields.get(i).copied().unwrap_or("").trim();
+    if s.is_empty() || s.eq_ignore_ascii_case("null") {
+        return Ok(None);
+    }
+    match s.to_ascii_lowercase().as_str() {
+        "true" | "t" | "1" => Ok(Some(true)),
+        "false" | "f" | "0" => Ok(Some(false)),
+        _ => Err(StarfieldError::DataError(format!(
+            "column at index {} not bool (got {:?})",
+            i, s
+        ))),
+    }
+}
+
+pub fn parse_opt_string(fields: &[&str], idx: Option<usize>) -> Option<String> {
+    let i = idx?;
+    let s = fields.get(i).copied().unwrap_or("").trim();
+    if s.is_empty() || s.eq_ignore_ascii_case("null") {
+        None
+    } else {
+        Some(s.to_string())
+    }
+}
+
+pub fn require_f64(fields: &[&str], idx: usize, label: &str, source: &str) -> Result<f64> {
+    let s = fields.get(idx).copied().unwrap_or("").trim();
+    if s.is_empty() {
+        return Err(StarfieldError::DataError(format!(
+            "{}: required column {} (idx {}) is empty",
+            source, label, idx
+        )));
+    }
+    s.parse::<f64>().map_err(|e| {
+        StarfieldError::DataError(format!(
+            "{}: column {} (idx {}) not f64: {} (got {:?})",
+            source, label, idx, e, s
+        ))
+    })
+}
+
+pub fn require_u64(fields: &[&str], idx: usize, label: &str, source: &str) -> Result<u64> {
+    let s = fields.get(idx).copied().unwrap_or("").trim();
+    if s.is_empty() {
+        return Err(StarfieldError::DataError(format!(
+            "{}: required column {} (idx {}) is empty",
+            source, label, idx
+        )));
+    }
+    s.parse::<u64>().map_err(|e| {
+        StarfieldError::DataError(format!(
+            "{}: column {} (idx {}) not u64: {} (got {:?})",
+            source, label, idx, e, s
+        ))
+    })
+}
+
+/// Open a `.csv` or `.csv.gz` file as a line iterator.
+pub fn open_csv(path: &Path) -> Result<Box<dyn BufRead>> {
+    let file = File::open(path).map_err(StarfieldError::IoError)?;
+    let is_gz = path.extension().is_some_and(|e| e == "gz");
+    if is_gz {
+        Ok(Box::new(BufReader::new(MultiGzDecoder::new(
+            BufReader::new(file),
+        ))))
+    } else {
+        Ok(Box::new(BufReader::new(file)))
+    }
+}

--- a/crates/gaia-extended/src/qso.rs
+++ b/crates/gaia-extended/src/qso.rs
@@ -1,0 +1,183 @@
+//! `gaiadr3.qso_candidates` loader.
+//!
+//! ~6.6 M quasar candidates with DSC + variability classifications, photometric
+//! redshift estimates from the QSOC pipeline, and ICRF cross-matches.
+//! No `phot_g_mean_mag` in this table either — join via `source_id` against
+//! `gaia_source` to get photometry.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+use starfield::{Result, StarfieldError};
+
+use crate::parse::{
+    open_csv, parse_opt_bool, parse_opt_f32, parse_opt_string, require_f64, require_u64,
+    ColumnIndex,
+};
+use starfield_gaia::Cone;
+
+/// One QSO-candidate entry.
+///
+/// Fields beyond the mandatory `source_id` / `ra` / `dec` are `Option`
+/// so an unfit/unclassified row degrades gracefully rather than failing
+/// the load.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Dr3QsoCandidate {
+    /// Foreign key to `gaia_source.source_id`.
+    pub source_id: u64,
+    pub ra: f64,
+    pub dec: f64,
+
+    // ------------------------------------------------------------------
+    // DSC outputs
+    // ------------------------------------------------------------------
+    pub classlabel_dsc: Option<String>,
+    pub classlabel_dsc_joint: Option<String>,
+    /// DSC combined-mod quasar probability (0..=1).
+    pub classprob_dsc_combmod_quasar: Option<f32>,
+    /// DSC combined-mod galaxy probability (0..=1).
+    pub classprob_dsc_combmod_galaxy: Option<f32>,
+
+    // ------------------------------------------------------------------
+    // QSOC photometric redshift
+    // ------------------------------------------------------------------
+    /// QSOC pipeline photo-z point estimate.
+    pub redshift_qsoc: Option<f32>,
+    /// 1-sigma lower bound on `redshift_qsoc`.
+    pub redshift_qsoc_lower: Option<f32>,
+    /// 1-sigma upper bound on `redshift_qsoc`.
+    pub redshift_qsoc_upper: Option<f32>,
+
+    // ------------------------------------------------------------------
+    // Reference-frame cross-match
+    // ------------------------------------------------------------------
+    /// True when the source is part of Gaia-CRF3 (the reference QSO frame).
+    pub gaia_crf_source: Option<bool>,
+    /// True when host-galaxy contamination is flagged.
+    pub host_galaxy_flag: Option<bool>,
+
+    // ------------------------------------------------------------------
+    // Variability classifier
+    // ------------------------------------------------------------------
+    pub vari_best_class_name: Option<String>,
+    pub vari_best_class_score: Option<f32>,
+}
+
+/// In-memory catalog of [`Dr3QsoCandidate`] keyed by `source_id`.
+#[derive(Debug, Default)]
+pub struct Dr3QsoCatalog {
+    entries: HashMap<u64, Dr3QsoCandidate>,
+}
+
+impl Dr3QsoCatalog {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Load every row from a `.csv` or `.csv.gz` file.
+    ///
+    /// `source_id`, `ra`, and `dec` are required; missing or empty cells
+    /// in any other column degrade to `None`.
+    pub fn from_csv_file(path: impl AsRef<Path>) -> Result<Self> {
+        let path = path.as_ref();
+        let mut reader = open_csv(path)?;
+        let mut header_line = String::new();
+        let n = reader
+            .read_line(&mut header_line)
+            .map_err(StarfieldError::IoError)?;
+        if n == 0 {
+            return Err(StarfieldError::DataError(format!(
+                "{}: file is empty",
+                path.display()
+            )));
+        }
+        let cols = ColumnIndex::from_header(&header_line, path.display().to_string());
+
+        let i_source_id = cols.require("source_id")?;
+        let i_ra = cols.require("ra")?;
+        let i_dec = cols.require("dec")?;
+
+        let i_classlabel_dsc = cols.optional("classlabel_dsc");
+        let i_classlabel_dsc_joint = cols.optional("classlabel_dsc_joint");
+        let i_classprob_dsc_quasar = cols.optional("classprob_dsc_combmod_quasar");
+        let i_classprob_dsc_galaxy = cols.optional("classprob_dsc_combmod_galaxy");
+
+        let i_redshift_qsoc = cols.optional("redshift_qsoc");
+        let i_redshift_qsoc_lower = cols.optional("redshift_qsoc_lower");
+        let i_redshift_qsoc_upper = cols.optional("redshift_qsoc_upper");
+
+        let i_gaia_crf_source = cols.optional("gaia_crf_source");
+        let i_host_galaxy_flag = cols.optional("host_galaxy_flag");
+
+        let i_vari_best_class_name = cols.optional("vari_best_class_name");
+        let i_vari_best_class_score = cols.optional("vari_best_class_score");
+
+        let mut entries = HashMap::new();
+        let mut line = String::new();
+        loop {
+            line.clear();
+            let n = reader
+                .read_line(&mut line)
+                .map_err(StarfieldError::IoError)?;
+            if n == 0 {
+                break;
+            }
+            if line.trim().is_empty() {
+                continue;
+            }
+            let fields: Vec<&str> = line.trim_end().split(',').collect();
+            let source_id = require_u64(&fields, i_source_id, "source_id", &cols.source)?;
+            let ra = require_f64(&fields, i_ra, "ra", &cols.source)?;
+            let dec = require_f64(&fields, i_dec, "dec", &cols.source)?;
+
+            let entry = Dr3QsoCandidate {
+                source_id,
+                ra,
+                dec,
+                classlabel_dsc: parse_opt_string(&fields, i_classlabel_dsc),
+                classlabel_dsc_joint: parse_opt_string(&fields, i_classlabel_dsc_joint),
+                classprob_dsc_combmod_quasar: parse_opt_f32(&fields, i_classprob_dsc_quasar)?,
+                classprob_dsc_combmod_galaxy: parse_opt_f32(&fields, i_classprob_dsc_galaxy)?,
+                redshift_qsoc: parse_opt_f32(&fields, i_redshift_qsoc)?,
+                redshift_qsoc_lower: parse_opt_f32(&fields, i_redshift_qsoc_lower)?,
+                redshift_qsoc_upper: parse_opt_f32(&fields, i_redshift_qsoc_upper)?,
+                gaia_crf_source: parse_opt_bool(&fields, i_gaia_crf_source)?,
+                host_galaxy_flag: parse_opt_bool(&fields, i_host_galaxy_flag)?,
+                vari_best_class_name: parse_opt_string(&fields, i_vari_best_class_name),
+                vari_best_class_score: parse_opt_f32(&fields, i_vari_best_class_score)?,
+            };
+            entries.insert(source_id, entry);
+        }
+        Ok(Self { entries })
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &Dr3QsoCandidate> {
+        self.entries.values()
+    }
+
+    pub fn get(&self, source_id: u64) -> Option<&Dr3QsoCandidate> {
+        self.entries.get(&source_id)
+    }
+
+    pub fn insert(&mut self, entry: Dr3QsoCandidate) {
+        self.entries.insert(entry.source_id, entry);
+    }
+
+    /// QSOs whose `(ra, dec)` falls inside `cone`. Linear scan; use when
+    /// the catalog comfortably fits in memory (today's ~6.6 M rows do).
+    pub fn in_cone(&self, cone: &Cone) -> Vec<&Dr3QsoCandidate> {
+        self.entries
+            .values()
+            .filter(|q| cone.contains_radec_deg(q.ra, q.dec))
+            .collect()
+    }
+}

--- a/crates/gaia-extended/tests/galaxy.rs
+++ b/crates/gaia-extended/tests/galaxy.rs
@@ -1,0 +1,133 @@
+//! Galaxy-candidates loader tests against synthetic CSV fixtures.
+
+use std::io::Write;
+
+use starfield_gaia::Cone;
+use starfield_gaia_extended::Dr3GalaxyCatalog;
+
+/// (source_id, ra, dec, radius_sersic, n_sersic) per row.
+type GalaxyRow = (u64, f64, f64, Option<f32>, Option<f32>);
+
+/// Build a minimal CSV that exercises the columns we model. The published
+/// `galaxy_candidates` files have ~50 columns; we include only the ones
+/// the parser looks up by name and let the rest be implicitly absent.
+fn write_galaxy_fixture(rows: &[GalaxyRow]) -> tempfile::NamedTempFile {
+    let mut f = tempfile::Builder::new().suffix(".csv").tempfile().unwrap();
+    writeln!(
+        f,
+        "source_id,ra,dec,classlabel_dsc,classprob_dsc_combmod_galaxy,classprob_dsc_combmod_quasar,radius_sersic,n_sersic,ellipticity_sersic,pa_sersic,gof_galaxy,vari_best_class_name,vari_best_class_score"
+    )
+    .unwrap();
+    for (i, (id, ra, dec, radius_sersic, n_sersic)) in rows.iter().enumerate() {
+        let radius = radius_sersic.map(|v| v.to_string()).unwrap_or_default();
+        let nser = n_sersic.map(|v| v.to_string()).unwrap_or_default();
+        let label = if i % 2 == 0 { "galaxy" } else { "" };
+        writeln!(
+            f,
+            "{id},{ra},{dec},{label},0.97,0.02,{radius},{nser},0.3,42.0,1.5,VARIABLE,0.8"
+        )
+        .unwrap();
+    }
+    f.flush().unwrap();
+    f
+}
+
+#[test]
+fn parses_minimal_fixture() {
+    let fixture = write_galaxy_fixture(&[
+        (1001, 10.0, 20.0, Some(2.5), Some(4.0)),
+        (1002, 11.0, 21.0, Some(1.2), Some(1.0)),
+        (1003, 12.0, 22.0, None, None),
+    ]);
+    let cat = Dr3GalaxyCatalog::from_csv_file(fixture.path()).unwrap();
+    assert_eq!(cat.len(), 3);
+    let g = cat.get(1001).unwrap();
+    assert_eq!(g.ra, 10.0);
+    assert_eq!(g.dec, 20.0);
+    assert_eq!(g.radius_sersic, Some(2.5));
+    assert_eq!(g.n_sersic, Some(4.0));
+    assert_eq!(g.classlabel_dsc.as_deref(), Some("galaxy"));
+    assert_eq!(g.classprob_dsc_combmod_galaxy, Some(0.97));
+
+    let g3 = cat.get(1003).unwrap();
+    assert_eq!(g3.radius_sersic, None);
+    assert_eq!(g3.n_sersic, None);
+
+    // 1002 is the odd-indexed row in the fixture and has an empty
+    // `classlabel_dsc` cell; the parser should turn that into None.
+    let g2 = cat.get(1002).unwrap();
+    assert_eq!(g2.classlabel_dsc, None);
+}
+
+#[test]
+fn cone_filter_returns_only_inside_galaxies() {
+    let fixture = write_galaxy_fixture(&[
+        (1, 10.0, 20.0, None, None),   // inside
+        (2, 10.5, 20.5, None, None),   // inside
+        (3, 200.0, -45.0, None, None), // outside
+        (4, 11.0, 19.0, None, None),   // inside
+    ]);
+    let cat = Dr3GalaxyCatalog::from_csv_file(fixture.path()).unwrap();
+    let cone = Cone::from_degrees(10.0, 20.0, 2.0);
+    let inside = cat.in_cone(&cone);
+    let mut ids: Vec<u64> = inside.iter().map(|g| g.source_id).collect();
+    ids.sort();
+    assert_eq!(ids, vec![1, 2, 4]);
+}
+
+#[test]
+fn missing_required_column_errors() {
+    // Drop `dec` — the parser must reject this loudly.
+    let mut f = tempfile::Builder::new().suffix(".csv").tempfile().unwrap();
+    writeln!(f, "source_id,ra,radius_sersic").unwrap();
+    writeln!(f, "1,10.0,2.5").unwrap();
+    f.flush().unwrap();
+    let err = Dr3GalaxyCatalog::from_csv_file(f.path()).expect_err("dec missing");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("dec"),
+        "error should mention missing dec column, got: {}",
+        msg
+    );
+}
+
+#[test]
+fn unknown_columns_are_ignored() {
+    // Add a bunch of columns we don't model — parser should ignore them.
+    let mut f = tempfile::Builder::new().suffix(".csv").tempfile().unwrap();
+    writeln!(
+        f,
+        "source_id,ra,dec,n_sersic,some_fake_extra_col,another_extra"
+    )
+    .unwrap();
+    writeln!(f, "1,10.0,20.0,4.0,foo,bar").unwrap();
+    f.flush().unwrap();
+    let cat = Dr3GalaxyCatalog::from_csv_file(f.path()).unwrap();
+    assert_eq!(cat.len(), 1);
+    assert_eq!(cat.get(1).unwrap().n_sersic, Some(4.0));
+}
+
+#[test]
+fn empty_file_after_header_yields_empty_catalog() {
+    let mut f = tempfile::Builder::new().suffix(".csv").tempfile().unwrap();
+    writeln!(f, "source_id,ra,dec").unwrap();
+    f.flush().unwrap();
+    let cat = Dr3GalaxyCatalog::from_csv_file(f.path()).unwrap();
+    assert_eq!(cat.len(), 0);
+    assert!(cat.is_empty());
+}
+
+#[test]
+fn duplicate_source_id_collides() {
+    // Same source_id twice → second wins (HashMap insert semantics).
+    let mut f = tempfile::Builder::new().suffix(".csv").tempfile().unwrap();
+    writeln!(f, "source_id,ra,dec,n_sersic").unwrap();
+    writeln!(f, "42,10.0,20.0,1.0").unwrap();
+    writeln!(f, "42,30.0,40.0,4.0").unwrap();
+    f.flush().unwrap();
+    let cat = Dr3GalaxyCatalog::from_csv_file(f.path()).unwrap();
+    assert_eq!(cat.len(), 1);
+    let g = cat.get(42).unwrap();
+    assert_eq!(g.ra, 30.0);
+    assert_eq!(g.n_sersic, Some(4.0));
+}

--- a/crates/gaia-extended/tests/qso.rs
+++ b/crates/gaia-extended/tests/qso.rs
@@ -1,0 +1,117 @@
+//! QSO-candidates loader tests against synthetic CSV fixtures.
+
+use std::io::Write;
+
+use starfield_gaia::Cone;
+use starfield_gaia_extended::Dr3QsoCatalog;
+
+/// (source_id, ra, dec, redshift_qsoc, gaia_crf_source) per row.
+type QsoRow = (u64, f64, f64, Option<f32>, Option<bool>);
+
+fn write_qso_fixture(rows: &[QsoRow]) -> tempfile::NamedTempFile {
+    let mut f = tempfile::Builder::new().suffix(".csv").tempfile().unwrap();
+    writeln!(
+        f,
+        "source_id,ra,dec,classlabel_dsc,classprob_dsc_combmod_quasar,classprob_dsc_combmod_galaxy,redshift_qsoc,redshift_qsoc_lower,redshift_qsoc_upper,gaia_crf_source,host_galaxy_flag,vari_best_class_name,vari_best_class_score"
+    )
+    .unwrap();
+    for (id, ra, dec, redshift, in_crf) in rows {
+        let z = redshift.map(|v| v.to_string()).unwrap_or_default();
+        let crf = in_crf
+            .map(|b| if b { "true" } else { "false" }.to_string())
+            .unwrap_or_default();
+        writeln!(
+            f,
+            "{id},{ra},{dec},quasar,0.99,0.005,{z},,,{crf},false,QSO,0.85"
+        )
+        .unwrap();
+    }
+    f.flush().unwrap();
+    f
+}
+
+#[test]
+fn parses_minimal_fixture() {
+    let fixture = write_qso_fixture(&[
+        (2001, 100.0, -10.0, Some(2.5), Some(true)),
+        (2002, 101.0, -11.0, Some(0.8), Some(false)),
+        (2003, 102.0, -12.0, None, None),
+    ]);
+    let cat = Dr3QsoCatalog::from_csv_file(fixture.path()).unwrap();
+    assert_eq!(cat.len(), 3);
+    let q = cat.get(2001).unwrap();
+    assert_eq!(q.ra, 100.0);
+    assert_eq!(q.dec, -10.0);
+    assert_eq!(q.redshift_qsoc, Some(2.5));
+    assert_eq!(q.gaia_crf_source, Some(true));
+    assert_eq!(q.classlabel_dsc.as_deref(), Some("quasar"));
+    assert_eq!(q.classprob_dsc_combmod_quasar, Some(0.99));
+
+    let q3 = cat.get(2003).unwrap();
+    assert_eq!(q3.redshift_qsoc, None);
+    assert_eq!(q3.gaia_crf_source, None);
+}
+
+#[test]
+fn cone_filter_returns_only_inside_quasars() {
+    let fixture = write_qso_fixture(&[
+        (1, 100.0, -10.0, None, None), // inside
+        (2, 100.5, -10.5, None, None), // inside
+        (3, 50.0, 50.0, None, None),   // outside
+    ]);
+    let cat = Dr3QsoCatalog::from_csv_file(fixture.path()).unwrap();
+    let cone = Cone::from_degrees(100.0, -10.0, 2.0);
+    let inside = cat.in_cone(&cone);
+    let mut ids: Vec<u64> = inside.iter().map(|q| q.source_id).collect();
+    ids.sort();
+    assert_eq!(ids, vec![1, 2]);
+}
+
+#[test]
+fn missing_required_column_errors() {
+    let mut f = tempfile::Builder::new().suffix(".csv").tempfile().unwrap();
+    writeln!(f, "source_id,dec,redshift_qsoc").unwrap(); // ra missing
+    writeln!(f, "1,20.0,1.5").unwrap();
+    f.flush().unwrap();
+    let err = Dr3QsoCatalog::from_csv_file(f.path()).expect_err("ra missing");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("ra"),
+        "error should mention missing ra column, got: {}",
+        msg
+    );
+}
+
+#[test]
+fn boolean_parsing_handles_t_f_and_numeric() {
+    // gaia_crf_source can show up as true/false, t/f, or 1/0 in different
+    // exports; the parser should accept all three.
+    let mut f = tempfile::Builder::new().suffix(".csv").tempfile().unwrap();
+    writeln!(f, "source_id,ra,dec,gaia_crf_source").unwrap();
+    writeln!(f, "1,10.0,20.0,true").unwrap();
+    writeln!(f, "2,11.0,21.0,t").unwrap();
+    writeln!(f, "3,12.0,22.0,1").unwrap();
+    writeln!(f, "4,13.0,23.0,false").unwrap();
+    writeln!(f, "5,14.0,24.0,f").unwrap();
+    writeln!(f, "6,15.0,25.0,0").unwrap();
+    writeln!(f, "7,16.0,26.0,").unwrap(); // empty -> None
+    f.flush().unwrap();
+    let cat = Dr3QsoCatalog::from_csv_file(f.path()).unwrap();
+    assert_eq!(cat.get(1).unwrap().gaia_crf_source, Some(true));
+    assert_eq!(cat.get(2).unwrap().gaia_crf_source, Some(true));
+    assert_eq!(cat.get(3).unwrap().gaia_crf_source, Some(true));
+    assert_eq!(cat.get(4).unwrap().gaia_crf_source, Some(false));
+    assert_eq!(cat.get(5).unwrap().gaia_crf_source, Some(false));
+    assert_eq!(cat.get(6).unwrap().gaia_crf_source, Some(false));
+    assert_eq!(cat.get(7).unwrap().gaia_crf_source, None);
+}
+
+#[test]
+fn empty_file_after_header_yields_empty_catalog() {
+    let mut f = tempfile::Builder::new().suffix(".csv").tempfile().unwrap();
+    writeln!(f, "source_id,ra,dec").unwrap();
+    f.flush().unwrap();
+    let cat = Dr3QsoCatalog::from_csv_file(f.path()).unwrap();
+    assert_eq!(cat.len(), 0);
+    assert!(cat.is_empty());
+}

--- a/crates/starfield-datasources/Cargo.toml
+++ b/crates/starfield-datasources/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starfield-datasources"
-version = "0.6.0"
+version = "0.7.0"
 description = "Astronomical data source clients for the starfield ecosystem"
 edition.workspace = true
 license.workspace = true
@@ -12,6 +12,7 @@ horizons = ["dep:starfield-horizons"]
 sbdb = ["dep:starfield-sbdb"]
 gaia = ["dep:starfield-gaia"]
 gaia-all = ["gaia", "starfield-gaia/all-releases"]
+gaia-extended = ["gaia", "dep:starfield-gaia-extended"]
 hipparcos = ["dep:starfield-hipparcos"]
 mpc = ["dep:starfield-mpc"]
 nsa = ["dep:starfield-nsa"]
@@ -21,6 +22,7 @@ rubin = ["dep:starfield-rubin"]
 starfield-horizons = { path = "../horizons", optional = true }
 starfield-sbdb = { path = "../sbdb", optional = true }
 starfield-gaia = { path = "../gaia", optional = true }
+starfield-gaia-extended = { path = "../gaia-extended", optional = true }
 starfield-hipparcos = { path = "../hipparcos", optional = true }
 starfield-mpc = { path = "../mpc", optional = true }
 starfield-nsa = { path = "../nsa", optional = true }

--- a/crates/starfield-datasources/src/lib.rs
+++ b/crates/starfield-datasources/src/lib.rs
@@ -9,6 +9,7 @@
 //! - `sbdb` — NASA JPL Small-Body Database API client
 //! - `gaia` — ESA Gaia DR3 loader (default)
 //! - `gaia-all` — adds DR1 and DR2 alongside DR3
+//! - `gaia-extended` — DR3 galaxy_candidates + qso_candidates loaders
 //! - `hipparcos` — Hipparcos star catalog loader
 //! - `mpc` — Minor Planet Center client (MPCORB, observatory codes, observations)
 //! - `nsa` — NASA-Sloan Atlas (NSA) galaxy catalog loader
@@ -22,6 +23,9 @@ pub use starfield_sbdb as sbdb;
 
 #[cfg(feature = "gaia")]
 pub use starfield_gaia as gaia;
+
+#[cfg(feature = "gaia-extended")]
+pub use starfield_gaia_extended as gaia_extended;
 
 #[cfg(feature = "hipparcos")]
 pub use starfield_hipparcos as hipparcos;


### PR DESCRIPTION
## Summary

Adds a new `starfield-gaia-extended` crate that parses Gaia DR3's two morphology-pipeline candidate catalogs:

- **`galaxy_candidates`** (~6.6 M rows) — Sersic morphology fits (`radius_sersic`, `n_sersic`, `ellipticity_sersic`, `pa_sersic`, `gof_galaxy`) + DSC class probabilities + variability classifier outputs.
- **`qso_candidates`** (~6.6 M rows) — QSOC photometric redshift (`redshift_qsoc` ± uncertainties), Gaia-CRF3 cross-match flag, host-galaxy contamination flag, DSC + variability outputs.

These tables don't fit the `gaia_source` schema and they don't carry `phot_g_mean_mag` — to render with photometry, callers join `source_id` against `starfield-gaia::Dr3Catalog`.

## Crate layout

- `Dr3GalaxyCandidate` + `Dr3GalaxyCatalog` (in-memory `HashMap<source_id, ...>`)
- `Dr3QsoCandidate` + `Dr3QsoCatalog` (same shape)
- Both expose `from_csv_file(path)` (handles `.csv` / `.csv.gz`), `len`, `is_empty`, `iter`, `get(source_id)`, `insert`, `in_cone(&Cone)` — `Cone` is re-used from `starfield-gaia` (no parallel type).

## Parser design

Header-driven, position-agnostic:
- Looks columns up by **name**, not column index — so the published schema can drift across DR3 sub-releases without breaking us.
- `source_id`, `ra`, `dec` are **required** (typed error on missing).
- All other modeled columns are `Option<T>` and degrade to `None` when the column is missing or the cell is empty / `"null"`.
- Unknown columns are silently ignored.
- Booleans accept `true`/`false`, `t`/`f`, `1`/`0`, and empty (`None`) — useful because TAP exports are inconsistent.

## Bulk download

Skipped for v1. The two catalogs are small enough (~6.6 M each) that one-shot manual downloads from ESA's CDN paths (`Misc/galaxy_candidates/`, `Misc/qso_candidates/`) are tolerable, and the existing `Downloader<R>` infrastructure in `starfield-gaia` is parameterized over `GaiaRelease` which expects `gaia_source` shape — that's not a fit. Adding a bulk downloader is a follow-on if there's demand.

## Facade wiring

- `starfield-datasources` facade bumped 0.6.0 → 0.7.0 (per `CLAUDE.md`: "When adding a new datasource crate, increment the minor version").
- New optional feature `gaia-extended` (off by default; pulls in the `gaia` feature transitively since the crate re-uses `Cone` from there).

## Test plan

- [x] `cargo test -p starfield-gaia-extended` — 11 tests + 1 doc test, all green
- [x] `cargo clippy -p starfield-gaia-extended --all-targets -- -D warnings`
- [x] `cargo build --workspace --all-features`
- [x] `cargo fmt --all -- --check`

Tests cover (per loader):
- happy-path parse with Optional fields populated and missing
- `in_cone` filter returns only the inside rows
- missing-required-column error mentions the missing column
- unknown-column tolerance
- empty-file (header only) → empty catalog
- duplicate `source_id` → second row wins (HashMap insert semantics)
- (QSO) boolean parser accepts `true`/`false`, `t`/`f`, `1`/`0`, and empty

## Future work

- Bulk downloader (issue worth filing if a consumer wants it)
- TAP-query helper to build the source CSVs from ADQL on the fly
- Bridge to `Dr3Catalog::augment_extended` that joins photometry from gaia_source by source_id when both catalogs are loaded