### PR TITLE
bright-galaxies: hand-curated supplement of nearby bright galaxies (M31, LMC, etc.)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "crates/bright-galaxies",
     "crates/datasource-utils",
     "crates/horizons",
     "crates/sbdb",

--- a/crates/bright-galaxies/Cargo.toml
+++ b/crates/bright-galaxies/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "starfield-bright-galaxies"
+version = "0.1.0"
+description = "Hand-curated supplement of nearby bright galaxies (M31, LMC, Virgo, etc.) missing from automated extragalactic catalogs"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+starfield = { workspace = true }
+starfield-gaia = { version = "0.2.0", path = "../gaia" }
+serde = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/bright-galaxies/data/bright-galaxies.csv
+++ b/crates/bright-galaxies/data/bright-galaxies.csv
@@ -1,0 +1,44 @@
+name,ra_deg,dec_deg,morph_type,mag_v,radius_sersic_arcsec,n_sersic,ellipticity_sersic,pa_sersic_deg,notes
+M31,10.6847,41.2691,Sb,3.44,720.0,2.5,0.68,35.0,Andromeda; B-band Sersic fits give R_e ~12 arcmin
+M32,10.6743,40.8653,cE2,8.08,30.0,4.0,0.18,170.0,Andromeda companion; compact elliptical
+M110,10.0921,41.6853,dE5,8.07,130.0,1.5,0.50,169.0,Andromeda companion; dwarf elliptical
+M33,23.4621,30.6602,Sc,5.72,360.0,1.4,0.41,23.0,Triangulum; late-type spiral
+LMC,80.8939,-69.7561,Irr,0.40,5400.0,0.7,0.27,170.0,Large Magellanic Cloud; Sersic is a coarse approximation for the irregular disk
+SMC,13.158,-72.800,Irr,2.20,2400.0,0.5,0.50,45.0,Small Magellanic Cloud; Sersic is a very coarse approximation
+NGC6822,296.2358,-14.7892,IB,8.71,250.0,1.0,0.37,10.0,Barnard's Galaxy; dwarf irregular
+M77,40.6696,-0.0133,Sb,8.87,60.0,2.5,0.15,70.0,Cetus A; Seyfert nucleus
+M51,202.4696,47.1953,Sbc,8.40,70.0,2.0,0.05,80.0,Whirlpool; nearly face-on
+NGC5195,202.4983,47.2725,SB0pec,9.60,60.0,2.0,0.10,80.0,M51 companion (NGC 5195)
+M81,148.8881,69.0653,Sab,6.94,240.0,4.0,0.48,157.0,Bode's Galaxy
+M82,148.9697,69.6797,I0/Sbrst,8.41,100.0,1.0,0.57,65.0,Cigar Galaxy; edge-on starburst
+M101,210.8023,54.3486,Scd,7.86,350.0,1.5,0.05,39.0,Pinwheel; large face-on grand design
+M104,189.9976,-11.6230,Sa,8.00,80.0,4.0,0.59,89.0,Sombrero; bulge-dominated edge-on
+M83,204.2538,-29.8657,SBc,7.50,230.0,1.4,0.09,51.0,Southern Pinwheel
+NGC5128,201.3651,-43.0192,S0pec,6.84,305.0,4.0,0.22,35.0,Centaurus A; gE with prominent dust lane
+NGC253,11.8881,-25.2884,SBc,7.10,210.0,2.0,0.73,53.0,Sculptor Galaxy; edge-on starburst
+NGC1316,50.6738,-37.2083,S0pec,8.40,90.0,4.0,0.29,50.0,Fornax A; merger remnant
+M64,194.1820,21.6826,Sab,8.52,90.0,3.0,0.49,115.0,Black Eye Galaxy
+M94,192.7211,41.1204,Sab,8.24,75.0,3.0,0.16,105.0,Cat's Eye Galaxy (sometimes)
+M106,184.7396,47.3038,Sb,8.41,220.0,2.0,0.59,150.0,maser Seyfert
+M65,169.7325,13.0925,Sa,9.30,130.0,2.0,0.71,174.0,Leo Triplet member
+M66,170.0621,12.9915,Sb,8.92,140.0,2.0,0.45,173.0,Leo Triplet member
+M95,160.9904,11.7038,SBb,9.70,75.0,1.5,0.10,13.0,
+M96,161.6905,11.8200,Sab,9.20,90.0,2.0,0.30,5.0,
+M105,161.9568,12.5816,E1,9.30,60.0,4.0,0.10,71.0,
+M87,187.7059,12.3911,E0,8.60,81.0,4.0,0.15,153.0,Virgo cluster cD; jet host
+M86,186.5488,12.9461,E3,8.90,90.0,4.0,0.30,130.0,Virgo
+M84,186.2654,12.8870,E1,9.10,56.0,4.0,0.10,135.0,Virgo
+M49,187.4451,8.0006,E2,8.40,105.0,4.0,0.20,155.0,Virgo
+M60,190.9163,11.5526,E2,8.83,70.0,4.0,0.16,105.0,Virgo
+M59,190.5096,11.6469,E5,9.60,50.0,4.0,0.32,163.0,Virgo
+M89,188.9159,12.5563,E0,9.80,30.0,4.0,0.05,0.0,Virgo
+M90,189.2076,13.1628,Sab,9.50,100.0,2.0,0.49,23.0,Virgo
+NGC891,35.6392,42.3492,Sb,10.00,110.0,1.5,0.86,22.0,classic edge-on disk
+NGC4565,189.0866,25.9879,Sb,9.60,200.0,2.0,0.86,136.0,Needle Galaxy; edge-on
+NGC5907,228.9737,56.3289,Sc,10.30,200.0,2.0,0.85,155.0,edge-on with stellar streams
+NGC4631,190.5333,32.5414,SBd,9.20,200.0,1.5,0.78,86.0,Whale Galaxy; edge-on
+NGC3115,151.3083,-7.7183,S0,8.90,70.0,4.0,0.45,43.0,Spindle Galaxy
+NGC1300,49.9208,-19.4114,SBb,10.40,100.0,1.5,0.30,100.0,classic barred spiral
+NGC1399,54.6213,-35.4506,E1,9.50,60.0,4.0,0.07,150.0,Fornax cluster cD
+IC342,56.7022,68.0961,SBcd,8.40,250.0,1.5,0.05,180.0,face-on spiral behind galactic plane
+NGC6946,308.7180,60.1539,SBc,9.60,200.0,1.5,0.10,80.0,Fireworks Galaxy

