### PR TITLE
mast: new crate — HST observations, FITS downloads, WCS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/gaia-extended",
     "crates/gaia-tools",
     "crates/hipparcos",
+    "crates/mast",
     "crates/mpc",
     "crates/nsa",
     "crates/rubin",

--- a/crates/mast/Cargo.toml
+++ b/crates/mast/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "starfield-mast"
+version = "0.1.0"
+description = "MAST (Mikulski Archive for Space Telescopes) client — HST observations, data products, FITS downloads, WCS"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+starfield = { workspace = true }
+starfield-gaia = { version = "0.2.0", path = "../gaia" }
+starfield-datasource-utils = { version = "0.1.0", path = "../datasource-utils" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+reqwest = { workspace = true }
+fitsio-pure = { workspace = true }
+log = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/mast/src/client.rs
+++ b/crates/mast/src/client.rs
@@ -1,0 +1,227 @@
+//! `MastClient` and the Mashup invoke plumbing shared by every
+//! observation / catalog query.
+//!
+//! Mashup's request format:
+//!
+//! ```text
+//! POST https://mast.stsci.edu/api/v0/invoke
+//! Content-Type: application/x-www-form-urlencoded
+//! Body: request=<URL-encoded JSON>
+//! ```
+//!
+//! where the JSON is `{"service": "...", "params": {...}, "format": "json"}`.
+//!
+//! Response shape:
+//!
+//! ```json
+//! { "status": "COMPLETE",
+//!   "msg": "",
+//!   "data": [ { ...row... }, ... ],
+//!   "fields": [ { "name": "obsid", "type": "string" }, ... ],
+//!   "paging": { "page": 1, "pageSize": 5000, "rowsTotal": 12 } }
+//! ```
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use starfield::{Result, StarfieldError};
+use starfield_datasource_utils::ensure_cache_subdir;
+
+const MAST_INVOKE_URL: &str = "https://mast.stsci.edu/api/v0/invoke";
+const DEFAULT_TIMEOUT_SECS: u64 = 60;
+/// Per-request page size. MAST allows up to 50_000 rows per Mashup
+/// response; 5000 is a practical balance between memory and request
+/// count for HST-density fields. Wider cones may need pagination —
+/// tracked as a follow-on; v1 fetches a single page and emits a warning
+/// when more rows are available.
+const DEFAULT_PAGESIZE: u64 = 5_000;
+
+/// Public client for the MAST Mashup API.
+///
+/// Wraps a [`reqwest::blocking::Client`] with a 60 s default timeout.
+/// Construction is cheap (one client per process is plenty); the client
+/// is `Send + Sync` so it can be shared across threads.
+pub struct MastClient {
+    http: reqwest::blocking::Client,
+}
+
+impl MastClient {
+    pub fn new() -> Result<Self> {
+        Self::with_timeout(Duration::from_secs(DEFAULT_TIMEOUT_SECS))
+    }
+
+    pub fn with_timeout(timeout: Duration) -> Result<Self> {
+        let http = reqwest::blocking::Client::builder()
+            .timeout(timeout)
+            .user_agent("starfield-mast/0.1")
+            .build()
+            .map_err(|e| StarfieldError::DataError(format!("build http client: {}", e)))?;
+        Ok(Self { http })
+    }
+
+    /// POST a Mashup request and decode the typed response. Errors out
+    /// when the HTTP request fails, the server returns a non-`COMPLETE`
+    /// status, or the JSON shape doesn't match `T`.
+    pub(crate) fn invoke<T>(&self, service: &str, params: JsonValue) -> Result<MashupOk<T>>
+    where
+        T: DeserializeOwned,
+    {
+        let req = MashupRequest {
+            service,
+            params,
+            format: "json",
+            page: 1,
+            pagesize: DEFAULT_PAGESIZE,
+            removenullcolumns: true,
+        };
+        let body = serde_json::to_string(&req)
+            .map_err(|e| StarfieldError::DataError(format!("encode request: {}", e)))?;
+
+        let response = self
+            .http
+            .post(MAST_INVOKE_URL)
+            .header(
+                reqwest::header::CONTENT_TYPE,
+                "application/x-www-form-urlencoded",
+            )
+            .body(format!("request={}", urlencode(&body)))
+            .send()
+            .map_err(|e| StarfieldError::DataError(format!("MAST POST: {}", e)))?;
+
+        if !response.status().is_success() {
+            return Err(StarfieldError::DataError(format!(
+                "MAST returned HTTP {}",
+                response.status()
+            )));
+        }
+
+        // Read the body once and decode in two passes — first as the
+        // generic envelope to check `status`, then as the typed `data`
+        // array — so we can surface an error message from the server
+        // before the typed deserialization fails confusingly.
+        let bytes = response
+            .bytes()
+            .map_err(|e| StarfieldError::DataError(format!("read MAST body: {}", e)))?;
+        let envelope: MashupEnvelope = serde_json::from_slice(&bytes).map_err(|e| {
+            let preview = String::from_utf8_lossy(&bytes[..bytes.len().min(200)]);
+            StarfieldError::DataError(format!(
+                "decode MAST envelope: {} — first 200 bytes: {}",
+                e, preview
+            ))
+        })?;
+        if envelope.status != "COMPLETE" {
+            return Err(StarfieldError::DataError(format!(
+                "MAST returned status={}: {}",
+                envelope.status,
+                envelope.msg.unwrap_or_default()
+            )));
+        }
+
+        let typed: TypedMashupResponse<T> = serde_json::from_slice(&bytes).map_err(|e| {
+            StarfieldError::DataError(format!("decode MAST {} rows: {}", service, e))
+        })?;
+
+        Ok(MashupOk {
+            data: typed.data,
+            paging: typed.paging,
+        })
+    }
+
+    /// Cache directory used by [`Self::download_product`].
+    /// `~/.cache/starfield/mast/`
+    pub fn cache_dir(&self) -> Result<PathBuf> {
+        ensure_cache_subdir("mast").map_err(StarfieldError::IoError)
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct MashupRequest<'a> {
+    service: &'a str,
+    params: JsonValue,
+    format: &'a str,
+    page: u32,
+    pagesize: u64,
+    removenullcolumns: bool,
+}
+
+/// Envelope shape we use to read `status` / `msg` before committing to
+/// a typed deserialization of `data`.
+#[derive(Debug, Deserialize)]
+struct MashupEnvelope {
+    status: String,
+    msg: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TypedMashupResponse<T> {
+    data: Vec<T>,
+    paging: Option<MashupPaging>,
+}
+
+/// Paging metadata returned alongside the `data` array.
+#[derive(Debug, Clone, Deserialize)]
+pub struct MashupPaging {
+    pub page: u32,
+    #[serde(rename = "pageSize")]
+    pub page_size: u64,
+    #[serde(rename = "rowsTotal")]
+    pub rows_total: u64,
+}
+
+/// Successful Mashup response: typed rows + the paging metadata so
+/// callers can detect truncation.
+pub struct MashupOk<T> {
+    pub data: Vec<T>,
+    pub paging: Option<MashupPaging>,
+}
+
+impl<T> MashupOk<T> {
+    /// True when the server reports more rows than this single page
+    /// returned. v1 doesn't auto-paginate; callers should re-issue with
+    /// a tighter cone or check this flag.
+    pub fn truncated(&self) -> bool {
+        self.paging
+            .as_ref()
+            .is_some_and(|p| p.rows_total > self.data.len() as u64)
+    }
+}
+
+/// Minimal application/x-www-form-urlencoded encoder for the Mashup
+/// `request=<JSON>` body. We can't reach for `urlencoding` because it
+/// isn't already in the workspace; this covers what JSON throws at us
+/// (curly braces, brackets, quotes, commas, colons, spaces, etc.).
+fn urlencode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for byte in s.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(byte as char)
+            }
+            _ => out.push_str(&format!("%{:02X}", byte)),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::urlencode;
+
+    #[test]
+    fn urlencode_keeps_unreserved_intact() {
+        assert_eq!(urlencode("abcXYZ09-_.~"), "abcXYZ09-_.~");
+    }
+
+    #[test]
+    fn urlencode_percent_encodes_json_punctuation() {
+        // Spot-check the characters Mashup sees in our payload.
+        assert_eq!(urlencode("{}"), "%7B%7D");
+        assert_eq!(urlencode("[]"), "%5B%5D");
+        assert_eq!(urlencode("\""), "%22");
+        assert_eq!(urlencode(":"), "%3A");
+        assert_eq!(urlencode(","), "%2C");
+        assert_eq!(urlencode(" "), "%20");
+    }
+}

--- a/crates/mast/src/lib.rs
+++ b/crates/mast/src/lib.rs
@@ -1,0 +1,65 @@
+//! MAST (Mikulski Archive for Space Telescopes) client.
+//!
+//! Wraps the public Mashup JSON-RPC endpoint at
+//! `https://mast.stsci.edu/api/v0/invoke` and the data-product download
+//! URLs to give Rust callers:
+//!
+//! - **Observation discovery** — cone-search the CAOM observation table
+//!   to find what HST (or any other collection) imaging covers a region
+//!   of sky. See [`MastClient::observations_in_cone`] /
+//!   [`MastClient::hst_observations_in_cone`].
+//! - **Data-product listing** — for any observation, list the FITS files
+//!   and other artifacts associated with it. See
+//!   [`MastClient::data_products`].
+//! - **FITS download** — fetch a data product to a per-crate cache dir
+//!   under `~/.cache/starfield/mast/`. See
+//!   [`MastClient::download_product`].
+//! - **WCS parsing** — read CRVAL/CRPIX/CD/CTYPE/NAXIS from a FITS
+//!   header, and (for TAN projections) compute pixel↔world transforms +
+//!   the four image-corner footprint in world coordinates. See
+//!   [`Wcs`].
+//!
+//! HSC v3 source-catalog queries are deliberately out of scope for v1;
+//! this crate focuses on the observation / image / WCS path.
+//!
+//! # Distortion caveat
+//!
+//! HST FLT (flatfielded but undistorted) products carry SIP polynomial
+//! distortion coefficients that this crate does **not** apply.
+//! `Wcs::pixel_to_world` and `Wcs::footprint` use the linear CD-matrix
+//! TAN projection only — accurate to ~arcsec for typical HST FOV, fine
+//! for "what region does this image cover" but not for sub-pixel
+//! astrometry. DRZ / DRC drizzled products have already been distortion-
+//! corrected upstream and the linear WCS is exact.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use starfield_gaia::Cone;
+//! use starfield_mast::MastClient;
+//!
+//! let client = MastClient::new()?;
+//! let cone = Cone::from_degrees(210.802, 54.349, 0.05); // M101 nucleus, 3'
+//! let hst = client.hst_observations_in_cone(&cone)?;
+//! println!("found {} HST observations", hst.len());
+//!
+//! if let Some(obs) = hst.first() {
+//!     let products = client.data_products(&obs.obs_id)?;
+//!     for p in products.iter().filter(|p| p.is_science_fits()).take(3) {
+//!         let path = client.download_product(p)?;
+//!         let wcs = starfield_mast::Wcs::read_from_fits(&path)?;
+//!         println!("{} pointing → ({:.4}, {:.4})", p.filename, wcs.crval1, wcs.crval2);
+//!     }
+//! }
+//! # Ok::<(), starfield::StarfieldError>(())
+//! ```
+
+pub mod client;
+pub mod observations;
+pub mod products;
+pub mod wcs;
+
+pub use client::MastClient;
+pub use observations::{CaomObservation, ObsCollection};
+pub use products::{DataProduct, ProductType};
+pub use wcs::Wcs;

--- a/crates/mast/src/observations.rs
+++ b/crates/mast/src/observations.rs
@@ -1,0 +1,173 @@
+//! CAOM (Common Archive Observation Model) cone-search.
+//!
+//! Returns `Vec<CaomObservation>` for any region of sky. The HST-only
+//! convenience method post-filters by `obs_collection == "HST"` so the
+//! caller doesn't have to pull JWST / GALEX / TESS / IUE / etc. just to
+//! find Hubble pointings.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value as JsonValue};
+use starfield::Result;
+use starfield_gaia::Cone;
+
+use crate::client::MastClient;
+
+/// One row of the CAOM observation table. Many of the ~30 standard CAOM
+/// columns are optional in practice (per-collection differences); the
+/// fields we model directly cover the common-case Hubble use; everything
+/// else is preserved in `extras` so callers can dig into less-common
+/// columns (proposal_pi, target_name, dataRights, etc.) without us
+/// having to commit to the full schema.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CaomObservation {
+    /// Public observation id (`obs_id`). Use this to fetch data
+    /// products via [`MastClient::data_products`](crate::MastClient::data_products).
+    #[serde(rename = "obs_id")]
+    pub obs_id: String,
+
+    /// Internal MAST id (`obsid`) — required by
+    /// [`MastClient::data_products`](crate::MastClient::data_products).
+    /// MAST returns this as a JSON number for HST/JWST and as a string
+    /// for some other collections; we keep the raw `JsonValue` and
+    /// expose [`Self::obsid_string`] for the common conversion.
+    #[serde(rename = "obsid", default)]
+    pub obsid_internal: Option<JsonValue>,
+
+    /// Mission / archive grouping (`"HST"`, `"JWST"`, `"GALEX"`, etc.).
+    #[serde(rename = "obs_collection")]
+    pub obs_collection: String,
+
+    /// Instrument (e.g. `"ACS/WFC"`, `"WFC3/UVIS"`).
+    #[serde(rename = "instrument_name", default)]
+    pub instrument_name: Option<String>,
+
+    /// Filter combination (e.g. `"F814W"`, `"F606W;CLEAR2L"`).
+    #[serde(rename = "filters", default)]
+    pub filters: Option<String>,
+
+    /// Centre RA in degrees (J2000).
+    #[serde(rename = "s_ra", default)]
+    pub s_ra: Option<f64>,
+    /// Centre Dec in degrees (J2000).
+    #[serde(rename = "s_dec", default)]
+    pub s_dec: Option<f64>,
+
+    /// Total exposure time, seconds.
+    #[serde(rename = "t_exptime", default)]
+    pub t_exptime: Option<f64>,
+    /// Observation start, MJD.
+    #[serde(rename = "t_min", default)]
+    pub t_min: Option<f64>,
+    /// Observation end, MJD.
+    #[serde(rename = "t_max", default)]
+    pub t_max: Option<f64>,
+
+    /// Proposal id.
+    #[serde(rename = "proposal_id", default)]
+    pub proposal_id: Option<String>,
+    /// Proposal PI.
+    #[serde(rename = "proposal_pi", default)]
+    pub proposal_pi: Option<String>,
+    /// Target name as recorded by the proposal.
+    #[serde(rename = "target_name", default)]
+    pub target_name: Option<String>,
+
+    /// Direct URL to the primary data product (a FITS file for HST
+    /// imaging). Often `None` here; the products list returns more
+    /// detail.
+    #[serde(rename = "dataURL", default)]
+    pub data_url: Option<String>,
+
+    /// `"PUBLIC"` for unrestricted data, `"PROPRIETARY"` while still
+    /// under a proprietary period.
+    #[serde(rename = "dataRights", default)]
+    pub data_rights: Option<String>,
+
+    /// STC-S footprint string (polygon in world coordinates). Useful for
+    /// downstream geometry but tedious to parse — preserved as a string
+    /// and left to callers.
+    #[serde(rename = "s_region", default)]
+    pub s_region: Option<String>,
+
+    /// Anything else MAST returned that we didn't model above.
+    #[serde(flatten)]
+    pub extras: BTreeMap<String, JsonValue>,
+}
+
+impl CaomObservation {
+    /// String form of the internal numeric `obsid`, ready to pass to
+    /// [`MastClient::data_products`](crate::MastClient::data_products).
+    pub fn obsid_string(&self) -> Option<String> {
+        match self.obsid_internal.as_ref()? {
+            JsonValue::Number(n) => Some(n.to_string()),
+            JsonValue::String(s) => Some(s.clone()),
+            _ => None,
+        }
+    }
+}
+
+/// Common values of `obs_collection`. These aren't exhaustive; CAOM
+/// admits any collection string. Use [`Self::as_str`] to compare.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ObsCollection {
+    Hst,
+    Jwst,
+    Galex,
+    Iue,
+    Kepler,
+    Tess,
+}
+
+impl ObsCollection {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ObsCollection::Hst => "HST",
+            ObsCollection::Jwst => "JWST",
+            ObsCollection::Galex => "GALEX",
+            ObsCollection::Iue => "IUE",
+            ObsCollection::Kepler => "K2",
+            ObsCollection::Tess => "TESS",
+        }
+    }
+}
+
+impl MastClient {
+    /// Cone-search the CAOM observation table. Returns observations
+    /// from every collection MAST knows about; combine with a client-
+    /// side filter on `obs_collection` for a single mission.
+    ///
+    /// Cone radius is taken from the [`Cone`] in degrees (its native
+    /// unit). MAST's `Mast.Caom.Cone` service expects degrees too, so
+    /// no conversion is needed.
+    pub fn observations_in_cone(&self, cone: &Cone) -> Result<Vec<CaomObservation>> {
+        let params = json!({
+            "ra": cone.ra_rad.to_degrees(),
+            "dec": cone.dec_rad.to_degrees(),
+            "radius": cone.radius_rad.to_degrees(),
+        });
+        let response = self.invoke::<CaomObservation>("Mast.Caom.Cone", params)?;
+        if response.truncated() {
+            log::warn!(
+                "MAST cone returned a truncated page; total rows = {} but only {} fetched. \
+                 Tighten the cone or implement pagination.",
+                response.paging.as_ref().map(|p| p.rows_total).unwrap_or(0),
+                response.data.len()
+            );
+        }
+        Ok(response.data)
+    }
+
+    /// HST-only cone-search. Equivalent to
+    /// [`Self::observations_in_cone`] post-filtered to
+    /// `obs_collection == "HST"`. Server-side filtering would be
+    /// fractionally cheaper but requires a more complex Mashup service
+    /// (`Mast.Caom.Filtered.Position`); deferred to a follow-on if cone
+    /// sizes get large.
+    pub fn hst_observations_in_cone(&self, cone: &Cone) -> Result<Vec<CaomObservation>> {
+        let mut all = self.observations_in_cone(cone)?;
+        all.retain(|o| o.obs_collection == ObsCollection::Hst.as_str());
+        Ok(all)
+    }
+}

