### PR TITLE
deps: bump starfield 0.12 -> 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ license = "MIT"
 repository = "https://github.com/OrbitalCommons/starfield-datasources"
 
 [workspace.dependencies]
-starfield = "0.12.5"
+starfield = "0.13"
 reqwest = { version = "0.12", features = ["blocking", "json", "multipart"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
Bumps the workspace `starfield` dependency `0.12.5` -> `0.13` (semver-incompatible; pulls ndarray 0.17 transitively).

Part of the coordinated ndarray 0.16 -> 0.17 unification. Downstream `focalplane/simulator` consumes `starfield-nsa`/`starfield-gaia`/`starfield-datasource-utils` from this repo and can't move to starfield 0.13 / ndarray 0.17 until these crates do.

No source changes needed — starfield 0.12 -> 0.13 required no API updates here. Full workspace builds, clippy clean, `cargo test --workspace` green.