--- a/crates/bright-galaxies/src/lib.rs
+++ b/crates/bright-galaxies/src/lib.rs
@@ -1,0 +1,231 @@
+//! Hand-curated supplement of bright nearby galaxies.
+//!
+//! Both `starfield-nsa` (SDSS-derived) and `starfield-gaia-extended`
+//! (Gaia DR3 `galaxy_candidates`) systematically miss the naked-eye and
+//! wide-FOV bright extended objects — M31, M33, the Magellanic Clouds,
+//! M51, M81/82, M101, M104, NGC 253, Centaurus A, Fornax A, the Virgo
+//! cluster headliners, etc. NSA explicitly excluded them because the
+//! SDSS photometric pipeline can't fit objects that span many image
+//! fields; Gaia's morphology pipeline can't fit them either because each
+//! `galaxy_candidates` row assumes a roughly point-like-to-few-arcsec
+//! source.
+//!
+//! This crate fills that gap with a small (< 50 entries) hand-curated
+//! list of nearby bright galaxies, parameterized as Sersic profiles so
+//! they slot into the same renderer path as either of the larger
+//! catalogs above.
+//!
+//! # Caveats
+//!
+//! - **Sersic is an approximation** for many entries. Ellipticals and
+//!   bulge-dominated systems (n=4) are fine; late-type disks (n≈1) are
+//!   reasonable; LMC/SMC and other strongly irregular systems use Sersic
+//!   only as a rough surface-brightness envelope. The `notes` field
+//!   flags entries where the approximation is loose.
+//! - **Sizes** (`radius_sersic_arcsec`) are half-light radii drawn from
+//!   literature Sersic fits where available, otherwise scaled from RC3
+//!   D25 isophotal diameters by a morphology-dependent factor (~0.3–0.4
+//!   of the semi-major D25 axis). Trust to ~30%.
+//! - **`mag_v`** is the integrated Johnson V from RC3 / NED; trust to
+//!   ~0.1 mag.
+//!
+//! Use this catalog as a *visual* supplement, not for photometric
+//! calibration.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use starfield_bright_galaxies::BrightGalaxyCatalog;
+//! use starfield_gaia::Cone;
+//!
+//! let cat = BrightGalaxyCatalog::load_embedded()?;
+//! let m31 = cat.get("M31").expect("M31 is in the supplement");
+//! let virgo = Cone::from_degrees(187.7, 12.4, 5.0);
+//! let nearby = cat.in_cone(&virgo);
+//! println!("{} bright galaxies in the Virgo cone", nearby.len());
+//! # Ok::<(), starfield::StarfieldError>(())
+//! ```
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+use starfield::{Result, StarfieldError};
+
+use starfield_gaia::Cone;
+
+const EMBEDDED_CSV: &str = include_str!("../data/bright-galaxies.csv");
+
+/// One bright-galaxy supplement entry.
+///
+/// Sersic parameters are fit (or approximated — see `notes`) so the
+/// entry can be rendered with the same `SersicSplat`-style depositor a
+/// consumer uses for `Dr3GalaxyCandidate` or `NsaEntry`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BrightGalaxy {
+    /// Common Messier / NGC / IC / colloquial name (`"M31"`, `"NGC253"`,
+    /// `"LMC"`, etc.). Used as the catalog key — must be unique.
+    pub name: String,
+    pub ra_deg: f64,
+    pub dec_deg: f64,
+    /// RC3-style morphological type (`"Sb"`, `"E0"`, `"SBcd"`, etc.).
+    pub morph_type: String,
+    /// Integrated Johnson V magnitude.
+    pub mag_v: f32,
+    /// Sersic effective (half-light) radius, arcsec.
+    pub radius_sersic_arcsec: f32,
+    /// Sersic index n. 1.0 = exponential disk, 4.0 = de Vaucouleurs.
+    pub n_sersic: f32,
+    /// Ellipticity e = 1 - b/a (0 = circular).
+    pub ellipticity_sersic: f32,
+    /// Position angle of major axis, degrees east of north.
+    pub pa_sersic_deg: f32,
+    /// Free-form provenance / approximation notes.
+    pub notes: String,
+}
+
+/// In-memory catalog of [`BrightGalaxy`] keyed by `name`.
+#[derive(Debug, Default)]
+pub struct BrightGalaxyCatalog {
+    by_name: HashMap<String, BrightGalaxy>,
+}
+
+impl BrightGalaxyCatalog {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Parse the embedded supplement CSV bundled with this crate.
+    pub fn load_embedded() -> Result<Self> {
+        Self::from_csv_str(EMBEDDED_CSV, "<embedded>")
+    }
+
+    /// Parse a `.csv` file off disk. The schema must match the header
+    /// of the embedded CSV (same columns, same order).
+    pub fn from_csv_file(path: impl AsRef<Path>) -> Result<Self> {
+        let path = path.as_ref();
+        let text = fs::read_to_string(path).map_err(StarfieldError::IoError)?;
+        Self::from_csv_str(&text, &path.display().to_string())
+    }
+
+    fn from_csv_str(text: &str, source: &str) -> Result<Self> {
+        let mut by_name = HashMap::new();
+        let mut lines = text.lines();
+        let header = lines.next().ok_or_else(|| {
+            StarfieldError::DataError(format!("{}: empty CSV (no header)", source))
+        })?;
+        let cols: Vec<&str> = header.trim().split(',').collect();
+        let expected = [
+            "name",
+            "ra_deg",
+            "dec_deg",
+            "morph_type",
+            "mag_v",
+            "radius_sersic_arcsec",
+            "n_sersic",
+            "ellipticity_sersic",
+            "pa_sersic_deg",
+            "notes",
+        ];
+        if cols.len() < expected.len() || cols[..expected.len()] != expected {
+            return Err(StarfieldError::DataError(format!(
+                "{}: header columns must be {:?}, got {:?}",
+                source, expected, cols
+            )));
+        }
+
+        for (lineno, raw) in lines.enumerate() {
+            let line = raw.trim();
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            // Notes is the trailing field; split into 10 pieces only so
+            // any internal commas (none today, but be safe) don't break
+            // the row.
+            let fields: Vec<&str> = line.splitn(expected.len(), ',').collect();
+            if fields.len() != expected.len() {
+                return Err(StarfieldError::DataError(format!(
+                    "{}: line {} has {} fields, expected {}",
+                    source,
+                    lineno + 2,
+                    fields.len(),
+                    expected.len()
+                )));
+            }
+            let name = fields[0].trim().to_string();
+            let entry = BrightGalaxy {
+                name: name.clone(),
+                ra_deg: parse_f64(fields[1], "ra_deg", source, lineno + 2)?,
+                dec_deg: parse_f64(fields[2], "dec_deg", source, lineno + 2)?,
+                morph_type: fields[3].trim().to_string(),
+                mag_v: parse_f32(fields[4], "mag_v", source, lineno + 2)?,
+                radius_sersic_arcsec: parse_f32(
+                    fields[5],
+                    "radius_sersic_arcsec",
+                    source,
+                    lineno + 2,
+                )?,
+                n_sersic: parse_f32(fields[6], "n_sersic", source, lineno + 2)?,
+                ellipticity_sersic: parse_f32(fields[7], "ellipticity_sersic", source, lineno + 2)?,
+                pa_sersic_deg: parse_f32(fields[8], "pa_sersic_deg", source, lineno + 2)?,
+                notes: fields[9].trim().to_string(),
+            };
+            if by_name.insert(name.clone(), entry).is_some() {
+                return Err(StarfieldError::DataError(format!(
+                    "{}: duplicate entry name {:?} (line {})",
+                    source,
+                    name,
+                    lineno + 2
+                )));
+            }
+        }
+        Ok(Self { by_name })
+    }
+
+    pub fn len(&self) -> usize {
+        self.by_name.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.by_name.is_empty()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &BrightGalaxy> {
+        self.by_name.values()
+    }
+
+    pub fn get(&self, name: &str) -> Option<&BrightGalaxy> {
+        self.by_name.get(name)
+    }
+
+    pub fn insert(&mut self, entry: BrightGalaxy) {
+        self.by_name.insert(entry.name.clone(), entry);
+    }
+
+    /// Galaxies whose `(ra, dec)` falls inside `cone`.
+    pub fn in_cone(&self, cone: &Cone) -> Vec<&BrightGalaxy> {
+        self.by_name
+            .values()
+            .filter(|g| cone.contains_radec_deg(g.ra_deg, g.dec_deg))
+            .collect()
+    }
+}
+
+fn parse_f64(s: &str, label: &str, source: &str, lineno: usize) -> Result<f64> {
+    s.trim().parse::<f64>().map_err(|e| {
+        StarfieldError::DataError(format!(
+            "{}: line {}: column {} not f64: {} (got {:?})",
+            source, lineno, label, e, s
+        ))
+    })
+}
+
+fn parse_f32(s: &str, label: &str, source: &str, lineno: usize) -> Result<f32> {
+    s.trim().parse::<f32>().map_err(|e| {
+        StarfieldError::DataError(format!(
+            "{}: line {}: column {} not f32: {} (got {:?})",
+            source, lineno, label, e, s
+        ))
+    })
+}

--- a/crates/bright-galaxies/tests/embedded.rs
+++ b/crates/bright-galaxies/tests/embedded.rs
@@ -1,0 +1,191 @@
+//! Tests against the embedded bright-galaxy supplement + the from-file
+//! parser path.
+
+use std::io::Write;
+
+use starfield_bright_galaxies::BrightGalaxyCatalog;
+use starfield_gaia::Cone;
+
+#[test]
+fn embedded_loads_and_parses() {
+    let cat = BrightGalaxyCatalog::load_embedded().unwrap();
+    assert!(
+        cat.len() >= 30,
+        "supplement should hold at least 30 entries, got {}",
+        cat.len()
+    );
+
+    // M31 must be present and at the right position.
+    let m31 = cat.get("M31").expect("M31 in supplement");
+    assert!((m31.ra_deg - 10.6847).abs() < 0.01, "M31 RA off");
+    assert!((m31.dec_deg - 41.2691).abs() < 0.01, "M31 Dec off");
+    assert!(m31.mag_v < 4.0, "M31 should be naked-eye bright");
+    assert!(
+        m31.radius_sersic_arcsec > 100.0,
+        "M31 R_e should be substantial"
+    );
+}
+
+#[test]
+fn every_entry_has_plausible_values() {
+    let cat = BrightGalaxyCatalog::load_embedded().unwrap();
+    for g in cat.iter() {
+        assert!(
+            (-90.0..=90.0).contains(&g.dec_deg),
+            "{}: dec out of range: {}",
+            g.name,
+            g.dec_deg
+        );
+        assert!(
+            (0.0..360.0).contains(&g.ra_deg),
+            "{}: ra out of range: {}",
+            g.name,
+            g.ra_deg
+        );
+        assert!(
+            (-2.0..15.0).contains(&g.mag_v),
+            "{}: mag_v out of plausible range: {}",
+            g.name,
+            g.mag_v
+        );
+        assert!(
+            g.radius_sersic_arcsec > 0.0,
+            "{}: radius must be positive",
+            g.name
+        );
+        assert!(
+            (0.3..=8.0).contains(&g.n_sersic),
+            "{}: n_sersic out of plausible range: {}",
+            g.name,
+            g.n_sersic
+        );
+        assert!(
+            (0.0..=1.0).contains(&g.ellipticity_sersic),
+            "{}: ellipticity out of [0,1]: {}",
+            g.name,
+            g.ellipticity_sersic
+        );
+        assert!(
+            (0.0..=180.0).contains(&g.pa_sersic_deg),
+            "{}: PA out of [0,180]: {}",
+            g.name,
+            g.pa_sersic_deg
+        );
+        assert!(!g.morph_type.is_empty(), "{}: empty morph type", g.name);
+    }
+}
+
+#[test]
+fn local_group_landmarks_present() {
+    let cat = BrightGalaxyCatalog::load_embedded().unwrap();
+    for name in ["M31", "M32", "M110", "M33", "LMC", "SMC"] {
+        assert!(
+            cat.get(name).is_some(),
+            "missing Local Group landmark: {}",
+            name
+        );
+    }
+}
+
+#[test]
+fn virgo_cluster_headliners_present() {
+    let cat = BrightGalaxyCatalog::load_embedded().unwrap();
+    for name in ["M87", "M86", "M84", "M49", "M60"] {
+        assert!(cat.get(name).is_some(), "missing Virgo headliner: {}", name);
+    }
+}
+
+#[test]
+fn cone_filter_returns_only_inside_galaxies() {
+    let cat = BrightGalaxyCatalog::load_embedded().unwrap();
+    // Cone around the Virgo cluster centre — should pull M84/M86/M87/M89 et al.
+    let cone = Cone::from_degrees(187.7, 12.4, 3.0);
+    let inside = cat.in_cone(&cone);
+    let names: std::collections::HashSet<&str> = inside.iter().map(|g| g.name.as_str()).collect();
+    assert!(names.contains("M87"), "M87 should be in Virgo cone");
+    assert!(names.contains("M84"), "M84 should be in Virgo cone");
+    assert!(names.contains("M86"), "M86 should be in Virgo cone");
+    // And things far away should NOT be in there.
+    assert!(!names.contains("M31"));
+    assert!(!names.contains("LMC"));
+}
+
+#[test]
+fn from_csv_file_round_trips() {
+    let cat = BrightGalaxyCatalog::load_embedded().unwrap();
+    // Write a custom file with one entry then re-parse.
+    let mut f = tempfile::Builder::new().suffix(".csv").tempfile().unwrap();
+    writeln!(
+        f,
+        "name,ra_deg,dec_deg,morph_type,mag_v,radius_sersic_arcsec,n_sersic,ellipticity_sersic,pa_sersic_deg,notes"
+    )
+    .unwrap();
+    writeln!(
+        f,
+        "TestGalaxy,123.45,-67.89,Sb,9.5,42.0,2.0,0.30,90.0,unit test row"
+    )
+    .unwrap();
+    f.flush().unwrap();
+    let custom = BrightGalaxyCatalog::from_csv_file(f.path()).unwrap();
+    assert_eq!(custom.len(), 1);
+    let g = custom.get("TestGalaxy").unwrap();
+    assert_eq!(g.ra_deg, 123.45);
+    assert_eq!(g.dec_deg, -67.89);
+    assert_eq!(g.notes, "unit test row");
+
+    // The embedded one is still the bigger catalog.
+    assert!(cat.len() > custom.len());
+}
+
+#[test]
+fn rejects_bad_header() {
+    let mut f = tempfile::Builder::new().suffix(".csv").tempfile().unwrap();
+    writeln!(f, "name,ra,dec").unwrap(); // wrong column names
+    writeln!(f, "Foo,0.0,0.0").unwrap();
+    f.flush().unwrap();
+    let err = BrightGalaxyCatalog::from_csv_file(f.path()).expect_err("should reject bad header");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("header columns must be"),
+        "error should explain header schema, got: {}",
+        msg
+    );
+}
+
+#[test]
+fn rejects_duplicate_names() {
+    let mut f = tempfile::Builder::new().suffix(".csv").tempfile().unwrap();
+    writeln!(
+        f,
+        "name,ra_deg,dec_deg,morph_type,mag_v,radius_sersic_arcsec,n_sersic,ellipticity_sersic,pa_sersic_deg,notes"
+    )
+    .unwrap();
+    writeln!(f, "Twin,0.0,0.0,E0,10.0,30.0,4.0,0.1,0.0,first").unwrap();
+    writeln!(f, "Twin,1.0,1.0,Sa,11.0,40.0,2.0,0.3,90.0,second").unwrap();
+    f.flush().unwrap();
+    let err = BrightGalaxyCatalog::from_csv_file(f.path()).expect_err("duplicate name");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("duplicate"),
+        "error should mention duplicate, got: {}",
+        msg
+    );
+}
+
+#[test]
+fn comment_and_blank_lines_skipped() {
+    let mut f = tempfile::Builder::new().suffix(".csv").tempfile().unwrap();
+    writeln!(
+        f,
+        "name,ra_deg,dec_deg,morph_type,mag_v,radius_sersic_arcsec,n_sersic,ellipticity_sersic,pa_sersic_deg,notes"
+    )
+    .unwrap();
+    writeln!(f, "# this is a comment line").unwrap();
+    writeln!(f).unwrap();
+    writeln!(f, "Galaxy1,0.0,0.0,E0,10.0,30.0,4.0,0.1,0.0,").unwrap();
+    writeln!(f, "  ").unwrap(); // whitespace-only
+    writeln!(f, "Galaxy2,1.0,1.0,Sa,11.0,40.0,2.0,0.3,90.0,").unwrap();
+    f.flush().unwrap();
+    let cat = BrightGalaxyCatalog::from_csv_file(f.path()).unwrap();
+    assert_eq!(cat.len(), 2);
+}