--- a/crates/mast/src/products.rs
+++ b/crates/mast/src/products.rs
@@ -1,0 +1,160 @@
+//! Per-observation data-product listing + FITS download.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value as JsonValue};
+use starfield::{Result, StarfieldError};
+use starfield_datasource_utils::{download_to_file, file_exists_and_not_empty};
+
+use crate::client::MastClient;
+
+/// One artifact produced by an observation. CAOM groups artifacts by
+/// `productType` (`SCIENCE`, `PREVIEW`, `INFO`, `AUXILIARY`,
+/// `THUMBNAIL`); for HST the headline science product is typically a
+/// `_drz.fits` (drizzled mosaic) or `_flt.fits` (flatfielded per-
+/// exposure).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DataProduct {
+    /// Bare filename, e.g. `j8c0a1011_drz.fits`.
+    #[serde(rename = "productFilename")]
+    pub filename: String,
+
+    /// CAOM productType. Use [`Self::product_type`] for the parsed
+    /// enum.
+    #[serde(rename = "productType", default)]
+    pub product_type: Option<String>,
+
+    /// MIME type / file class string (`image/fits`, etc.).
+    #[serde(rename = "productSubGroupDescription", default)]
+    pub product_subgroup: Option<String>,
+
+    /// Public download URL. Often a `mast:` URI; we resolve it via
+    /// [`MastClient::download_product`].
+    #[serde(rename = "dataURI", default)]
+    pub data_uri: Option<String>,
+
+    /// Direct HTTPS download URL (when MAST publishes one). Preferred
+    /// over `data_uri` when present.
+    #[serde(rename = "dataURL", default)]
+    pub data_url: Option<String>,
+
+    /// File size in bytes (when MAST reports it).
+    #[serde(rename = "size", default)]
+    pub size_bytes: Option<u64>,
+
+    /// Parent observation id this product belongs to.
+    #[serde(rename = "obs_id", default)]
+    pub obs_id: Option<String>,
+
+    /// Description text MAST attaches to the product (rarely useful).
+    #[serde(rename = "description", default)]
+    pub description: Option<String>,
+
+    /// Anything else MAST returned that we didn't model above.
+    #[serde(flatten)]
+    pub extras: BTreeMap<String, JsonValue>,
+}
+
+/// Parsed CAOM productType. Use [`DataProduct::product_type`] to get
+/// the enum form.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProductType {
+    Science,
+    Preview,
+    Info,
+    Auxiliary,
+    Thumbnail,
+    Other,
+}
+
+impl ProductType {
+    /// Parse a CAOM `productType` string. Unknown values map to
+    /// [`ProductType::Other`]. Named `parse_caom` (rather than `from_str`)
+    /// to avoid shadowing the `std::str::FromStr` trait — implementing
+    /// the trait would force a `Result` return that no caller wants.
+    pub fn parse_caom(s: &str) -> Self {
+        match s {
+            "SCIENCE" => Self::Science,
+            "PREVIEW" => Self::Preview,
+            "INFO" => Self::Info,
+            "AUXILIARY" => Self::Auxiliary,
+            "THUMBNAIL" => Self::Thumbnail,
+            _ => Self::Other,
+        }
+    }
+}
+
+impl DataProduct {
+    pub fn product_type_enum(&self) -> ProductType {
+        ProductType::parse_caom(self.product_type.as_deref().unwrap_or(""))
+    }
+
+    /// True for `productType=SCIENCE` *and* a `.fits` filename.
+    pub fn is_science_fits(&self) -> bool {
+        self.product_type_enum() == ProductType::Science
+            && self.filename.to_ascii_lowercase().ends_with(".fits")
+    }
+
+    /// Resolve the best available download URL: prefer the explicit
+    /// `dataURL`, then translate `mast:` URIs to the standard MAST
+    /// download endpoint.
+    pub fn resolve_url(&self) -> Option<String> {
+        if let Some(url) = self.data_url.as_ref() {
+            return Some(url.clone());
+        }
+        if let Some(uri) = self.data_uri.as_ref() {
+            if let Some(rest) = uri.strip_prefix("mast:") {
+                return Some(format!(
+                    "https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:{}",
+                    rest
+                ));
+            }
+            return Some(uri.clone());
+        }
+        None
+    }
+}
+
+impl MastClient {
+    /// List the data products for a given observation. Backed by the
+    /// `Mast.Caom.Products` Mashup service.
+    ///
+    /// `obsid` is the **internal numeric** id (the `obsid` column in
+    /// CAOM, not the human-readable `obs_id`). Use
+    /// [`CaomObservation::obsid_string`] to extract it from a row, or
+    /// pass the numeric value directly.
+    pub fn data_products(&self, obsid: &str) -> Result<Vec<DataProduct>> {
+        let params = json!({ "obsid": obsid });
+        let response = self.invoke::<DataProduct>("Mast.Caom.Products", params)?;
+        Ok(response.data)
+    }
+
+    /// Download `product` to the per-crate cache (`~/.cache/starfield/mast/`).
+    /// If the file already exists at the cache path and is non-empty,
+    /// returns the path without re-fetching.
+    ///
+    /// Errors out when the product has no resolvable download URL.
+    pub fn download_product(&self, product: &DataProduct) -> Result<PathBuf> {
+        let url = product.resolve_url().ok_or_else(|| {
+            StarfieldError::DataError(format!(
+                "data product {:?} has neither dataURL nor dataURI",
+                product.filename
+            ))
+        })?;
+        let cache = self.cache_dir()?;
+        let dest = cache.join(&product.filename);
+        if file_exists_and_not_empty(&dest) {
+            log::debug!("MAST cache hit for {}", product.filename);
+            return Ok(dest);
+        }
+        log::info!(
+            "downloading MAST product {} → {}",
+            product.filename,
+            dest.display()
+        );
+        download_to_file(&url, &dest, 60)?;
+        Ok(dest)
+    }
+}

