### PR TITLE
gaia: GaiaCore::proper_motion() typed accessor (closes #56)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ license = "MIT"
 repository = "https://github.com/OrbitalCommons/starfield-datasources"
 
 [workspace.dependencies]
-starfield = "0.12"
+starfield = "0.12.5"
 reqwest = { version = "0.12", features = ["blocking", "json", "multipart"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/gaia/src/common/core.rs
+++ b/crates/gaia/src/common/core.rs
@@ -2,6 +2,7 @@
 
 use nalgebra as na;
 use serde::{Deserialize, Serialize};
+use starfield::ProperMotion;
 
 /// The variability flag reported by Gaia photometry.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -87,5 +88,17 @@ impl GaiaCore {
             let dist_pc = 1000.0 / plx;
             self.unit_vector() * dist_pc
         })
+    }
+
+    /// Typed proper motion in the Gaia DR3 convention (`pmra` carries
+    /// the cos(dec) factor; both fields mas/yr). Returns `Some` only
+    /// when both `pmra` and `pmdec` are populated — Gaia rows where
+    /// the astrometric fit didn't produce a PM solution have either
+    /// or both null and should fall back to the catalog's `ref_epoch`
+    /// position.
+    pub fn proper_motion(&self) -> Option<ProperMotion> {
+        let pmra = self.pmra?;
+        let pmdec = self.pmdec?;
+        Some(ProperMotion::new(pmra, pmdec))
     }
 }