--- a/crates/starfield-datasources/Cargo.toml
+++ b/crates/starfield-datasources/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starfield-datasources"
-version = "0.7.0"
+version = "0.8.0"
 description = "Astronomical data source clients for the starfield ecosystem"
 edition.workspace = true
 license.workspace = true
@@ -13,6 +13,7 @@ sbdb = ["dep:starfield-sbdb"]
 gaia = ["dep:starfield-gaia"]
 gaia-all = ["gaia", "starfield-gaia/all-releases"]
 gaia-extended = ["gaia", "dep:starfield-gaia-extended"]
+bright-galaxies = ["gaia", "dep:starfield-bright-galaxies"]
 hipparcos = ["dep:starfield-hipparcos"]
 mpc = ["dep:starfield-mpc"]
 nsa = ["dep:starfield-nsa"]
@@ -23,6 +24,7 @@ starfield-horizons = { path = "../horizons", optional = true }
 starfield-sbdb = { path = "../sbdb", optional = true }
 starfield-gaia = { path = "../gaia", optional = true }
 starfield-gaia-extended = { path = "../gaia-extended", optional = true }
+starfield-bright-galaxies = { path = "../bright-galaxies", optional = true }
 starfield-hipparcos = { path = "../hipparcos", optional = true }
 starfield-mpc = { path = "../mpc", optional = true }
 starfield-nsa = { path = "../nsa", optional = true }

