### PR TITLE
gaia-extended + bright-galaxies: impl starfield::ExtendedSource for the Sersic-bearing entries

### DIFF
--- a/crates/bright-galaxies/src/lib.rs
+++ b/crates/bright-galaxies/src/lib.rs
@@ -51,6 +51,7 @@ use std::fs;
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
+use starfield::catalogs::{ExtendedSource, SersicProfile};
 use starfield::{Result, StarfieldError};
 
 use starfield_gaia::Cone;
@@ -83,6 +84,19 @@ pub struct BrightGalaxy {
     pub pa_sersic_deg: f32,
     /// Free-form provenance / approximation notes.
     pub notes: String,
+}
+
+impl ExtendedSource for BrightGalaxy {
+    fn sersic_profile(&self) -> Option<SersicProfile> {
+        // Convert our (e = 1 - b/a) to upstream's `axis_ratio` (b/a).
+        let axis_ratio = 1.0 - self.ellipticity_sersic as f64;
+        Some(SersicProfile {
+            theta_half_arcsec: self.radius_sersic_arcsec as f64,
+            n: self.n_sersic as f64,
+            axis_ratio,
+            position_angle_deg: self.pa_sersic_deg as f64,
+        })
+    }
 }
 
 /// In-memory catalog of [`BrightGalaxy`] keyed by `name`.

--- a/crates/bright-galaxies/tests/embedded.rs
+++ b/crates/bright-galaxies/tests/embedded.rs
@@ -173,6 +173,62 @@ fn rejects_duplicate_names() {
 }
 
 #[test]