--- a/crates/mast/src/wcs.rs
+++ b/crates/mast/src/wcs.rs
@@ -1,0 +1,269 @@
+//! Minimal FITS WCS parser + TAN-projection helpers.
+//!
+//! Reads the keys we care about (CRVAL1/2, CRPIX1/2, CD or PC+CDELT,
+//! CTYPE1/2, NAXIS1/2) from a FITS header via `fitsio_pure`. Provides
+//! pixel↔world for TAN projections plus a 4-corner footprint so callers
+//! can answer "where is this image pointing and what does it cover?"
+//!
+//! HST products use either:
+//!
+//! - DRZ / DRC drizzled mosaics — distortion-corrected upstream, linear
+//!   CD-matrix WCS is exact.
+//! - FLT / FLC flatfielded per-exposure files — carry SIP polynomial
+//!   distortion that this crate does **not** apply. The footprint is
+//!   accurate to ~arcsec (fine for "what region is covered" but not for
+//!   sub-pixel astrometry).
+//!
+//! Only TAN (gnomonic) projection is supported. Anything else
+//! (`SIN`, `ARC`, `ZEA`, `STG`, `CAR`, `HPX`, …) errors out at
+//! `pixel_to_world` time so consumers don't silently get bad
+//! coordinates.
+
+use std::fs;
+use std::path::Path;
+
+use fitsio_pure::hdu::{parse_fits, HduInfo};
+use fitsio_pure::header::Card;
+use fitsio_pure::value::Value;
+use starfield::{Result, StarfieldError};
+
+/// Linear FITS WCS, populated from a FITS header.
+///
+/// Field names match the FITS keyword conventions: `crval1` is the
+/// reference-point RA in degrees, `crval2` is the reference-point Dec
+/// in degrees, etc. `cd` is the 2x2 CD matrix in degrees per pixel;
+/// older PC + CDELT layouts are normalised into a CD matrix at parse
+/// time. `naxis1` / `naxis2` are the image dimensions in pixels.
+#[derive(Debug, Clone)]
+pub struct Wcs {
+    pub crval1: f64,
+    pub crval2: f64,
+    pub crpix1: f64,
+    pub crpix2: f64,
+    pub cd: [[f64; 2]; 2],
+    pub ctype1: String,
+    pub ctype2: String,
+    pub naxis1: u32,
+    pub naxis2: u32,
+}
+
+impl Wcs {
+    /// Read WCS from a FITS file on disk.
+    ///
+    /// HST imaging products typically put the WCS in a `SCI`
+    /// extension, not the primary HDU; this scans the primary first
+    /// then every extension and returns the first HDU that carries a
+    /// usable WCS (CRVAL1 + CRVAL2 + CRPIX1 + CRPIX2 + a CD or
+    /// PC+CDELT matrix + CTYPE1/2 + NAXIS1/2).
+    pub fn read_from_fits<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let bytes = fs::read(path.as_ref()).map_err(StarfieldError::IoError)?;
+        Self::read_from_bytes(&bytes)
+    }
+
+    /// Read WCS from in-memory FITS bytes.
+    pub fn read_from_bytes(bytes: &[u8]) -> Result<Self> {
+        let fits = parse_fits(bytes)
+            .map_err(|e| StarfieldError::DataError(format!("FITS parse: {:?}", e)))?;
+        for hdu in fits.iter() {
+            if !matches!(hdu.info, HduInfo::Primary { .. } | HduInfo::Image { .. }) {
+                continue;
+            }
+            if let Ok(wcs) = Self::read_from_cards(&hdu.cards) {
+                return Ok(wcs);
+            }
+        }
+        Err(StarfieldError::DataError(
+            "no HDU in this FITS file carried a complete WCS".into(),
+        ))
+    }
+
+    /// Parse WCS from a slice of FITS header cards.
+    pub fn read_from_cards(cards: &[Card]) -> Result<Self> {
+        let crval1 = require_float(cards, "CRVAL1")?;
+        let crval2 = require_float(cards, "CRVAL2")?;
+        let crpix1 = require_float(cards, "CRPIX1")?;
+        let crpix2 = require_float(cards, "CRPIX2")?;
+        let ctype1 = require_string(cards, "CTYPE1")?;
+        let ctype2 = require_string(cards, "CTYPE2")?;
+        let naxis1 = require_int(cards, "NAXIS1")? as u32;
+        let naxis2 = require_int(cards, "NAXIS2")? as u32;
+        let cd = read_cd_matrix(cards)?;
+        Ok(Wcs {
+            crval1,
+            crval2,
+            crpix1,
+            crpix2,
+            cd,
+            ctype1,
+            ctype2,
+            naxis1,
+            naxis2,
+        })
+    }
+
+    /// True iff both axes use the TAN projection. Also matches
+    /// `RA---TAN-SIP` / `DEC--TAN-SIP` — SIP is a distortion suffix on
+    /// top of the TAN base projection, and our linear-only evaluator
+    /// treats it as plain TAN with the documented "SIP not applied"
+    /// caveat (see crate docs).
+    pub fn is_tan(&self) -> bool {
+        ctype_projection(&self.ctype1) == Some("TAN")
+            && ctype_projection(&self.ctype2) == Some("TAN")
+    }
+
+    /// Convert pixel coordinates `(x, y)` (FITS-style, 1-indexed,
+    /// where (1.0, 1.0) is the centre of the first pixel) to world
+    /// coordinates `(ra_deg, dec_deg)`.
+    ///
+    /// Errors out for non-TAN projections.
+    pub fn pixel_to_world(&self, x: f64, y: f64) -> Result<(f64, f64)> {
+        if !self.is_tan() {
+            return Err(StarfieldError::DataError(format!(
+                "pixel_to_world: only TAN projection supported, got CTYPE1={:?} / CTYPE2={:?}",
+                self.ctype1, self.ctype2
+            )));
+        }
+        let dx = x - self.crpix1;
+        let dy = y - self.crpix2;
+        // Standard / native (xi, eta), in degrees, then converted to
+        // radians for the inverse-gnomonic formulae below.
+        let xi_deg = self.cd[0][0] * dx + self.cd[0][1] * dy;
+        let eta_deg = self.cd[1][0] * dx + self.cd[1][1] * dy;
+        let xi = xi_deg.to_radians();
+        let eta = eta_deg.to_radians();
+
+        let alpha0 = self.crval1.to_radians();
+        let delta0 = self.crval2.to_radians();
+
+        let rho = (xi * xi + eta * eta).sqrt();
+        if rho == 0.0 {
+            return Ok((self.crval1, self.crval2));
+        }
+        let c = rho.atan();
+        let sin_c = c.sin();
+        let cos_c = c.cos();
+        let sin_d0 = delta0.sin();
+        let cos_d0 = delta0.cos();
+
+        let delta = (cos_c * sin_d0 + (eta * sin_c * cos_d0) / rho).asin();
+        let alpha = alpha0 + (xi * sin_c).atan2(rho * cos_d0 * cos_c - eta * sin_d0 * sin_c);
+        // Wrap RA into [0, 360).
+        let mut ra_deg = alpha.to_degrees();
+        ra_deg = ra_deg.rem_euclid(360.0);
+        Ok((ra_deg, delta.to_degrees()))
+    }
+
+    /// Returns the four image corners in world coordinates `(ra_deg,
+    /// dec_deg)`, ordered (BL, BR, TR, TL) where bottom-left is pixel
+    /// (0.5, 0.5) — the pixel-grid edge, not the centre of the corner
+    /// pixel.
+    ///
+    /// Errors out for non-TAN projections (consistent with
+    /// [`Self::pixel_to_world`]).
+    pub fn footprint(&self) -> Result<[(f64, f64); 4]> {
+        let nx = self.naxis1 as f64;
+        let ny = self.naxis2 as f64;
+        Ok([
+            self.pixel_to_world(0.5, 0.5)?,
+            self.pixel_to_world(nx + 0.5, 0.5)?,
+            self.pixel_to_world(nx + 0.5, ny + 0.5)?,
+            self.pixel_to_world(0.5, ny + 0.5)?,
+        ])
+    }
+
+    /// Approximate plate scale at the reference point, arcsec/pixel.
+    /// Computed as `sqrt(|det(CD)|) * 3600`, which matches the standard
+    /// astropy `wcs.proj_plane_pixel_scales` average to within a few
+    /// percent for typical small-FOV instruments.
+    pub fn pixel_scale_arcsec(&self) -> f64 {
+        let det = self.cd[0][0] * self.cd[1][1] - self.cd[0][1] * self.cd[1][0];
+        det.abs().sqrt() * 3600.0
+    }
+}
+
+/// Extract the base 3-character projection code from a CTYPE string
+/// like `"RA---TAN"` / `"DEC--TAN"` / `"RA---SIN"` / `"RA---TAN-SIP"`.
+///
+/// FITS WCS CTYPE format: an axis name (`RA`, `DEC`, `GLON`, etc.)
+/// padded with `-` to 4 chars, then `-`, then a 3-char projection code,
+/// optionally followed by a distortion suffix like `-SIP`. We look for
+/// the projection code by splitting on `-`, dropping empty tokens, and
+/// taking the **second** token (first = axis name, second = projection).
+fn ctype_projection(ctype: &str) -> Option<&str> {
+    let mut tokens = ctype.trim().split('-').filter(|s| !s.is_empty());
+    let _axis = tokens.next()?;
+    tokens.next()
+}
+
+fn read_cd_matrix(cards: &[Card]) -> Result<[[f64; 2]; 2]> {
+    if let (Some(a), Some(b), Some(c), Some(d)) = (
+        find_float(cards, "CD1_1"),
+        find_float(cards, "CD1_2"),
+        find_float(cards, "CD2_1"),
+        find_float(cards, "CD2_2"),
+    ) {
+        return Ok([[a, b], [c, d]]);
+    }
+    // PC + CDELT fallback (older WCS layout).
+    let pc11 = find_float(cards, "PC1_1").unwrap_or(1.0);
+    let pc12 = find_float(cards, "PC1_2").unwrap_or(0.0);
+    let pc21 = find_float(cards, "PC2_1").unwrap_or(0.0);
+    let pc22 = find_float(cards, "PC2_2").unwrap_or(1.0);
+    let cdelt1 = find_float(cards, "CDELT1");
+    let cdelt2 = find_float(cards, "CDELT2");
+    match (cdelt1, cdelt2) {
+        (Some(d1), Some(d2)) => Ok([[d1 * pc11, d1 * pc12], [d2 * pc21, d2 * pc22]]),
+        _ => Err(StarfieldError::DataError(
+            "no CD matrix and no PC+CDELT keys; can't derive WCS rotation".into(),
+        )),
+    }
+}
+
+fn find_card<'a>(cards: &'a [Card], keyword: &str) -> Option<&'a Card> {
+    cards.iter().find(|c| c.keyword_str() == keyword)
+}
+
+fn find_float(cards: &[Card], keyword: &str) -> Option<f64> {
+    let card = find_card(cards, keyword)?;
+    match card.value.as_ref()? {
+        Value::Float(f) => Some(*f),
+        Value::Integer(i) => Some(*i as f64),
+        _ => None,
+    }
+}
+
+fn require_float(cards: &[Card], keyword: &str) -> Result<f64> {
+    find_float(cards, keyword).ok_or_else(|| {
+        StarfieldError::DataError(format!(
+            "WCS: required FITS keyword {} missing or not numeric",
+            keyword
+        ))
+    })
+}
+
+fn require_int(cards: &[Card], keyword: &str) -> Result<i64> {
+    let card = find_card(cards, keyword).ok_or_else(|| {
+        StarfieldError::DataError(format!("WCS: required FITS keyword {} missing", keyword))
+    })?;
+    match card.value.as_ref() {
+        Some(Value::Integer(i)) => Ok(*i),
+        Some(Value::Float(f)) => Ok(*f as i64),
+        _ => Err(StarfieldError::DataError(format!(
+            "WCS: FITS keyword {} not an integer",
+            keyword
+        ))),
+    }
+}
+
+fn require_string(cards: &[Card], keyword: &str) -> Result<String> {
+    let card = find_card(cards, keyword).ok_or_else(|| {
+        StarfieldError::DataError(format!("WCS: required FITS keyword {} missing", keyword))
+    })?;
+    match card.value.as_ref() {
+        Some(Value::String(s)) => Ok(s.trim().to_string()),
+        _ => Err(StarfieldError::DataError(format!(
+            "WCS: FITS keyword {} not a string",
+            keyword
+        ))),
+    }
+}