--- a/crates/starfield-datasources/src/lib.rs
+++ b/crates/starfield-datasources/src/lib.rs
@@ -10,6 +10,7 @@
 //! - `gaia` — ESA Gaia DR3 loader (default)
 //! - `gaia-all` — adds DR1 and DR2 alongside DR3
 //! - `gaia-extended` — DR3 galaxy_candidates + qso_candidates loaders
+//! - `bright-galaxies` — hand-curated supplement of nearby bright galaxies (M31, LMC, Virgo, etc.)
 //! - `hipparcos` — Hipparcos star catalog loader
 //! - `mpc` — Minor Planet Center client (MPCORB, observatory codes, observations)
 //! - `nsa` — NASA-Sloan Atlas (NSA) galaxy catalog loader
@@ -26,6 +27,9 @@ pub use starfield_gaia as gaia;
 
 #[cfg(feature = "gaia-extended")]
 pub use starfield_gaia_extended as gaia_extended;
+
+#[cfg(feature = "bright-galaxies")]
+pub use starfield_bright_galaxies as bright_galaxies;
 
 #[cfg(feature = "hipparcos")]
 pub use starfield_hipparcos as hipparcos;


### PR DESCRIPTION
## Summary

Closes #51.

Both `starfield-nsa` (SDSS-derived) and `starfield-gaia-extended` (Gaia DR3 `galaxy_candidates`) systematically miss the naked-eye / wide-FOV bright extended objects: M31, M33, LMC, SMC, M51, M81/82, M101, M104, NGC 253, Centaurus A, Fornax A, the Virgo cluster headliners. They're missing for the same reason in both catalogs — the source's angular size is way past what the upstream pipelines can fit. A focal-plane render pointed at M31 today shows stars but no galaxy.