+fn extended_source_impl_round_trips_params() {
+    use starfield::catalogs::ExtendedSource;
+
+    let cat = BrightGalaxyCatalog::load_embedded().unwrap();
+    let m31 = cat.get("M31").unwrap();
+    let p = m31.sersic_profile().expect("M31 has Sersic params");
+
+    // Field-shape conversion: ours stores ellipticity (1 - b/a),
+    // upstream stores axis_ratio (b/a). Verify the flip.
+    let expected_axis_ratio = 1.0 - m31.ellipticity_sersic as f64;
+    assert!(
+        (p.axis_ratio - expected_axis_ratio).abs() < 1e-9,
+        "axis_ratio not flipped correctly: got {}, expected {}",
+        p.axis_ratio,
+        expected_axis_ratio
+    );
+    assert_eq!(p.theta_half_arcsec, m31.radius_sersic_arcsec as f64);
+    assert_eq!(p.n, m31.n_sersic as f64);
+    assert_eq!(p.position_angle_deg, m31.pa_sersic_deg as f64);
+}
+
+#[test]
+fn extended_source_surface_brightness_matches_sersic_formula() {
+    // `surface_brightness_at` returns I(r)/I_e where
+    // I(r) = I_e · exp[-b_n · ((r/θ_half)^(1/n) − 1)].
+    // At r = θ_half along the major axis, the value is exactly 1.0;
+    // at r = 0 (centre) it's exp(b_n), which for n=4 is ≈ 2140.
+    use starfield::catalogs::{ExtendedSource, SersicProfile};
+
+    let cat = BrightGalaxyCatalog::load_embedded().unwrap();
+    let m87 = cat.get("M87").unwrap(); // n_sersic = 4 → de Vaucouleurs
+    let p = m87.sersic_profile().unwrap();
+    let sb_centre = p.surface_brightness_at(0.0, 0.0);
+    assert!(
+        sb_centre > 100.0,
+        "centre should be exp(b_n) >> 1 for de Vaucouleurs, got {}",
+        sb_centre
+    );
+
+    // Cleaner check: an axis-aligned, circular, n=4 profile evaluated
+    // at the half-light radius should give exactly 1.0.
+    let p0 = SersicProfile {
+        theta_half_arcsec: 10.0,
+        n: 4.0,
+        axis_ratio: 1.0,
+        position_angle_deg: 0.0,
+    };
+    let sb_at_re = p0.surface_brightness_at(0.0, 10.0);
+    assert!(
+        (sb_at_re - 1.0).abs() < 1e-9,
+        "I(R_e) / I_e should be 1.0, got {}",
+        sb_at_re
+    );
+}
+
+#[test]
 fn comment_and_blank_lines_skipped() {
     let mut f = tempfile::Builder::new().suffix(".csv").tempfile().unwrap();
     writeln!(

--- a/crates/gaia-extended/src/galaxy.rs
+++ b/crates/gaia-extended/src/galaxy.rs
@@ -9,6 +9,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
+use starfield::catalogs::{ExtendedSource, SersicProfile};
 use starfield::{Result, StarfieldError};
 
 use crate::parse::{
@@ -65,6 +66,28 @@ pub struct Dr3GalaxyCandidate {
     pub vari_best_class_name: Option<String>,
     /// Score for the best variability class (0..=1).
     pub vari_best_class_score: Option<f32>,
+}
+
+impl ExtendedSource for Dr3GalaxyCandidate {
+    /// Returns `Some(SersicProfile)` only when the four shape fields
+    /// (`radius_sersic`, `n_sersic`, `ellipticity_sersic`, `pa_sersic`)
+    /// are all populated. The DR3 morphology pipeline can fail per
+    /// source — rows with any field missing are unfit and a renderer
+    /// should fall back to a point source.
+    fn sersic_profile(&self) -> Option<SersicProfile> {
+        let radius = self.radius_sersic?;
+        let n = self.n_sersic?;
+        let ellipticity = self.ellipticity_sersic?;
+        let pa = self.pa_sersic?;
+        // Convert our (e = 1 - b/a) to upstream's `axis_ratio` (b/a).
+        let axis_ratio = (1.0 - ellipticity as f64).clamp(0.0, 1.0);
+        Some(SersicProfile {
+            theta_half_arcsec: radius as f64,
+            n: n as f64,
+            axis_ratio,
+            position_angle_deg: pa as f64,
+        })
+    }
 }
 
 /// In-memory catalog of [`Dr3GalaxyCandidate`] keyed by `source_id`.

--- a/crates/gaia-extended/tests/galaxy.rs
+++ b/crates/gaia-extended/tests/galaxy.rs
@@ -118,6 +118,42 @@ fn empty_file_after_header_yields_empty_catalog() {
 }
 
 #[test]
+fn extended_source_returns_some_when_all_sersic_fields_present() {
+    use starfield::catalogs::ExtendedSource;
+
+    let fixture = write_galaxy_fixture(&[(1001, 10.0, 20.0, Some(2.5), Some(4.0))]);
+    let cat = Dr3GalaxyCatalog::from_csv_file(fixture.path()).unwrap();
+    let g = cat.get(1001).unwrap();
+    let p = g.sersic_profile().expect("all four shape fields populated");
+    assert_eq!(p.theta_half_arcsec, 2.5);
+    assert_eq!(p.n, 4.0);
+    // Fixture writes ellipticity_sersic = 0.3 and pa_sersic = 42.0.
+    assert!(
+        (p.axis_ratio - 0.7).abs() < 1e-6,
+        "axis_ratio should be 1 - 0.3, got {}",
+        p.axis_ratio
+    );
+    assert_eq!(p.position_angle_deg, 42.0);
+}
+
+#[test]
+fn extended_source_returns_none_when_any_sersic_field_missing() {
+    use starfield::catalogs::ExtendedSource;
+
+    // The fixture writer leaves radius_sersic and n_sersic empty when
+    // the option is None, but still emits ellipticity (0.3) and PA (42)
+    // unconditionally. The impl must require all four — entry 1003
+    // returns None because radius and n are blank.
+    let fixture = write_galaxy_fixture(&[(1003, 12.0, 22.0, None, None)]);
+    let cat = Dr3GalaxyCatalog::from_csv_file(fixture.path()).unwrap();
+    let g = cat.get(1003).unwrap();
+    assert!(
+        g.sersic_profile().is_none(),
+        "missing radius/n should mean no sersic_profile"
+    );
+}
+
+#[test]
 fn duplicate_source_id_collides() {
     // Same source_id twice → second wins (HashMap insert semantics).
     let mut f = tempfile::Builder::new().suffix(".csv").tempfile().unwrap();


### PR DESCRIPTION
## Summary

Both `Dr3GalaxyCandidate` (in `starfield-gaia-extended`) and `BrightGalaxy` (in `starfield-bright-galaxies`) now implement `starfield::catalogs::ExtendedSource` — the upstream trait for catalog rows that may have a Sersic morphology fit. Consumers can drop them straight into a renderer that knows about the upstream `SersicProfile` API (`surface_brightness_at`, `b_n`, `total_flux_per_ie`) without re-deriving the math from raw fields.

## Conversion notes

| Ours | Upstream `SersicProfile` | Same? |
|------|--------------------------|-------|
| `radius_sersic_arcsec` | `theta_half_arcsec` | yes — name only |
| `n_sersic` | `n` | yes |
| `ellipticity_sersic` (= 1 − b/a) | `axis_ratio` (= b/a) | **flipped** |
| `pa_sersic_deg` | `position_angle_deg` | yes — same convention (east of north) |

Both impls do the e ↔ b/a flip.

## Per-crate behaviour

- **`BrightGalaxy`** has non-optional shape fields (the supplement is hand-curated), so the impl always returns `Some(SersicProfile)`.
- **`Dr3GalaxyCandidate`** has the four shape fields as `Option<f32>` because the DR3 morphology pipeline fails per source. The impl returns `None` if any one is missing — the renderer should fall back to a point source for unfit rows.

## Test plan

- [x] `cargo test -p starfield-bright-galaxies` — 11 tests + 1 doctest, all green
- [x] `cargo test -p starfield-gaia-extended` — 13 tests + 1 doctest, all green
- [x] `cargo clippy -p starfield-bright-galaxies --all-targets -- -D warnings`
- [x] `cargo clippy -p starfield-gaia-extended --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`

New tests:
- BrightGalaxy: `extended_source_impl_round_trips_params` (verifies the field mapping + e ↔ b/a flip on M31), `extended_source_surface_brightness_matches_sersic_formula` (asserts that an axis-aligned circular n=4 profile evaluates to exactly 1.0 at the half-light radius and to exp(b_n) > 100 at the centre).
- Dr3GalaxyCandidate: `extended_source_returns_some_when_all_sersic_fields_present` (verifies same field mapping with explicit fixture values), `extended_source_returns_none_when_any_sersic_field_missing` (unfit row → None).

## Why no facade bump

Pure additive trait impl on existing public types in two existing crates. No new public modules, no new feature flag, no new dependency (both crates already pull in `starfield`). Doesn't change the surface of `starfield-datasources` itself.