--- a/crates/mast/tests/network.rs
+++ b/crates/mast/tests/network.rs
@@ -1,0 +1,69 @@
+//! Real-network integration tests against MAST. All `#[ignore]`d so
+//! `cargo test` doesn't hit the network in CI; run them locally with:
+//!
+//! ```sh
+//! cargo test -p starfield-mast --test network -- --ignored --nocapture
+//! ```
+//!
+//! These tests download real HST data products (small ones, but
+//! still — expect a few MB per run). Per-product cache hits make
+//! re-runs essentially free.
+
+use starfield_gaia::Cone;
+use starfield_mast::{MastClient, Wcs};
+
+#[test]
+#[ignore]
+fn end_to_end_m101_cone_search_and_first_drz_download() {
+    // 3' cone around the M101 nucleus — guaranteed dense HST coverage.
+    let cone = Cone::from_degrees(210.802, 54.349, 0.05);
+    let client = MastClient::new().expect("build client");
+
+    let hst = client
+        .hst_observations_in_cone(&cone)
+        .expect("CAOM cone search");
+    eprintln!("M101 nucleus 3' cone → {} HST observations", hst.len());
+    assert!(!hst.is_empty(), "M101 should have HST imaging");
+
+    // Pick the first observation, list its products, find a SCIENCE
+    // .fits file, download it, parse the WCS.
+    let obs = &hst[0];
+    eprintln!(
+        "first obs: id={} instrument={:?} filters={:?}",
+        obs.obs_id, obs.instrument_name, obs.filters
+    );
+    let obsid = obs.obsid_string().expect("CAOM rows must carry an obsid");
+    let products = client.data_products(&obsid).expect("data products");
+    eprintln!("  {} data products listed", products.len());
+
+    let science = products
+        .iter()
+        .find(|p| p.is_science_fits())
+        .expect("at least one SCIENCE .fits product");
+    eprintln!(
+        "  downloading: {} ({} bytes)",
+        science.filename,
+        science.size_bytes.unwrap_or(0)
+    );
+    let path = client.download_product(science).expect("download");
+    eprintln!("  cached at: {}", path.display());
+
+    // Parse the WCS and dump pointing + footprint.
+    let wcs = Wcs::read_from_fits(&path).expect("read WCS");
+    eprintln!(
+        "  WCS: CRVAL=({:.4}, {:.4}) CTYPE=({}, {}) NAXIS={}x{} scale={:.3} \"/pix",
+        wcs.crval1,
+        wcs.crval2,
+        wcs.ctype1,
+        wcs.ctype2,
+        wcs.naxis1,
+        wcs.naxis2,
+        wcs.pixel_scale_arcsec()
+    );
+    if wcs.is_tan() {
+        let corners = wcs.footprint().expect("TAN footprint");
+        for (i, (ra, dec)) in corners.iter().enumerate() {
+            eprintln!("  corner[{}] = ({:.4}°, {:.4}°)", i, ra, dec);
+        }
+    }
+}