--- a/crates/gaia/tests/proper_motion.rs
+++ b/crates/gaia/tests/proper_motion.rs
@@ -1,0 +1,93 @@
+//! `GaiaCore::proper_motion()` exercised end-to-end through the CSV parser.
+
+#![cfg(feature = "dr3")]
+
+use std::collections::HashMap;
+use std::io::Write;
+
+use starfield::ProperMotion;
+use starfield_gaia::Dr3Catalog;
+
+const HEADER: &str = "source_id,solution_id,ref_epoch,random_index,designation,ra,ra_error,dec,dec_error,ra_dec_corr,parallax,parallax_error,parallax_over_error,pm,pmra,pmra_error,pmdec,pmdec_error,l,b,ecl_lon,ecl_lat,phot_g_mean_mag,phot_g_mean_flux,phot_g_mean_flux_error,phot_g_n_obs,phot_variable_flag,astrometric_n_obs_al,astrometric_excess_noise,astrometric_excess_noise_sig,astrometric_primary_flag,duplicated_source,matched_observations,astrometric_n_good_obs_al,astrometric_n_bad_obs_al,astrometric_gof_al,astrometric_chi2_al,astrometric_params_solved,visibility_periods_used,astrometric_sigma5d_max,nu_eff_used_in_astrometry,pseudocolour,pseudocolour_error,ruwe,ipd_gof_harmonic_amplitude,ipd_gof_harmonic_phase,ipd_frac_multi_peak,ipd_frac_odd_win,phot_bp_mean_mag,phot_bp_mean_flux,phot_bp_mean_flux_error,phot_bp_n_obs,phot_rp_mean_mag,phot_rp_mean_flux,phot_rp_mean_flux_error,phot_rp_n_obs,bp_rp,bp_g,g_rp,phot_bp_rp_excess_factor,phot_proc_mode,radial_velocity,radial_velocity_error,rv_method_used,rv_nb_transits,rv_expected_sig_to_noise,rv_amplitude_robust,rv_template_teff,rv_template_logg,rv_template_fe_h,rv_atm_param_origin,teff_gspphot,teff_gspphot_lower,teff_gspphot_upper,logg_gspphot,mh_gspphot,distance_gspphot,distance_gspphot_lower,distance_gspphot_upper,azero_gspphot,ag_gspphot,ebpminrp_gspphot,libname_gspphot,has_xp_continuous,has_xp_sampled,has_rvs,has_epoch_photometry,has_epoch_rv,has_mcmc_gspphot,has_mcmc_msc,in_qso_candidates,in_galaxy_candidates,in_andromeda_survey,non_single_star,classprob_dsc_combmod_quasar,classprob_dsc_combmod_galaxy,classprob_dsc_combmod_star";
+
+fn row_from(overrides: &HashMap<&str, &str>) -> String {
+    HEADER
+        .split(',')
+        .map(|c| overrides.get(c).copied().unwrap_or(""))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn write_fixture(rows: &[(u64, Option<f64>, Option<f64>)]) -> tempfile::NamedTempFile {
+    let mut f = tempfile::Builder::new().suffix(".csv").tempfile().unwrap();
+    writeln!(f, "{}", HEADER).unwrap();
+    for (id, pmra, pmdec) in rows {
+        let pmra_str = pmra.map(|v| v.to_string()).unwrap_or_default();
+        let pmdec_str = pmdec.map(|v| v.to_string()).unwrap_or_default();
+        let row = row_from(&HashMap::from([
+            ("source_id", id.to_string().as_str()),
+            ("solution_id", "1635721458409799680"),
+            ("ref_epoch", "2016.0"),
+            ("ra", "10.0"),
+            ("ra_error", "0.04"),
+            ("dec", "20.0"),
+            ("dec_error", "0.04"),
+            ("pmra", pmra_str.as_str()),
+            ("pmdec", pmdec_str.as_str()),
+            ("l", "0.0"),
+            ("b", "0.0"),
+            ("ecl_lon", "0.0"),
+            ("ecl_lat", "0.0"),
+            ("phot_g_mean_mag", "12.0"),
+            ("phot_variable_flag", "NOT_AVAILABLE"),
+        ]));
+        writeln!(f, "{}", row).unwrap();
+    }
+    f.flush().unwrap();
+    f
+}
+
+#[test]
+fn proper_motion_returns_some_when_both_components_present() {
+    let f = write_fixture(&[(1, Some(-4.6), Some(11.2))]);
+    let cat = Dr3Catalog::from_csv_file(f.path(), f64::INFINITY).unwrap();
+    let entry = cat.get_star(1).unwrap();
+    let pm = entry
+        .core
+        .proper_motion()
+        .expect("both components populated");
+    assert_eq!(pm, ProperMotion::new(-4.6, 11.2));
+    assert_eq!(pm.pmra, -4.6);
+    assert_eq!(pm.pmdec, 11.2);
+}
+
+#[test]
+fn proper_motion_returns_none_when_either_component_missing() {
+    let f = write_fixture(&[
+        (10, None, None),       // both missing → None
+        (11, Some(1.5), None),  // pmdec missing → None
+        (12, None, Some(-2.3)), // pmra missing → None
+    ]);
+    let cat = Dr3Catalog::from_csv_file(f.path(), f64::INFINITY).unwrap();
+    for id in [10, 11, 12] {
+        let pm = cat.get_star(id).unwrap().core.proper_motion();
+        assert!(
+            pm.is_none(),
+            "source_id {} should have no proper_motion, got {:?}",
+            id,
+            pm
+        );
+    }
+}
+
+#[test]
+fn proper_motion_zero_components_round_trip() {
+    // pmra == 0 / pmdec == 0 is a valid (if unusual) Gaia value — not the
+    // same as "missing". The accessor should return Some(ProperMotion::ZERO).
+    let f = write_fixture(&[(99, Some(0.0), Some(0.0))]);
+    let cat = Dr3Catalog::from_csv_file(f.path(), f64::INFINITY).unwrap();
+    let pm = cat.get_star(99).unwrap().core.proper_motion().unwrap();
+    assert_eq!(pm, ProperMotion::ZERO);
+}
+
+use starfield::catalogs::StarCatalog;


### PR DESCRIPTION
## Summary

Closes #56.

Wraps the loose `(Option<f64>, Option<f64>)` `pmra` / `pmdec` pair on `GaiaCore` in `starfield::ProperMotion` (Gaia DR3 convention: `pmra` carries the `cos(dec)` factor, both fields in mas/yr). Returns `Some` only when both components are populated — Gaia rows where the astrometric fit produced no PM solution have one or both null and should fall back to the catalog's `ref_epoch` position.

```rust
impl GaiaCore {
    pub fn proper_motion(&self) -> Option<ProperMotion> {
        let pmra = self.pmra?;
        let pmdec = self.pmdec?;
        Some(ProperMotion::new(pmra, pmdec))
    }
}
```

Available on every `Dr{1,2,3}Entry` automatically via its `core` field.

## Upstream dependency

`ProperMotion` lives at `starfield::framelib::inertial::ProperMotion` (also re-exported as `starfield::ProperMotion`), landed in [OrbitalCommons/starfield#140](https://github.com/OrbitalCommons/starfield/pull/140) and published as **starfield 0.12.5**. Workspace dep bumps `starfield = "0.12"` → `starfield = "0.12.5"` (pure additive — no API breaks).

## Why

Downstream consumers (zodiacal does HST plate-solve PM propagation many years from the Gaia DR3 epoch — see zodiacal#125) currently project the Gaia record into their own runtime types and lose the typed-PM benefit at the boundary. With this accessor + the upstream type, they can stay in typed land:

```rust
// before
let dt_yr = (target_jd - 2016.0) * 365.25 / 365.25;
let dra = entry.core.pmra.unwrap_or(0.0) * dt_yr / 3.6e6 / dec.cos();
let ddec = entry.core.pmdec.unwrap_or(0.0) * dt_yr / 3.6e6;

// after
if let Some(pm) = entry.core.proper_motion() {
    let dt_yr = (target_jd - 2016.0) / 365.25;
    let dra = pm.pmra * dt_yr / 3.6e6 / dec.cos();
    let ddec = pm.pmdec * dt_yr / 3.6e6;
}
```

## Test plan

- [x] `cargo test -p starfield-gaia --features dr3 --test proper_motion` — 3 passed
- [x] `cargo clippy -p starfield-gaia --features all-releases --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`

New tests exercise the accessor through the CSV parser:
- `proper_motion_returns_some_when_both_components_present`
- `proper_motion_returns_none_when_either_component_missing` (3 sub-cases: both, pmra-only, pmdec-only)
- `proper_motion_zero_components_round_trip` — `pmra = pmdec = 0` is a valid catalog value, not "missing"; accessor returns `Some(ProperMotion::ZERO)`