This new sibling crate `starfield-bright-galaxies` fills the gap with ~45 hand-curated entries, parameterized as Sersic profiles so they slot into the same renderer path consumers already use for `Dr3GalaxyCandidate` or `NsaEntry`.

## What's in the supplement

- **Local Group** (6): M31, M32, M110, M33, LMC, SMC, NGC 6822
- **Virgo cluster headliners** (8): M87, M86, M84, M49, M60, M59, M89, M90
- **Bright spirals around the sky** (15): M51 (+ NGC 5195), M81, M82, M101, M104, M83, M77, M94, M106, M64, M65, M66, M95, M96, M105
- **Edge-on showpieces** (4): NGC 891, NGC 4565, NGC 5907, NGC 4631
- **Southern bright** (4): NGC 5128 (Centaurus A), NGC 253, NGC 1316 (Fornax A), NGC 1399
- **Other** (4): NGC 3115 (Spindle), NGC 1300, IC 342, NGC 6946

## API

```rust
let cat = BrightGalaxyCatalog::load_embedded()?;
let m31 = cat.get("M31").expect("M31 in supplement");
let virgo_field = cat.in_cone(&Cone::from_degrees(187.7, 12.4, 5.0));
```

`Cone` is re-used from `starfield-gaia` (no parallel type). Catalog also has `from_csv_file(path)`, `iter()`, `len()`, `is_empty()`, `insert()` for downstream consumers that want to extend the supplement.