--- a/crates/mast/tests/synthetic_json.rs
+++ b/crates/mast/tests/synthetic_json.rs
@@ -1,0 +1,131 @@
+//! Synthetic-JSON tests for the CaomObservation and DataProduct serde
+//! shapes. We don't have a `MashupResponse` parser exposed publicly
+//! (the client wraps it), so test the row deserialisation directly.
+
+use starfield_mast::{CaomObservation, DataProduct, ProductType};
+
+#[test]
+fn caom_observation_parses_minimal_row() {
+    let row = serde_json::json!({
+        "obs_id": "j8c0a1011",
+        "obsid": 1234567,
+        "obs_collection": "HST",
+        "instrument_name": "ACS/WFC",
+        "filters": "F814W",
+        "s_ra": 210.802,
+        "s_dec": 54.349,
+        "t_exptime": 720.0,
+        "t_min": 52800.0,
+        "t_max": 52800.01,
+        "proposal_id": "9405",
+        "proposal_pi": "Holtzman",
+        "target_name": "NGC-5457-FIELD",
+        "dataURL": "mast:HST/product/j8c0a1011_drz.fits",
+        "dataRights": "PUBLIC",
+        "s_region": "POLYGON ICRS 210.7 54.3 210.9 54.3 210.9 54.4 210.7 54.4"
+    });
+    let obs: CaomObservation = serde_json::from_value(row).unwrap();
+    assert_eq!(obs.obs_id, "j8c0a1011");
+    assert_eq!(obs.obs_collection, "HST");
+    assert_eq!(obs.instrument_name.as_deref(), Some("ACS/WFC"));
+    assert_eq!(obs.filters.as_deref(), Some("F814W"));
+    assert_eq!(obs.s_ra, Some(210.802));
+    assert_eq!(obs.s_dec, Some(54.349));
+    assert_eq!(obs.t_exptime, Some(720.0));
+    assert_eq!(obs.proposal_id.as_deref(), Some("9405"));
+    assert_eq!(obs.target_name.as_deref(), Some("NGC-5457-FIELD"));
+    assert!(obs.data_url.as_deref().unwrap().starts_with("mast:HST"));
+    assert_eq!(obs.data_rights.as_deref(), Some("PUBLIC"));
+    assert!(obs.s_region.as_deref().unwrap().starts_with("POLYGON"));
+}
+
+#[test]
+fn caom_observation_unknown_columns_land_in_extras() {
+    let row = serde_json::json!({
+        "obs_id": "abc",
+        "obs_collection": "HST",
+        "wavelength_min": 1.2e-7,
+        "calib_level": 3
+    });
+    let obs: CaomObservation = serde_json::from_value(row).unwrap();
+    assert_eq!(obs.obs_id, "abc");
+    assert_eq!(obs.obs_collection, "HST");
+    // We don't model wavelength_min / calib_level — they should land in extras.
+    assert!(obs.extras.contains_key("wavelength_min"));
+    assert!(obs.extras.contains_key("calib_level"));
+}
+
+#[test]
+fn data_product_parses_minimal_row() {
+    let row = serde_json::json!({
+        "obs_id": "j8c0a1011",
+        "productFilename": "j8c0a1011_drz.fits",
+        "productType": "SCIENCE",
+        "productSubGroupDescription": "DRZ",
+        "dataURI": "mast:HST/product/j8c0a1011_drz.fits",
+        "size": 12345678
+    });
+    let p: DataProduct = serde_json::from_value(row).unwrap();
+    assert_eq!(p.filename, "j8c0a1011_drz.fits");
+    assert_eq!(p.product_type.as_deref(), Some("SCIENCE"));
+    assert_eq!(p.product_type_enum(), ProductType::Science);
+    assert!(p.is_science_fits());
+    assert_eq!(p.size_bytes, Some(12_345_678));
+    assert_eq!(p.obs_id.as_deref(), Some("j8c0a1011"));
+}
+
+#[test]
+fn data_product_resolve_url_translates_mast_uri() {
+    let p: DataProduct = serde_json::from_value(serde_json::json!({
+        "productFilename": "x.fits",
+        "productType": "SCIENCE",
+        "dataURI": "mast:HST/product/x.fits"
+    }))
+    .unwrap();
+    let url = p.resolve_url().unwrap();
+    assert!(
+        url.contains("mast.stsci.edu/api/v0.1/Download/file"),
+        "expected MAST download endpoint, got: {}",
+        url
+    );
+    assert!(url.ends_with("uri=mast:HST/product/x.fits"));
+}
+
+#[test]
+fn data_product_resolve_url_prefers_explicit_dataurl() {
+    let p: DataProduct = serde_json::from_value(serde_json::json!({
+        "productFilename": "y.fits",
+        "productType": "SCIENCE",
+        "dataURI": "mast:HST/product/y.fits",
+        "dataURL": "https://example.com/y.fits"
+    }))
+    .unwrap();
+    assert_eq!(
+        p.resolve_url().as_deref(),
+        Some("https://example.com/y.fits")
+    );
+}
+
+#[test]
+fn data_product_is_science_fits_only_for_fits() {
+    let preview: DataProduct = serde_json::from_value(serde_json::json!({
+        "productFilename": "preview.jpg",
+        "productType": "PREVIEW"
+    }))
+    .unwrap();
+    assert!(!preview.is_science_fits());
+
+    let aux_fits: DataProduct = serde_json::from_value(serde_json::json!({
+        "productFilename": "aux.fits",
+        "productType": "AUXILIARY"
+    }))
+    .unwrap();
+    assert!(!aux_fits.is_science_fits()); // wrong product type
+
+    let sci_jpg: DataProduct = serde_json::from_value(serde_json::json!({
+        "productFilename": "sci.jpg",
+        "productType": "SCIENCE"
+    }))
+    .unwrap();
+    assert!(!sci_jpg.is_science_fits()); // wrong filename
+}

--- a/crates/mast/tests/wcs.rs
+++ b/crates/mast/tests/wcs.rs
@@ -1,0 +1,232 @@
+//! Synthetic WCS tests — build a tiny FITS header with known keywords,
+//! parse it through `Wcs::read_from_cards`, and check pixel↔world,
+//! footprint, and plate-scale math.
+
+use fitsio_pure::header::Card;
+use fitsio_pure::value::Value;
+use starfield_mast::Wcs;
+
+/// Build a minimal Card for a known float value.
+fn float_card(keyword: &str, value: f64) -> Card {
+    Card {
+        keyword: pad_keyword(keyword),
+        value: Some(Value::Float(value)),
+        comment: None,
+    }
+}
+
+fn int_card(keyword: &str, value: i64) -> Card {
+    Card {
+        keyword: pad_keyword(keyword),
+        value: Some(Value::Integer(value)),
+        comment: None,
+    }
+}
+
+fn string_card(keyword: &str, value: &str) -> Card {
+    Card {
+        keyword: pad_keyword(keyword),
+        value: Some(Value::String(value.to_string())),
+        comment: None,
+    }
+}
+
+fn pad_keyword(keyword: &str) -> [u8; 8] {
+    let mut out = [b' '; 8];
+    let bytes = keyword.as_bytes();
+    out[..bytes.len()].copy_from_slice(bytes);
+    out
+}
+
+/// 100×100 axis-aligned TAN WCS centred at (180°, 0°), 1″/pixel.
+fn tan_test_cards() -> Vec<Card> {
+    let one_arcsec_deg = 1.0 / 3600.0;
+    vec![
+        float_card("CRVAL1", 180.0),
+        float_card("CRVAL2", 0.0),
+        float_card("CRPIX1", 50.5),
+        float_card("CRPIX2", 50.5),
+        float_card("CD1_1", one_arcsec_deg),
+        float_card("CD1_2", 0.0),
+        float_card("CD2_1", 0.0),
+        float_card("CD2_2", one_arcsec_deg),
+        string_card("CTYPE1", "RA---TAN"),
+        string_card("CTYPE2", "DEC--TAN"),
+        int_card("NAXIS1", 100),
+        int_card("NAXIS2", 100),
+    ]
+}
+
+#[test]
+fn parses_required_cards() {
+    let cards = tan_test_cards();
+    let wcs = Wcs::read_from_cards(&cards).unwrap();
+    assert_eq!(wcs.crval1, 180.0);
+    assert_eq!(wcs.crval2, 0.0);
+    assert_eq!(wcs.crpix1, 50.5);
+    assert_eq!(wcs.crpix2, 50.5);
+    assert_eq!(wcs.naxis1, 100);
+    assert_eq!(wcs.naxis2, 100);
+    assert_eq!(wcs.ctype1, "RA---TAN");
+    assert_eq!(wcs.ctype2, "DEC--TAN");
+    assert!(wcs.is_tan());
+}
+
+#[test]
+fn pixel_to_world_at_reference_point_returns_crval() {
+    let wcs = Wcs::read_from_cards(&tan_test_cards()).unwrap();
+    let (ra, dec) = wcs.pixel_to_world(50.5, 50.5).unwrap();
+    assert!(
+        (ra - 180.0).abs() < 1e-12,
+        "ra at CRPIX should be CRVAL1, got {}",
+        ra
+    );
+    assert!(
+        (dec - 0.0).abs() < 1e-12,
+        "dec at CRPIX should be CRVAL2, got {}",
+        dec
+    );
+}
+
+#[test]
+fn pixel_to_world_offset_matches_small_angle_approximation() {
+    // At Dec=0, RA at +1 pixel east is RA0 + (1″/3600) / cos(0) = RA0 + 1/3600 deg.
+    let wcs = Wcs::read_from_cards(&tan_test_cards()).unwrap();
+    let (ra, dec) = wcs.pixel_to_world(51.5, 50.5).unwrap();
+    let expected_dra = 1.0 / 3600.0;
+    assert!(
+        (ra - (180.0 + expected_dra)).abs() < 1e-9,
+        "RA off by more than 1 mas: got {}, expected {}",
+        ra,
+        180.0 + expected_dra
+    );
+    assert!(
+        dec.abs() < 1e-9,
+        "dec should stay at 0 along the row, got {}",
+        dec
+    );
+
+    // +1 pixel north → Dec rises by exactly 1/3600 (no cos factor in Dec).
+    let (_ra2, dec2) = wcs.pixel_to_world(50.5, 51.5).unwrap();
+    assert!(
+        (dec2 - 1.0 / 3600.0).abs() < 1e-12,
+        "dec off by more than 1e-12: got {}",
+        dec2
+    );
+}
+
+#[test]
+fn footprint_returns_four_corners_in_reasonable_bounds() {
+    // 100x100 at 1″/pix → ~50″ from centre to each corner.
+    let wcs = Wcs::read_from_cards(&tan_test_cards()).unwrap();
+    let corners = wcs.footprint().unwrap();
+    assert_eq!(corners.len(), 4);
+    let half_arcsec = 50.5 / 3600.0; // distance from centre to corner
+    for (i, (ra, dec)) in corners.iter().enumerate() {
+        let dra = (ra - 180.0).abs();
+        let ddec = dec.abs();
+        assert!(
+            dra <= half_arcsec * 1.5,
+            "corner {} RA out of range: {}",
+            i,
+            ra
+        );
+        assert!(
+            ddec <= half_arcsec * 1.5,
+            "corner {} Dec out of range: {}",
+            i,
+            dec
+        );
+    }
+
+    // Corners must be ordered (BL, BR, TR, TL) — Dec sign matches:
+    // first two are bottom (negative Dec), last two are top (positive).
+    assert!(corners[0].1 < 0.0, "BL should be south of centre");
+    assert!(corners[1].1 < 0.0, "BR should be south of centre");
+    assert!(corners[2].1 > 0.0, "TR should be north of centre");
+    assert!(corners[3].1 > 0.0, "TL should be north of centre");
+}
+
+#[test]
+fn pixel_scale_returns_arcsec_per_pixel() {
+    let wcs = Wcs::read_from_cards(&tan_test_cards()).unwrap();
+    let scale = wcs.pixel_scale_arcsec();
+    assert!(
+        (scale - 1.0).abs() < 1e-9,
+        "axis-aligned 1″/pix CD should give scale ≈ 1.0, got {}",
+        scale
+    );
+}
+
+#[test]
+fn pc_plus_cdelt_fallback_normalises_into_cd_matrix() {
+    let one_arcsec_deg = 1.0 / 3600.0;
+    let mut cards = vec![
+        float_card("CRVAL1", 0.0),
+        float_card("CRVAL2", 0.0),
+        float_card("CRPIX1", 50.5),
+        float_card("CRPIX2", 50.5),
+        // No CD matrix — only PC + CDELT.
+        float_card("PC1_1", 1.0),
+        float_card("PC1_2", 0.0),
+        float_card("PC2_1", 0.0),
+        float_card("PC2_2", 1.0),
+        float_card("CDELT1", one_arcsec_deg),
+        float_card("CDELT2", one_arcsec_deg),
+        string_card("CTYPE1", "RA---TAN"),
+        string_card("CTYPE2", "DEC--TAN"),
+        int_card("NAXIS1", 100),
+        int_card("NAXIS2", 100),
+    ];
+    let wcs = Wcs::read_from_cards(&cards).unwrap();
+    assert!((wcs.cd[0][0] - one_arcsec_deg).abs() < 1e-15);
+    assert!((wcs.cd[1][1] - one_arcsec_deg).abs() < 1e-15);
+
+    // Sanity: pixel_to_world still returns CRVAL at CRPIX.
+    let (ra, dec) = wcs.pixel_to_world(50.5, 50.5).unwrap();
+    assert!(ra.abs() < 1e-12 && dec.abs() < 1e-12);
+
+    // Drop CDELT — should now error.
+    cards.retain(|c| c.keyword_str() != "CDELT1" && c.keyword_str() != "CDELT2");
+    let err = Wcs::read_from_cards(&cards).expect_err("missing CDELT should error");
+    assert!(err.to_string().contains("PC+CDELT"));
+}
+
+#[test]
+fn missing_required_keyword_errors() {
+    let mut cards = tan_test_cards();
+    cards.retain(|c| c.keyword_str() != "CRVAL1");
+    let err = Wcs::read_from_cards(&cards).expect_err("missing CRVAL1 should error");
+    assert!(err.to_string().contains("CRVAL1"));
+}
+
+#[test]
+fn tan_sip_ctype_is_treated_as_tan() {
+    // HST FLT/FLC products use CTYPE like `RA---TAN-SIP` — the SIP
+    // suffix is a distortion model on top of TAN. Our linear evaluator
+    // treats them as TAN (with the documented "SIP not applied" caveat),
+    // so footprint() / pixel_to_world() must succeed without erroring.
+    let mut cards = tan_test_cards();
+    cards.retain(|c| c.keyword_str() != "CTYPE1" && c.keyword_str() != "CTYPE2");
+    cards.push(string_card("CTYPE1", "RA---TAN-SIP"));
+    cards.push(string_card("CTYPE2", "DEC--TAN-SIP"));
+    let wcs = Wcs::read_from_cards(&cards).unwrap();
+    assert!(wcs.is_tan(), "TAN-SIP should be accepted as TAN");
+    let (ra, dec) = wcs.pixel_to_world(50.5, 50.5).unwrap();
+    assert!((ra - 180.0).abs() < 1e-12 && dec.abs() < 1e-12);
+    let _ = wcs.footprint().unwrap();
+}
+
+#[test]
+fn non_tan_projection_errors_at_pixel_to_world() {
+    let mut cards = tan_test_cards();
+    // Replace CTYPE1 with a SIN projection so is_tan() returns false.
+    cards.retain(|c| c.keyword_str() != "CTYPE1");
+    cards.push(string_card("CTYPE1", "RA---SIN"));
+    let wcs = Wcs::read_from_cards(&cards).unwrap();
+    assert!(!wcs.is_tan());
+    let err = wcs
+        .pixel_to_world(50.5, 50.5)
+        .expect_err("non-TAN should error");
+    assert!(err.to_string().contains("TAN"));
+}