## Caveats

Documented in the crate-level docs:

- **Sersic is an approximation** for irregular systems (LMC/SMC); their `notes` field flags the loose fit.
- **Sizes** are half-light radii from literature Sersic fits where available, otherwise scaled from RC3 D25 isophotal diameters by a morphology-dependent factor (~0.3–0.4 of the semi-major D25 axis). Trust to ~30%.
- **`mag_v`** is integrated Johnson V from RC3 / NED; trust to ~0.1 mag.

This is a *visual* supplement, not photometric calibration. The CSV is small (~3 KB embedded) and easy to extend by hand.

## Facade wiring

- `starfield-datasources` bumped 0.7.0 → 0.8.0 (per `CLAUDE.md`: "When adding a new datasource crate, increment the minor version").
- New optional `bright-galaxies` feature flag (off by default; pulls in the `gaia` feature transitively for `Cone`).

## Why a sibling crate, not a `gaia-extended` module

Per #51's recommendation: the supplement isn't really Gaia-specific; it works just as well alongside NSA (which has the same gap). Living in its own crate keeps it neutral — both `gaia-extended` and `nsa` consumers can import it without dragging the other catalog in.

## Test plan

- [x] `cargo test -p starfield-bright-galaxies` — 9 tests + 1 doc test, all green
- [x] `cargo clippy -p starfield-bright-galaxies --all-targets -- -D warnings`
- [x] `cargo build --workspace --all-features`
- [x] `cargo fmt --all -- --check`

Tests cover:
- Embedded supplement loads and parses
- M31 has expected position / magnitude / size
- Every entry passes basic sanity ranges (RA/Dec/mag/Sersic-n/ellipticity/PA all plausible)
- Local Group landmarks present (M31, M32, M110, M33, LMC, SMC)
- Virgo headliners present (M87, M86, M84, M49, M60)
- Cone filter pulls Virgo entries when pointed at the Virgo cluster
- Round-trip through `from_csv_file`
- Bad header rejected with clear message
- Duplicate name rejected
- Comment lines (`#`) and blank lines tolerated