--- a/crates/starfield-datasources/Cargo.toml
+++ b/crates/starfield-datasources/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starfield-datasources"
-version = "0.8.0"
+version = "0.9.0"
 description = "Astronomical data source clients for the starfield ecosystem"
 edition.workspace = true
 license.workspace = true
@@ -15,6 +15,7 @@ gaia-all = ["gaia", "starfield-gaia/all-releases"]
 gaia-extended = ["gaia", "dep:starfield-gaia-extended"]
 bright-galaxies = ["gaia", "dep:starfield-bright-galaxies"]
 hipparcos = ["dep:starfield-hipparcos"]
+mast = ["dep:starfield-mast"]
 mpc = ["dep:starfield-mpc"]
 nsa = ["dep:starfield-nsa"]
 rubin = ["dep:starfield-rubin"]
@@ -26,6 +27,7 @@ starfield-gaia = { path = "../gaia", optional = true }
 starfield-gaia-extended = { path = "../gaia-extended", optional = true }
 starfield-bright-galaxies = { path = "../bright-galaxies", optional = true }
 starfield-hipparcos = { path = "../hipparcos", optional = true }
+starfield-mast = { path = "../mast", optional = true }
 starfield-mpc = { path = "../mpc", optional = true }
 starfield-nsa = { path = "../nsa", optional = true }
 starfield-rubin = { path = "../rubin", optional = true }

--- a/crates/starfield-datasources/src/lib.rs
+++ b/crates/starfield-datasources/src/lib.rs
@@ -12,6 +12,7 @@
 //! - `gaia-extended` — DR3 galaxy_candidates + qso_candidates loaders
 //! - `bright-galaxies` — hand-curated supplement of nearby bright galaxies (M31, LMC, Virgo, etc.)
 //! - `hipparcos` — Hipparcos star catalog loader
+//! - `mast` — MAST (Mikulski Archive for Space Telescopes): HST observations, data products, FITS downloads, WCS
 //! - `mpc` — Minor Planet Center client (MPCORB, observatory codes, observations)
 //! - `nsa` — NASA-Sloan Atlas (NSA) galaxy catalog loader
 //! - `rubin` — Vera C. Rubin Observatory LSST alert broker clients
@@ -33,6 +34,9 @@ pub use starfield_bright_galaxies as bright_galaxies;
 
 #[cfg(feature = "hipparcos")]
 pub use starfield_hipparcos as hipparcos;
+
+#[cfg(feature = "mast")]
+pub use starfield_mast as mast;
 
 #[cfg(feature = "mpc")]
 pub use starfield_mpc as mpc;


### PR DESCRIPTION
## Summary

New crate `starfield-mast` at `crates/mast/` wrapping the public MAST Mashup JSON-RPC endpoint at `https://mast.stsci.edu/api/v0/invoke` and the MAST data-product download URLs. Lets Rust callers ask "what HST imaging covers this region of sky, where do those images point, and can I have the FITS file?"

## Public surface

- `MastClient::observations_in_cone(&Cone) → Vec<CaomObservation>` — cone-search the CAOM observation table (every collection MAST hosts: HST, JWST, GALEX, IUE, Kepler, TESS, …).
- `MastClient::hst_observations_in_cone(&Cone)` — HST-only convenience wrapper.
- `MastClient::data_products(obsid_string) → Vec<DataProduct>` via `Mast.Caom.Products`. Use `CaomObservation::obsid_string()` to extract the internal numeric `obsid` from a row.
- `MastClient::download_product(&DataProduct) → PathBuf`. Cache hit on `~/.cache/starfield/mast/<filename>` is free; cache miss streams via `starfield-datasource-utils::download_to_file`.
- `Wcs::read_from_fits(path)` parses CRVAL / CRPIX / CD or PC+CDELT / CTYPE / NAXIS from the FITS primary or first image extension. Treats `RA---TAN-SIP` / `DEC--TAN-SIP` as TAN with the documented "SIP polynomial not applied" caveat.
- `Wcs::pixel_to_world(x, y)` and `Wcs::footprint()` — inverse gnomonic for TAN; non-TAN errors loudly.
- `Wcs::pixel_scale_arcsec()` — `sqrt(|det(CD)|) * 3600`, matches `astropy.wcs.proj_plane_pixel_scales` average to within a few percent.

`Cone` re-used from `starfield-gaia` (no parallel type).

## Demo run against real MAST

Local invocation `cargo test -p starfield-mast --test network -- --ignored --nocapture` against M101 nucleus (3′ cone):

```
M101 nucleus 3' cone → 893 HST observations
first obs: id=hst_11635_11_wfc3_uvis_f469n_ib3p11 instrument=Some("WFC3/UVIS") filters=Some("F469N")
  83 data products listed
  downloading: ib3p11p7q_flc.fits (169148160 bytes)
  cached at: /home/meawoppl/.cache/starfield/mast/ib3p11p7q_flc.fits
  WCS: CRVAL=(210.7788, 54.3271) CTYPE=(RA---TAN-SIP, DEC--TAN-SIP) NAXIS=4096x2051 scale=0.040 "/pix
  corner[0] = (210.7748°, 54.3012°)
  corner[1] = (210.7474°, 54.3437°)
  corner[2] = (210.7829°, 54.3530°)
  corner[3] = (210.8103°, 54.3106°)
```

Pointing within 1′ of M101 nucleus; 0.040″/pix is the correct WFC3/UVIS plate scale; the 2.7′×2.0′ footprint is the expected chip outline.

## Out of scope for v1

- HSC v3 source-catalog cone search (deferred — adding `Mast.Catalogs.Filtered.HSCv3.Position` once a downstream consumer asks)
- SIP / lookup-table / TPV distortion in the WCS evaluator (the linear CD evaluator is good to ~arcsec on FLT/FLC; DRZ/DRC products are already distortion-corrected upstream)
- Authenticated downloads (proprietary data products need a MAST API token; deferred)
- Pagination beyond a single 5000-row Mashup page (warns when truncated; tighten the cone for now)

## Test plan

- [x] `cargo test -p starfield-mast` — 14 unit tests + 1 doctest, all green
- [x] `cargo test -p starfield-mast --test network -- --ignored --nocapture` — real MAST round-trip, output above
- [x] `cargo clippy -p starfield-mast --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`

Tests cover:
- 8 WCS unit tests against synthetic FITS cards (TAN, TAN-SIP, PC+CDELT fallback, missing-keyword errors, footprint corners in expected ranges, plate-scale arcsec)
- 6 synthetic-JSON tests for `CaomObservation` + `DataProduct` serde shapes (`extras` catch-all for unknown columns, `mast:` URI translation to download endpoint, `is_science_fits` discrimination)
- The `#[ignore]`d network test that exercises the full M101 → cone → products → download → WCS pipeline against the live service.